### PR TITLE
Add stress test

### DIFF
--- a/manager/integration/Dockerfile
+++ b/manager/integration/Dockerfile
@@ -1,7 +1,13 @@
 FROM python:2.7.14-stretch
 
+ARG KUBECTL_VERSION=v1.15.0
+
 RUN apt-get update && \
     apt-get install -y vim-tiny nfs-common
+
+RUN wget -q https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl && \
+    mv kubectl /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
 
 ADD tests/requirements.txt .
 RUN pip install -r requirements.txt

--- a/manager/integration/deploy/stress.yml
+++ b/manager/integration/deploy/stress.yml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-test-service-account
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: longhorn-test-role
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "nodes/status", "pods", "pods/exec", "persistentvolumes", "persistentvolumeclaims", "secrets"]
+  verbs: ["*"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["statefulsets", "deployments"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-test-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-test-role
+subjects:
+- kind: ServiceAccount
+  name: longhorn-test-service-account
+  namespace: default
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: longhorn-stress-jobs
+spec:
+  parallelism: 10
+  completions: 10
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+      - name: longhorn-test-pod
+        image: longhornio/longhorn-manager-test:master
+        command: ["/bin/sh", "-c", "while py.test --include-stress-test -s test_stress.py::test_stress; do :; done"]
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+      restartPolicy: Never
+      serviceAccountName: longhorn-test-service-account

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -395,7 +395,7 @@ def delete_and_wait_longhorn(client, name):
     wait_for_volume_delete(client, name)
 
 
-def read_volume_data(api, pod_name):
+def read_volume_data(api, pod_name, filename='test'):
     """
     Retrieve data from a Pod's volume.
 
@@ -409,7 +409,7 @@ def read_volume_data(api, pod_name):
     read_command = [
         '/bin/sh',
         '-c',
-        'cat /data/test'
+        'cat /data/' + filename
     ]
     with timeout(seconds=STREAM_EXEC_TIMEOUT,
                  error_message='Timeout on executing stream read'):
@@ -419,7 +419,7 @@ def read_volume_data(api, pod_name):
             tty=False)
 
 
-def write_pod_volume_data(api, pod_name, test_data):
+def write_pod_volume_data(api, pod_name, test_data, filename='test'):
     """
     Write data into a Pod's volume.
 
@@ -431,7 +431,7 @@ def write_pod_volume_data(api, pod_name, test_data):
     write_command = [
         '/bin/sh',
         '-c',
-        'echo -ne ' + test_data + ' > /data/test'
+        'echo -ne ' + test_data + ' > /data/' + filename
     ]
     with timeout(seconds=STREAM_EXEC_TIMEOUT,
                  error_message='Timeout on executing stream write'):
@@ -2212,3 +2212,69 @@ def check_volume_last_backup(client, volume_name, last_backup):
         time.sleep(RETRY_INTERVAL)
     volume = client.by_id_volume(volume_name)
     assert volume['lastBackup'] == last_backup
+
+
+def generate_pod_with_pvc_manifest(pod_name, pvc_name):
+    pod_manifest = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+           "name": pod_name,
+           "namespace": "default"
+        },
+        "spec": {
+           "containers": [
+              {
+                 "name": "volume-test",
+                 "image": "nginx:stable-alpine",
+                 "imagePullPolicy": "IfNotPresent",
+                 "volumeMounts": [
+                    {
+                       "name": "volv",
+                       "mountPath": "/data"
+                    }
+                 ],
+                 "ports": [
+                    {
+                       "containerPort": 80
+                    }
+                 ]
+              }
+           ],
+           "volumes": [
+              {
+                 "name": "volv",
+                 "persistentVolumeClaim": {
+                    "claimName": pvc_name
+                 }
+              }
+           ]
+        }
+    }
+
+    return pod_manifest
+
+
+def delete_and_wait_volume_attachment(storage_api, volume_attachment_name):
+    try:
+        storage_api.delete_volume_attachment(
+            name=volume_attachment_name
+        )
+    except ApiException as e:
+        assert e.status == 404
+
+    wait_delete_volume_attachment(storage_api, volume_attachment_name)
+
+
+def wait_delete_volume_attachment(storage_api, volume_attachment_name):
+    for i in range(RETRY_COUNTS):
+        found = False
+        ret = storage_api.list_volume_attachment()
+        for item in ret.items:
+            if item.metadata.name == volume_attachment_name:
+                found = True
+                break
+        if not found:
+            break
+        time.sleep(RETRY_INTERVAL)
+    assert not found

--- a/manager/integration/tests/conftest.py
+++ b/manager/integration/tests/conftest.py
@@ -12,6 +12,7 @@ from common import check_longhorn, check_csi
 INCLUDE_BASE_IMAGE_OPT = "--include-base-image-test"
 SKIP_RECURRING_JOB_OPT = "--skip-recurring-job-test"
 INCLUDE_INFRA_OPT = "--include-infra-test"
+INCLUDE_STRESS_OPT = "--include-stress-test"
 
 
 def pytest_addoption(parser):
@@ -24,6 +25,10 @@ def pytest_addoption(parser):
     parser.addoption(INCLUDE_INFRA_OPT, action="store_true",
                      default=False,
                      help="include infra tests (default: False)")
+
+    parser.addoption(INCLUDE_STRESS_OPT, action="store_true",
+                     default=False,
+                     help="include stress tests (default: False)")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -104,3 +109,12 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "infra" in item.keywords:
                 item.add_marker(skip_infra)
+
+    if not config.getoption(INCLUDE_STRESS_OPT):
+        skip_stress = pytest.mark.skip(reason="include " +
+                                       INCLUDE_STRESS_OPT +
+                                       " option to run")
+
+        for item in items:
+            if "stress" in item.keywords:
+                item.add_marker(skip_stress)

--- a/manager/integration/tests/test_stress.py
+++ b/manager/integration/tests/test_stress.py
@@ -1,0 +1,271 @@
+import atexit
+import hashlib
+import os
+import pytest
+import subprocess
+import random
+import string
+
+from common import create_and_check_volume
+from common import create_and_wait_pod
+from common import create_pvc_for_volume
+from common import create_pv_for_volume
+from common import delete_and_wait_longhorn
+from common import delete_and_wait_pod
+from common import delete_and_wait_pv
+from common import delete_and_wait_pvc
+from common import delete_and_wait_volume_attachment
+from common import generate_pod_with_pvc_manifest
+from common import generate_random_data
+from common import get_core_api_client
+from common import get_longhorn_api_client
+from common import get_storage_api_client
+from common import Gi
+from common import read_volume_data
+from common import wait_for_snapshot_purge
+from common import wait_for_volume_detached
+from common import write_pod_volume_data
+from kubernetes.stream import stream
+from random import randrange
+
+
+NPODS = os.getenv("STRESS_TEST_NPODS")
+
+if NPODS is None:
+    NPODS = 1
+else:
+    NPODS = int(NPODS)
+
+count = [str(i) for i in range(NPODS)]
+
+
+STRESS_POD_NAME_PREFIX = "stress-test-pod-"
+STRESS_PVC_NAME_PREFIX = "stress-test-pvc-"
+STRESS_PV_NAME_PREFIX = "stress-test-pv-"
+STRESS_VOLUME_NAME_PREFIX = "stress-test-volume-"
+
+VOLUME_SIZE = str(2 * Gi)
+TEST_DATA_BYTES = 1 * Gi
+
+READ_MD5SUM_TIMEOUT = 60
+
+
+def get_random_suffix():
+    return ''.join(random.choice(string.ascii_lowercase + string.digits)
+                   for _ in range(6))
+
+
+def get_md5sum(file_path):
+    hash_md5 = hashlib.md5()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+
+def write_data(k8s_api_client, pod_name):
+    src_dir_path = '/tmp/'
+    dest_dir_path = '/data/'
+    file_name = 'data-' + pod_name + '.bin'
+
+    src_file_path = src_dir_path + file_name
+    dest_file_path = dest_dir_path + file_name
+
+    src_file = open('%s' % src_file_path, 'wb')
+    src_file.write(os.urandom(TEST_DATA_BYTES))
+    src_file.close()
+    src_file_md5sum = get_md5sum(src_file_path)
+    command = 'kubectl cp ' + src_file_path + \
+              ' ' + pod_name + ':' + dest_file_path
+    subprocess.call(command, shell=True)
+
+    exec_command = exec_command = ['/bin/sh']
+    resp = stream(k8s_api_client.connect_get_namespaced_pod_exec,
+                  pod_name,
+                  'default',
+                  command=exec_command,
+                  stderr=True, stdin=True,
+                  stdout=True, tty=False,
+                  _preload_content=False)
+
+    resp.write_stdin("md5sum " + dest_file_path + "\n")
+    res = resp.readline_stdout(timeout=READ_MD5SUM_TIMEOUT).split()[0]
+
+    assert res == src_file_md5sum
+
+
+def delete_data(k8s_api_client, pod_name):
+    file_name = 'data-' + pod_name + '.bin'
+    test_data = generate_random_data(0)
+
+    write_pod_volume_data(k8s_api_client,
+                          pod_name,
+                          test_data,
+                          filename=file_name)
+
+    volume_data = read_volume_data(k8s_api_client,
+                                   pod_name,
+                                   filename=file_name)
+
+    assert volume_data == ""
+
+
+def create_snapshot(longhorn_api_client, volume_name):
+    volume = longhorn_api_client.by_id_volume(volume_name)
+
+    snapshots = volume.snapshotList(volume=volume_name)
+    snapshots_count = len(snapshots.data)
+
+    volume.snapshotCreate()
+
+    snapshots = volume.snapshotList(volume=volume_name)
+
+    assert len(snapshots) == snapshots_count + 1
+
+
+def purge_random_snapshot(longhorn_api_client, volume_name, snapshot_name):
+
+    volume = longhorn_api_client.by_id_volume(volume_name)
+
+    volume.snapshotPurge()
+
+    wait_for_snapshot_purge(
+        longhorn_api_client,
+        volume_name,
+        snapshot_name
+    )
+
+
+def delete_random_snapshot(longhorn_api_client, volume_name):
+    volume = longhorn_api_client.by_id_volume(volume_name)
+
+    snapshots = volume.snapshotList(volume=volume_name)
+
+    snapshots_count = len(snapshots.data)
+
+    while True:
+        snapshot_id = randrange(0, snapshots_count)
+
+        if snapshots.data[snapshot_id].name == "volume-head":
+            continue
+        else:
+            break
+    snapshot_name = snapshots.data[snapshot_id].name
+
+    volume.snapshotDelete(name=snapshot_name)
+
+    trigger_purge = randrange(0, 2)
+
+    if trigger_purge == 1:
+        purge_random_snapshot(longhorn_api_client, volume_name, snapshot_name)
+
+
+@pytest.mark.stress
+def test_stress(generate_load):
+    pass
+
+
+@pytest.fixture
+def generate_load(request):
+
+    index = get_random_suffix()
+
+    longhorn_api_client = get_longhorn_api_client()
+    k8s_api_client = get_core_api_client()
+
+    volume_name = STRESS_VOLUME_NAME_PREFIX + index
+    pv_name = STRESS_PV_NAME_PREFIX + index
+    pvc_name = STRESS_PVC_NAME_PREFIX + index
+    pod_name = STRESS_POD_NAME_PREFIX + index
+
+    atexit.register(delete_and_wait_longhorn, longhorn_api_client, volume_name)
+    atexit.register(delete_and_wait_pv, k8s_api_client, pv_name)
+    atexit.register(delete_and_wait_pvc, k8s_api_client, pvc_name)
+    atexit.register(delete_and_wait_pod, k8s_api_client, pod_name)
+
+    longhorn_volume = create_and_check_volume(
+        longhorn_api_client,
+        volume_name,
+        size=VOLUME_SIZE
+    )
+
+    wait_for_volume_detached(longhorn_api_client, volume_name)
+
+    pod_manifest = generate_pod_with_pvc_manifest(pod_name, pvc_name)
+
+    create_pv_for_volume(longhorn_api_client,
+                         k8s_api_client,
+                         longhorn_volume,
+                         pv_name)
+
+    create_pvc_for_volume(longhorn_api_client,
+                          k8s_api_client,
+                          longhorn_volume,
+                          pvc_name)
+
+    create_and_wait_pod(k8s_api_client, pod_manifest)
+
+    write_data(k8s_api_client, pod_name)
+    create_snapshot(longhorn_api_client, volume_name)
+    write_data(k8s_api_client, pod_name)
+    create_snapshot(longhorn_api_client, volume_name)
+    delete_data(k8s_api_client, pod_name)
+    create_snapshot(longhorn_api_client, volume_name)
+
+    delete_random_snapshot(longhorn_api_client, volume_name)
+
+    # execute 3 more random actions
+    for round in range(3):
+        action = randrange(0, 4)
+
+        if action == 0:
+            write_data(k8s_api_client, pod_name)
+        elif action == 1:
+            delete_data(k8s_api_client, pod_name)
+        elif action == 2:
+            create_snapshot(longhorn_api_client, volume_name)
+        elif action == 3:
+            delete_random_snapshot(longhorn_api_client, volume_name)
+
+
+@pytest.mark.stress
+def test_reset_env():
+    k8s_api_client = get_core_api_client()
+    k8s_storage_client = get_storage_api_client()
+    longhorn_api_client = get_longhorn_api_client()
+
+    pod_list = k8s_api_client.list_namespaced_pod("default")
+    for pod in pod_list.items:
+        if STRESS_POD_NAME_PREFIX in pod.metadata.name:
+            delete_and_wait_pod(k8s_api_client, pod.metadata.name)
+
+    pvc_list = \
+        k8s_api_client.list_namespaced_persistent_volume_claim("default")
+    for pvc in pvc_list.items:
+        if STRESS_PVC_NAME_PREFIX in pvc.metadata.name:
+            delete_and_wait_pvc(k8s_api_client, pvc.metadata.name)
+
+    pv_list = k8s_api_client.list_persistent_volume()
+    for pv in pv_list.items:
+        pv_name = pv.metadata.name
+        if STRESS_PV_NAME_PREFIX in pv_name:
+            try:
+                delete_and_wait_pv(k8s_api_client, pv_name)
+            except AssertionError:
+                volumeattachment_list = \
+                    k8s_storage_client.list_volume_attachment()
+                for volumeattachment in volumeattachment_list.items:
+                    volume_attachment_name = \
+                        volumeattachment.spec.source.persistent_volume_name
+                    if volume_attachment_name == pv_name:
+                        delete_and_wait_volume_attachment(
+                            k8s_storage_client,
+                            volume_attachment_name
+                        )
+                        delete_and_wait_pv(k8s_api_client, pv.metadata.name)
+
+    volume_list = \
+        longhorn_api_client.list_volume()
+    for volume in volume_list.data:
+        if STRESS_VOLUME_NAME_PREFIX in volume.name:
+            delete_and_wait_longhorn(longhorn_api_client, volume.name)


### PR DESCRIPTION
**Updated**

longhorn/longhorn#679

Stress test actions:
- [x] Stress test job will, by default, create 10 test pods running in an infinite loop doing the following,
  1 - Create Longhorn volume, pv, pvc and a pod.
  2- Write random data with size **1 GB** to the volume, Validate the data and Make a snapshot (x2)
  3- Overwrite written data and Make a snapshot.
  4- Delete/purge snapshot (random)
  5- Choose 3 random actions from:
      - Write random data with size 1 GB
      - Delete data
      - Create a snapshot
      - Delete random snapshot / purge the snapshot randomly.
- [x]  Job keeps running till all pods are `completed`, in this case if test `failed`.