### PR TITLE
Return latest volume after KubernetesStatus wait

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2059,6 +2059,7 @@ def wait_volume_kubernetes_status(client, volume_name, expect_ks):
             break
         time.sleep(RETRY_INTERVAL)
     assert expected
+    return volume
 
 
 def create_pv_for_volume(client, core_api, volume, pv_name):


### PR DESCRIPTION
This PR modifies the `wait_volume_kubernetes_status` method that is defined in `common.py` to return the latest version of the `Volume` being waited on for use in testing, similar to how other similar methods such as `wait_for_volume_detached` or `wait_for_volume_healthy` work.

This one line change was accidentally dropped from #168 and is the reason why `test_backup_kubernetes_status_pod` is currently failing in the nightly integration tests.