### PR TITLE
Add tests for Disk and Node tagging

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -953,6 +953,26 @@ def get_clients(hosts):
     return clients
 
 
+def wait_scheduling_failure(client, volume_name):
+    """
+    Wait and make sure no new replicas are running on the specified
+    volume. Trigger a failed assertion of one is detected.
+    :param client: The Longhorn client to use in the request.
+    :param volume_name: The name of the volume.
+    """
+    scheduling_failure = False
+    for i in range(RETRY_COUNTS):
+        v = client.by_id_volume(volume_name)
+        if v["conditions"]["scheduled"]["status"] == "False" and \
+                v["conditions"]["scheduled"]["reason"] == \
+                "ReplicaSchedulingFailure":
+            scheduling_failure = True
+        if scheduling_failure:
+            break
+        time.sleep(RETRY_INTERVAL)
+    assert scheduling_failure
+
+
 def wait_for_device_login(dest_path, name):
     dev = ""
     for i in range(RETRY_COUNTS):

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -102,6 +102,23 @@ CSI_UNKNOWN = 0
 CSI_TRUE = 1
 CSI_FALSE = 2
 
+# Default Tag test case set up to fulfill as many test inputs as
+# possible.
+DEFAULT_TAGS = [
+    {
+        "disk": ["nvme", "ssd"],
+        "node": ["main", "storage"]
+    },
+    {
+        "disk": ["nvme", "ssd"],
+        "node": ["fallback", "storage"]
+    },
+    {
+        "disk": ["m2", "nvme"],
+        "node": ["main", "storage"]
+    }
+]
+
 
 def load_k8s_config():
     c = Configuration()
@@ -412,6 +429,44 @@ def wait_delete_pod(api, pod_name):
             break
         time.sleep(DEFAULT_POD_INTERVAL)
     assert not found
+
+
+def check_volume_replicas(volume, spec, tag_mapping):
+    """
+    Check the replicas on the volume to ensure that they were scheduled
+    properly.
+    :param volume: The Volume to check.
+    :param spec: The spec to validate the Tag against.
+    :param tag_mapping: The mapping of Nodes to the Tags they have.
+    :raise AssertionError: If the Volume doesn't match all the conditions.
+    """
+    found_hosts = {}
+    # Make sure that all the Tags the Volume requested were fulfilled.
+    for replica in volume["replicas"]:
+        found_hosts[replica["hostId"]] = {}
+        assert not len(set(spec["disk"]) -
+                       set(tag_mapping[replica["hostId"]]["disk"]))
+        assert not len(set(spec["node"]) -
+                       set(tag_mapping[replica["hostId"]]["node"]))
+
+    # The Volume should have replicas on as many nodes as matched
+    # the requirements (specified by "expected" in the spec variable).
+    assert len(found_hosts) == spec["expected"]
+
+
+# Default argument is mutable on this function, but it's fine since we're only
+# using it as an empty tag list to pass to the server and will never actually
+# modify it.
+def set_node_tags(client, node, tags=[]):  # NOQA
+    """
+    Set the tags on a node without modifying its scheduling status.
+    :param client: The Longhorn client to use in the request.
+    :param node: The Node to update.
+    :param tags: The tags to set on the node.
+    :return: The updated Node.
+    """
+    return client.update(node, allowScheduling=node["allowScheduling"],
+                         tags=tags)
 
 
 @pytest.fixture
@@ -749,6 +804,46 @@ def storage_class(request):
     request.addfinalizer(finalizer)
 
     return sc_manifest
+
+
+@pytest.yield_fixture
+def node_default_tags():
+    """
+    Assign the Tags under DEFAULT_TAGS to the Longhorn client's Nodes to
+    provide a base set of Tags to work with in the tests.
+    :return: A dictionary mapping a Node's ID to the Tags it has.
+    """
+    client = get_longhorn_api_client()  # NOQA
+    nodes = client.list_node()
+    assert len(nodes) == 3
+
+    tag_mappings = {}
+    for tags, node in zip(DEFAULT_TAGS, nodes):
+        assert len(node["disks"]) == 1
+
+        update_disks = get_update_disks(node["disks"])
+        update_disks[0]["tags"] = tags["disk"]
+        new_node = node.diskUpdate(disks=update_disks)
+        disks = get_update_disks(new_node["disks"])
+        assert disks[0]["tags"] == tags["disk"]
+
+        new_node = set_node_tags(client, node, tags["node"])
+        assert new_node["tags"] == tags["node"]
+
+        tag_mappings[node["id"]] = tags
+    yield tag_mappings
+
+    client = get_longhorn_api_client()  # NOQA
+    nodes = client.list_node()
+    for node in nodes:
+        update_disks = get_update_disks(node["disks"])
+        update_disks[0]["tags"] = []
+        new_node = node.diskUpdate(disks=update_disks)
+        disks = get_update_disks(new_node["disks"])
+        assert disks[0]["tags"] is None
+
+        new_node = set_node_tags(client, node)
+        assert new_node["tags"] is None
 
 
 @pytest.fixture

--- a/manager/integration/tests/test_scheduling.py
+++ b/manager/integration/tests/test_scheduling.py
@@ -5,7 +5,7 @@ from common import client, volume_name  # NOQA
 from common import check_volume_data, cleanup_volume, \
     create_and_check_volume, get_longhorn_api_client, get_self_host_id, \
     wait_for_volume_detached, wait_for_volume_degraded, \
-    wait_for_volume_healthy, write_volume_random_data
+    wait_for_volume_healthy, wait_scheduling_failure, write_volume_random_data
 from time import sleep
 
 SETTING_REPLICA_HARD_ANTI_AFFINITY = "replica-hard-anti-affinity"
@@ -61,26 +61,6 @@ def wait_new_replica_ready(client, volume_name, replica_names):  # NOQA
             break
         sleep(RETRY_INTERVAL)
     assert new_replica_ready
-
-
-def wait_scheduling_failure(client, volume_name):  # NOQA
-    """
-    Wait and make sure no new replicas are running on the specified
-    volume. Trigger a failed assertion of one is detected.
-    :param client: The Longhorn client to use in the request.
-    :param volume_name: The name of the volume.
-    """
-    scheduling_failure = False
-    for i in range(RETRY_COUNTS):
-        v = client.by_id_volume(volume_name)
-        if v["conditions"]["scheduled"]["status"] == "False" and \
-                v["conditions"]["scheduled"]["reason"] == \
-                "ReplicaSchedulingFailure":
-            scheduling_failure = True
-        if scheduling_failure:
-            break
-        sleep(RETRY_INTERVAL)
-    assert scheduling_failure
 
 
 def test_soft_anti_affinity_scheduling(client, volume_name):  # NOQA

--- a/manager/integration/tests/test_tagging.py
+++ b/manager/integration/tests/test_tagging.py
@@ -1,0 +1,246 @@
+import pytest
+import random
+import string
+
+from common import client, node_default_tags, volume_name # NOQA
+from common import RETRY_COUNTS, RETRY_INTERVAL, SIZE
+from common import check_volume_replicas, cleanup_volume, \
+    generate_volume_name, get_self_host_id, get_update_disks, set_node_tags, \
+    wait_for_volume_delete, wait_for_volume_detached, wait_for_volume_healthy
+from time import sleep
+
+
+def generate_tag_name():
+    return "tag/" + "".join(random.choice(string.ascii_lowercase +
+                                          string.digits) for _ in range(6))
+
+
+def generate_unordered_tag_names():
+    unsorted = []
+    is_sorted = []
+    while unsorted == is_sorted:
+        unsorted = []
+        for _ in range(3):
+            unsorted.append(generate_tag_name())
+        is_sorted = sorted(unsorted)
+    return unsorted, is_sorted
+
+
+def test_tag_basic(client):  # NOQA
+    """
+    Test that applying Tags to Nodes/Disks and retrieving them work as
+    expected. Ensures that Tags are properly validated when updated.
+    """
+    host_id = get_self_host_id()
+    node = client.by_id_node(host_id)
+    disks = get_update_disks(node["disks"])
+    assert len(node["disks"]) == 1
+    assert disks[0]["tags"] is None
+    assert node["tags"] is None
+
+    unsorted_disk, sorted_disk = generate_unordered_tag_names()
+    unsorted_node, sorted_node = generate_unordered_tag_names()
+    update_disks = get_update_disks(node["disks"])
+    update_disks[0]["tags"] = unsorted_disk
+    node = node.diskUpdate(disks=update_disks)
+    disks = get_update_disks(node["disks"])
+    assert disks[0]["tags"] == sorted_disk
+
+    node = set_node_tags(client, node, unsorted_node)
+    assert node["tags"] == sorted_node
+
+    improper_tag_cases = [
+        [""],   # Empty string
+        [" "],  # Whitespace
+        ["/"],  # Leading /
+        [","],  # Illegal character
+    ]
+    for tags in improper_tag_cases:
+        with pytest.raises(Exception) as e:
+            set_node_tags(client, node, tags)
+        assert "at least one error encountered while validating tags" in \
+               str(e.value)
+        with pytest.raises(Exception) as e:
+            update_disks = get_update_disks(node["disks"])
+            update_disks[0]["tags"] = tags
+            node.diskUpdate(disks=update_disks)
+        assert "at least one error encountered while validating tags" in \
+               str(e.value)
+
+    update_disks = get_update_disks(node["disks"])
+    update_disks[0]["tags"] = []
+    node = node.diskUpdate(disks=update_disks)
+    disks = get_update_disks(node["disks"])
+    assert disks[0]["tags"] is None
+
+    node = set_node_tags(client, node)
+    assert node["tags"] is None
+
+
+def test_tag_scheduling(client, node_default_tags):  # NOQA
+    """
+    Test that scheduling succeeds if there are available Nodes/Disks with the
+    requested Tags.
+    """
+    host_id = get_self_host_id()
+    tag_specs = [
+        # Select all Nodes.
+        {
+            "disk": [],
+            "expected": 3,
+            "node": []
+        },
+        # Selector works with AND on Disk Tags.
+        {
+            "disk": ["ssd", "nvme"],
+            "expected": 2,
+            "node": []
+        },
+        # Selector works with AND on Node Tags.
+        {
+            "disk": [],
+            "expected": 2,
+            "node": ["main", "storage"]
+        },
+        # Selector works based on combined Disk AND Node selector.
+        {
+            "disk": ["ssd", "nvme"],
+            "expected": 1,
+            "node": ["storage", "main"]
+        }
+    ]
+    for specs in tag_specs:
+        volume_name = generate_volume_name()  # NOQA
+        client.create_volume(name=volume_name, size=SIZE, numberOfReplicas=3,
+                             diskSelector=specs["disk"],
+                             nodeSelector=specs["node"])
+        volume = wait_for_volume_detached(client, volume_name)
+        assert volume["diskSelector"] == specs["disk"]
+        assert volume["nodeSelector"] == specs["node"]
+
+        volume.attach(hostId=host_id)
+        volume = wait_for_volume_healthy(client, volume_name)
+        assert len(volume["replicas"]) == 3
+        check_volume_replicas(volume, specs, node_default_tags)
+
+        cleanup_volume(client, volume)
+
+
+def test_tag_scheduling_failure(client, node_default_tags):  # NOQA
+    """
+    Test that scheduling fails if no Nodes/Disks with the requested Tags are
+    available.
+    """
+    invalid_tag_cases = [
+        # Only one Disk Tag exists.
+        {
+            "disk": ["doesnotexist", "ssd"],
+            "node": []
+        },
+        # Only one Node Tag exists.
+        {
+            "disk": [],
+            "node": ["doesnotexist", "main"]
+        }
+    ]
+    for tags in invalid_tag_cases:
+        volume_name = generate_volume_name()  # NOQA
+        with pytest.raises(Exception) as e:
+            client.create_volume(name=volume_name, size=SIZE,
+                                 numberOfReplicas=3,
+                                 diskSelector=tags["disk"],
+                                 nodeSelector=tags["node"])
+        assert "does not exist" in str(e.value)
+    unsatisfied_tag_cases = [
+        {
+            "disk": [],
+            "node": ["main", "fallback"]
+        },
+        {
+            "disk": ["ssd", "m2"],
+            "node": []
+        }
+    ]
+    for tags in unsatisfied_tag_cases:
+        volume_name = generate_volume_name()
+        client.create_volume(name=volume_name, size=SIZE, numberOfReplicas=3,
+                             diskSelector=tags["disk"],
+                             nodeSelector=tags["node"])
+        volume = wait_for_volume_detached(client, volume_name)
+        assert volume["diskSelector"] == tags["disk"]
+        assert volume["nodeSelector"] == tags["node"]
+
+        scheduling_failure = False
+        for i in range(RETRY_COUNTS):
+            v = client.by_id_volume(volume_name)
+            if v["conditions"]["scheduled"]["status"] == "False" and \
+                    v["conditions"]["scheduled"]["reason"] == \
+                    "ReplicaSchedulingFailure":
+                scheduling_failure = True
+            if scheduling_failure:
+                break
+            sleep(RETRY_INTERVAL)
+        assert scheduling_failure
+
+        client.delete(volume)
+        wait_for_volume_delete(client, volume["name"])
+        volumes = client.list_volume()
+        assert len(volumes) == 0
+
+
+def test_tag_scheduling_on_update(client, node_default_tags, volume_name):  # NOQA
+    """
+    Test that Replicas get scheduled if a Node/Disk disks updated with the
+    proper Tags.
+    """
+    tag_spec = {
+        "disk": ["ssd", "m2"],
+        "expected": 1,
+        "node": ["main", "fallback"]
+    }
+    client.create_volume(name=volume_name, size=SIZE, numberOfReplicas=3,
+                         diskSelector=tag_spec["disk"],
+                         nodeSelector=tag_spec["node"])
+    volume = wait_for_volume_detached(client, volume_name)
+    assert volume["diskSelector"] == tag_spec["disk"]
+    assert volume["nodeSelector"] == tag_spec["node"]
+
+    scheduling_failure = False
+    for i in range(RETRY_COUNTS):
+        v = client.by_id_volume(volume_name)
+        if v["conditions"]["scheduled"]["status"] == "False" and \
+                v["conditions"]["scheduled"]["reason"] == \
+                "ReplicaSchedulingFailure":
+            scheduling_failure = True
+        if scheduling_failure:
+            break
+        sleep(RETRY_INTERVAL)
+    assert scheduling_failure
+
+    host_id = get_self_host_id()
+    node = client.by_id_node(host_id)
+    update_disks = get_update_disks(node["disks"])
+    update_disks[0]["tags"] = tag_spec["disk"]
+    node = node.diskUpdate(disks=update_disks)
+    set_node_tags(client, node, tag_spec["node"])
+    scheduled = False
+    for i in range(RETRY_COUNTS):
+        v = client.by_id_volume(volume_name)
+        if v["conditions"]["scheduled"]["status"] == "True":
+            scheduled = True
+        if scheduled:
+            break
+        sleep(RETRY_INTERVAL)
+    assert scheduled
+
+    volume.attach(hostId=host_id)
+    volume = wait_for_volume_healthy(client, volume_name)
+    nodes = client.list_node()
+    node_mapping = {node["id"]: {
+        "disk": get_update_disks(node["disks"])[0]["tags"],
+        "node": node["tags"]
+    } for node in nodes}
+    assert len(volume["replicas"]) == 3
+    check_volume_replicas(volume, tag_spec, node_mapping)
+
+    cleanup_volume(client, volume)


### PR DESCRIPTION
This PR adds integration tests for the `Disk` and `Node` tagging functionality introduced in longhorn/longhorn-manager#315. The tests do a number of things:
1. Ensure `Tags` are properly sent to the server.
2. Ensure `Tags` are properly validated and reordered when updated.
3. Ensure that new `Volumes` are scheduled properly based on the `Tag` rules.
4. Ensure that `Volumes` can be scheduled after a failure once a `Node` or `Disk` receives the appropriate tags.
5. Ensure that the `nodeSelector` and `diskSelector` parameters are usable through a Kubernetes provisioned `Volume`.

These tests depend on a default set of `Tags` titled `DEFAULT_TAGS` that is set up as a fixture before some of the tests are run due how specific some of the tests are to make sure scheduling is working properly.

Additionally, the `wait_scheduling_failure` function in `test_scheduling.py` has been merged into `common.py` for general usage for other tests such as this one.