### PR TITLE
Add a test case for empty backup volume

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1140,6 +1140,20 @@ def wait_for_backup_volume_delete(client, name):
     assert not found
 
 
+def wait_for_backup_delete(backup_name, bv):
+    for i in range(RETRY_COUNTS):
+        backups = bv.backupList()
+        found = False
+        for b in backups:
+            if b["name"] == backup_name:
+                found = True
+                break
+        if not found:
+            break
+        time.sleep(RETRY_INTERVAL)
+    assert not found
+
+
 def wait_for_volume_current_image(client, name, image):
     wait_for_volume_creation(client, name)
     for i in range(RETRY_COUNTS):

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -816,6 +816,36 @@ def test_deleting_backup_volume(clients):  # NOQA
     cleanup_volume(client, volume)
 
 
+def test_empty_backup_volume(clients):  # NOQA
+    for host_id, client in clients.iteritems():
+        break
+    lht_hostId = get_self_host_id()
+
+    volName = generate_volume_name()
+    volume = create_and_check_volume(client, volName)
+
+    volume.attach(hostId=lht_hostId)
+    volume = common.wait_for_volume_healthy(client, volName)
+
+    bv, b1, snap1, _ = create_backup(client, volName)
+    bv.backupDelete(name=b1["name"])
+    common.wait_for_backup_delete(b1["name"], bv)
+
+    backup_list = bv.backupList()
+    assert len(backup_list) == 0
+
+    # test the empty backup volume can recreate backup
+    _, b2, snap2, _ = create_backup(client, volName)
+
+    # test the empty backup volume is still deletable
+    bv.backupDelete(name=b2["name"])
+    common.wait_for_backup_delete(b1["name"], bv)
+    bv = client.by_id_backupVolume(volName)
+    client.delete(bv)
+    common.wait_for_backup_volume_delete(client, volName)
+    cleanup_volume(client, volume)
+
+
 @pytest.mark.coretest   # NOQA
 def test_listing_backup_volume(clients, base_image=""):   # NOQA
     for host_id, client in clients.iteritems():


### PR DESCRIPTION
A function `wait_for_backup_deletion` is added since now the backup deletion is asynchronous