### PR TITLE
manager: Fix the wrong usage of wait_for_engine_image_deletion()

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1983,7 +1983,7 @@ def reset_engine_image(client):
                     ready = False
             else:
                 client.delete(ei)
-                wait_for_engine_image_deletion(ei['name'], core_api, client)
+                wait_for_engine_image_deletion(client, core_api, ei['name'])
         if ready:
             break
         time.sleep(RETRY_INTERVAL)


### PR DESCRIPTION
Error message from integration test:

```
Error Message
test setup failure
Stacktrace
>   request.addfinalizer(lambda: cleanup_client(client))

common.py:950: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
common.py:1004: in cleanup_client
    reset_engine_image(client)
common.py:1986: in reset_engine_image
    wait_for_engine_image_deletion(ei['name'], core_api, client)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

client = 'ei-a126797d'
core_api = <function get_core_api_client at 0x7f06e4e52320>
engine_image_name = <longhorn.Client object at 0x7f06e4536f10>

    def wait_for_engine_image_deletion(client, core_api, engine_image_name):
        deleted = False
    
        for i in range(RETRY_COUNTS):
            time.sleep(RETRY_INTERVAL)
            deleted = True
    
>           ei_list = client.list_engine_image().data
E           AttributeError: 'unicode' object has no attribute 'list_engine_image'

common.py:2483: AttributeError
```