### PR TITLE
manager: waiting for the volume endpoint

### DIFF
--- a/manager/integration/deploy/stress.yml
+++ b/manager/integration/deploy/stress.yml
@@ -4,7 +4,7 @@ metadata:
   name: longhorn-test-service-account
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: longhorn-test-role
@@ -19,7 +19,7 @@ rules:
   resources: ["statefulsets", "deployments"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: longhorn-test-bind

--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: longhorn-test-service-account
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: longhorn-test-role
@@ -19,7 +19,7 @@ rules:
   resources: ["statefulsets", "deployments", "daemonsets"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: longhorn-test-bind

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1089,6 +1089,16 @@ def wait_for_volume_creation(client, name):
     assert found
 
 
+def wait_for_volume_endpoint(client, name):
+    for i in range(RETRY_COUNTS):
+        v = client.by_id_volume(name)
+        engine = get_volume_engine(v)
+        if engine["endpoint"] != "":
+            break
+        time.sleep(RETRY_INTERVAL)
+    return v
+
+
 def wait_for_volume_detached(client, name):
     return wait_for_volume_status(client, name,
                                   VOLUME_FIELD_STATE,
@@ -1099,9 +1109,10 @@ def wait_for_volume_healthy(client, name):
     wait_for_volume_status(client, name,
                            VOLUME_FIELD_STATE,
                            VOLUME_STATE_ATTACHED)
-    return wait_for_volume_status(client, name,
-                                  VOLUME_FIELD_ROBUSTNESS,
-                                  VOLUME_ROBUSTNESS_HEALTHY)
+    wait_for_volume_status(client, name,
+                           VOLUME_FIELD_ROBUSTNESS,
+                           VOLUME_ROBUSTNESS_HEALTHY)
+    return wait_for_volume_endpoint(client, name)
 
 
 def wait_for_volume_restoration_completed(client, name):


### PR DESCRIPTION
Sometimes the endpoint is empty when the volume is healthy. We think
it's due to the delay caused by etcd while fetching the engine object in
the backend.

Workaround the issue by checking to make sure the endpoint is not empty
before proceed.

See the issue for details.

https://github.com/longhorn/longhorn/issues/707

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>