### PR TITLE
Fix typo in test_statefulset_recurring_backup

### DIFF
--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -311,7 +311,7 @@ def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
     time.sleep(300)
 
     for pod in pod_data:
-        volume = client.by_id_volume(pod['volume_name'])
+        volume = client.by_id_volume(pod['pv_name'])
         snapshots = volume.snapshotList()
         count = 0
         for snapshot in snapshots:


### PR DESCRIPTION
In `test_statefulset_recurring_backup`, the test was attempting to access a `volume_name` key of the pod data that we generated for handling `StatefulSets`. This key doesn't exist, and the correct key is named `pv_name`, which resulted in the test failing. 

This PR fixes that typo and prevents the `KeyError` that was caused by the typo.