### PR TITLE
longhorn.py: Update __len__()

### DIFF
--- a/manager/integration/tests/longhorn.py
+++ b/manager/integration/tests/longhorn.py
@@ -114,6 +114,11 @@ class RestObject:
                 data[k] = v
         return repr(data)
 
+    def __len__(self):
+        if self._is_list():
+            return len(self.data)
+        return len(self.__dict__)
+
     def __getattr__(self, k):
         if self._is_list() and k in LIST_METHODS:
             return getattr(self.data, k)

--- a/manager/integration/tests/longhorn.py
+++ b/manager/integration/tests/longhorn.py
@@ -119,6 +119,13 @@ class RestObject:
             return len(self.data)
         return len(self.__dict__)
 
+    def __getitem__(self, key):
+        if not self:
+            return None
+        if self._is_list():
+            return self.data[key]
+        return self.__dict__[key]
+
     def __getattr__(self, k):
         if self._is_list() and k in LIST_METHODS:
             return getattr(self.data, k)


### PR DESCRIPTION
Somehow python 3 doesn't use __len__() for len(obj) call. It might
failed to register the function due to invoking __getattr__().

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>