### PR TITLE
manager: Update deployment to longhornio/longhorn-manager-test:master

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -40,7 +40,7 @@ metadata:
 spec:
   containers:
   - name: longhorn-test-pod
-    image: longhornio/longhorn-manager-test:07dcd20
+    image: longhornio/longhorn-manager-test:master
 #    args: [
 #           "-x", "-s",
 #           "-m", "coretest",


### PR DESCRIPTION
I think it's better to use `master` tag to deploy `longhorn-manager-test` image, since it will be updated on every merge, and it will be ideal for test_framework to use.