### PR TITLE
Wait for Snapshot purge completion in tests

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -371,7 +371,8 @@ def snapshot_test(clients, volume_name, base_image):  # NOQA
     volume.snapshotDelete(name=snap2["name"])
 
     volume.snapshotPurge()
-    wait_for_snapshot_purge(volume, snap1["name"], snap3["name"])
+    volume = wait_for_snapshot_purge(client, volume_name, snap1["name"],
+                                     snap3["name"])
 
     snapshots = volume.snapshotList(volume=volume_name)
     snapMap = {}

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -6,7 +6,7 @@ from common import client, volume_name  # NOQA
 from common import SIZE, DEV_PATH
 from common import check_volume_data, cleanup_volume, create_and_check_volume
 from common import get_self_host_id, get_volume_endpoint
-from common import write_volume_random_data
+from common import wait_for_snapshot_purge, write_volume_random_data
 from common import RETRY_COUNTS, RETRY_INTERVAL
 
 
@@ -183,6 +183,9 @@ def ha_backup_deletion_recovery_test(client, volume_name, size, base_image=""): 
 
         res_volume.snapshotDelete(name=backup_snapshot)
         res_volume.snapshotPurge()
+        res_volume = wait_for_snapshot_purge(client, res_name,
+                                             backup_snapshot)
+
         snapshots = res_volume.snapshotList()
         assert len(snapshots) == 2
 


### PR DESCRIPTION
This PR modifies the logic of the `snapshotPurge` calls in the `integration tests` to wait for the `SnapshotPurge` operation on the `SyncAgentServer` to complete before attempting to proceed and running the rest of the test's operations.

This PR modifies the tests to handle the new `asynchronous` version of the `SnapshotPurge` operation as described in longhorn/longhorn#665.