### PR TITLE
Flip Anti-Affinity Setting in scheduler tests

### DIFF
--- a/manager/integration/tests/test_scheduling.py
+++ b/manager/integration/tests/test_scheduling.py
@@ -8,7 +8,7 @@ from common import check_volume_data, cleanup_volume, \
     wait_for_volume_healthy, wait_scheduling_failure, write_volume_random_data
 from time import sleep
 
-SETTING_REPLICA_HARD_ANTI_AFFINITY = "replica-hard-anti-affinity"
+SETTING_REPLICA_SOFT_ANTI_AFFINITY = "replica-soft-anti-affinity"
 
 
 @pytest.yield_fixture(autouse=True)
@@ -18,8 +18,8 @@ def reset_settings():
     host_id = get_self_host_id()
     node = client.by_id_node(host_id)
     client.update(node, allowScheduling=True)
-    setting = client.by_id_setting(SETTING_REPLICA_HARD_ANTI_AFFINITY)
-    client.update(setting, value="false")
+    setting = client.by_id_setting(SETTING_REPLICA_SOFT_ANTI_AFFINITY)
+    client.update(setting, value="true")
 
 
 def get_host_replica(volume, host_id):
@@ -78,8 +78,8 @@ def test_soft_anti_affinity_scheduling(client, volume_name):  # NOQA
     assert len(volume["replicas"]) == 3
 
     data = write_volume_random_data(volume)
-    setting = client.by_id_setting(SETTING_REPLICA_HARD_ANTI_AFFINITY)
-    client.update(setting, value="false")
+    setting = client.by_id_setting(SETTING_REPLICA_SOFT_ANTI_AFFINITY)
+    client.update(setting, value="true")
     node = client.by_id_node(host_id)
     client.update(node, allowScheduling=False)
     replica_names = map(lambda replica: replica.name, volume["replicas"])
@@ -106,8 +106,8 @@ def test_soft_anti_affinity_detach(client, volume_name):  # NOQA
     assert len(volume["replicas"]) == 3
 
     data = write_volume_random_data(volume)
-    setting = client.by_id_setting(SETTING_REPLICA_HARD_ANTI_AFFINITY)
-    client.update(setting, value="false")
+    setting = client.by_id_setting(SETTING_REPLICA_SOFT_ANTI_AFFINITY)
+    client.update(setting, value="true")
     node = client.by_id_node(host_id)
     client.update(node, allowScheduling=False)
     replica_names = map(lambda replica: replica.name, volume["replicas"])
@@ -142,8 +142,8 @@ def test_hard_anti_affinity_scheduling(client, volume_name):  # NOQA
     assert len(volume["replicas"]) == 3
 
     data = write_volume_random_data(volume)
-    setting = client.by_id_setting(SETTING_REPLICA_HARD_ANTI_AFFINITY)
-    client.update(setting, value="true")
+    setting = client.by_id_setting(SETTING_REPLICA_SOFT_ANTI_AFFINITY)
+    client.update(setting, value="false")
     node = client.by_id_node(host_id)
     client.update(node, allowScheduling=False)
     host_replica = get_host_replica(volume, host_id)
@@ -180,8 +180,8 @@ def test_hard_anti_affinity_detach(client, volume_name):  # NOQA
     assert len(volume["replicas"]) == 3
 
     data = write_volume_random_data(volume)
-    setting = client.by_id_setting(SETTING_REPLICA_HARD_ANTI_AFFINITY)
-    client.update(setting, value="true")
+    setting = client.by_id_setting(SETTING_REPLICA_SOFT_ANTI_AFFINITY)
+    client.update(setting, value="false")
     node = client.by_id_node(host_id)
     client.update(node, allowScheduling=False)
     host_replica = get_host_replica(volume, host_id)
@@ -224,8 +224,8 @@ def test_hard_anti_affinity_live_rebuild(client, volume_name):  # NOQA
     assert len(volume["replicas"]) == 3
 
     data = write_volume_random_data(volume)
-    setting = client.by_id_setting(SETTING_REPLICA_HARD_ANTI_AFFINITY)
-    client.update(setting, value="true")
+    setting = client.by_id_setting(SETTING_REPLICA_SOFT_ANTI_AFFINITY)
+    client.update(setting, value="false")
     node = client.by_id_node(host_id)
     client.update(node, allowScheduling=False)
     replica_names = map(lambda replica: replica.name, volume["replicas"])
@@ -259,8 +259,8 @@ def test_hard_anti_affinity_offline_rebuild(client, volume_name):  # NOQA
     assert len(volume["replicas"]) == 3
 
     data = write_volume_random_data(volume)
-    setting = client.by_id_setting(SETTING_REPLICA_HARD_ANTI_AFFINITY)
-    client.update(setting, value="true")
+    setting = client.by_id_setting(SETTING_REPLICA_SOFT_ANTI_AFFINITY)
+    client.update(setting, value="false")
     node = client.by_id_node(host_id)
     client.update(node, allowScheduling=False)
     replica_names = map(lambda replica: replica.name, volume["replicas"])


### PR DESCRIPTION
This PR handles the naming change to the now `Replica Soft Anti-Affinity Setting` and changes the values of this `Setting` set in the tests to make sure the tests still function properly in response to longhorn/longhorn-manager#327.