### PR TITLE
Fixing unmount delete test failure

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1503,6 +1503,11 @@ def umount_disk(mount_path):
     subprocess.check_call(cmd)
 
 
+def lazy_umount_disk(mount_path):
+    cmd = ['umount', '-l', mount_path]
+    subprocess.check_call(cmd)
+
+
 def cleanup_host_disk(vol_name):
     mount_path = os.path.join(DIRECTORY_PATH, vol_name)
     umount_disk(mount_path)

--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -878,7 +878,12 @@ def test_node_delete_umount_disks(client):  # NOQA
 
     # umount the disk
     mount_path = os.path.join(DIRECTORY_PATH, disk_volume_name)
-    common.umount_disk(mount_path)
+    # After longhorn refactor, umount_disk will fail with
+    # `target is busy` error from Linux as replica is using
+    # this mount path for storing it's files.
+    # As a work around, we are using `-l` flag that does the
+    # unmount for active mount destinations.
+    common.lazy_umount_disk(mount_path)
 
     # wait for update node status
     node = client.by_id_node(lht_hostId)


### PR DESCRIPTION
After the longhorn refactor, this case was failing as Linux throws error
when the test case was trying to unmount the mount path when an active
volume has a replica running and storing meta files in this mount path.
The following code changes fixes it using -l flag to accomplish the
motive that the test case was trying to achieve.