### PR TITLE
Avoid checking endpoint for disaster recovery volumes

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1116,6 +1116,7 @@ def wait_for_volume_endpoint(client, name):
         if engine["endpoint"] != "":
             break
         time.sleep(RETRY_INTERVAL)
+    assert engine["endpoint"] != ""
     return v
 
 

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1135,6 +1135,15 @@ def wait_for_volume_healthy(client, name):
     return wait_for_volume_endpoint(client, name)
 
 
+def wait_for_dr_volume_healthy(client, name):
+    wait_for_volume_status(client, name,
+                           VOLUME_FIELD_STATE,
+                           VOLUME_STATE_ATTACHED)
+    return wait_for_volume_status(client, name,
+                                  VOLUME_FIELD_ROBUSTNESS,
+                                  VOLUME_ROBUSTNESS_HEALTHY)
+
+
 def wait_for_volume_restoration_completed(client, name):
     wait_for_volume_creation(client, name)
     monitor_restore_progress(client, name)

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -41,6 +41,7 @@ from common import storage_class # NOQA
 from common import pod_make # NOQA
 from common import set_random_backupstore
 from common import create_snapshot
+from common import wait_for_dr_volume_healthy
 
 
 @pytest.mark.coretest   # NOQA
@@ -622,9 +623,9 @@ def restore_inc_test(client, core_api, volume_name, pod):  # NOQA
     common.wait_for_volume_restoration_completed(client, sb_volume1_name)
     common.wait_for_volume_restoration_completed(client, sb_volume2_name)
 
-    sb_volume0 = common.wait_for_volume_healthy(client, sb_volume0_name)
-    sb_volume1 = common.wait_for_volume_healthy(client, sb_volume1_name)
-    sb_volume2 = common.wait_for_volume_healthy(client, sb_volume2_name)
+    sb_volume0 = wait_for_dr_volume_healthy(client, sb_volume0_name)
+    sb_volume1 = wait_for_dr_volume_healthy(client, sb_volume1_name)
+    sb_volume2 = wait_for_dr_volume_healthy(client, sb_volume2_name)
 
     for i in range(RETRY_COUNTS):
         sb_volume0 = client.by_id_volume(sb_volume0_name)


### PR DESCRIPTION
There is no assertion after waiting for the endpoint of dr volumes hence the test won't error out. But we need to fix it to avoid meaningless waiting.