### PR TITLE
Add test for CreateDefaultDisk Setting

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -9,7 +9,7 @@ metadata:
   name: longhorn-test-role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "pods/exec", "persistentvolumes", "persistentvolumeclaims", "secrets"]
+  resources: ["nodes", "pods", "pods/exec", "persistentvolumes", "persistentvolumeclaims", "secrets"]
   verbs: ["*"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]

--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: longhorn-test-service-account
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -35,6 +36,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: longhorn-test
+  namespace: default
   labels:
     longhorn-test: test-job
 spec:


### PR DESCRIPTION
This PR adds a test for the `Setting: Create Default Disk on Labeled Nodes` that was implemented in longhorn/longhorn-manager#331. The test will check three different cases for when this `Setting` is enabled:
1. A `Disk` already exists on the `Node`. No additional `Disk` should be created.
2. A `Disk` doesn't exist on the `Node`, and the `Node` is labeled properly. The default `Disk` should be created at the path specified in `Setting: Default Data Path`.
3. A `Disk` doesn't exist on the `Node`, but the `Node` doesn't have the appropriate label. The default `Disk` should not be created.

Note that since additional permissions are needed to label the `Nodes` in this test, the `ClusterRole` created for the test has been modified accordingly.

This PR also contains a commit to set the `Namespace` for the test's `Resources` explicitly to `default` so that the test `Resources` are not inadvertently created in the wrong `Namespace`.