### PR TITLE
Improve test_rebuild_failure_with_intensive_data()

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2871,6 +2871,7 @@ def wait_for_rebuild_start(client, volume_name):
             break
         time.sleep(RETRY_INTERVAL)
     assert started
+    return status.fromReplica, status.replica
 
 
 @pytest.fixture


### PR DESCRIPTION
Right now there is a simpler way to trigger replica rebuild failure
without retry, since we can directly find out the replica which
sends data to the rebuilding replica and crash it.

https://github.com/longhorn/longhorn/issues/1167