### PR TITLE
add pytest-rerunfailures to tests requirments

### DIFF
--- a/manager/integration/tests/requirements.txt
+++ b/manager/integration/tests/requirements.txt
@@ -5,3 +5,4 @@ kubernetes==10.0.1
 pytest==5.3.1
 requests==2.22.0
 six==1.12.0
+pytest-rerunfailures==9.0


### PR DESCRIPTION
added tests
    - test_csi_backup
    - test_tag_basic
    - test_restore_inc
    - test_deleting_backup_volume
    - test_volume_update_replica_count
    - test_salvage_auto_crash_all_replicas
    - test_salvage_auto_crash_replicas_short_wait
    - test_engine_live_upgrade
    - test_pvc_creation_with_default_sc_set
    - test_recurring_job_kubernetes_status

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>