### PR TITLE
Add backup status test for unavailable replicas

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2016,9 +2016,24 @@ def wait_for_backup_completion(client, volume_name, snapshot_name):
     for i in range(RETRY_BACKUP_COUNTS):
         v = client.by_id_volume(volume_name)
         for b in v.backupStatus:
-            assert b.error == ""
             if b.snapshot == snapshot_name and b.state == "complete":
                 assert b.progress == 100
+                assert b.error == ""
+                completed = True
+                break
+        if completed:
+            break
+        time.sleep(RETRY_BACKUP_INTERVAL)
+    assert completed is True
+    return v
+
+
+def wait_for_backup_state(client, volume_name, predicate):
+    completed = False
+    for i in range(RETRY_BACKUP_COUNTS):
+        v = client.by_id_volume(volume_name)
+        for b in v.backupStatus:
+            if predicate(b):
                 completed = True
                 break
         if completed:


### PR DESCRIPTION
This test is used to make sure that we do not try to get the backup 
status from unavailable replicas. This could lead to the engine backup 
status retrieval process exceeding the maximum allowed time, after which
the manager would terminate that process. Since we wouldn't be able to
retrieve updated backup statuses we could no longer show new backups in
the frontend.

longhorn/longhorn#1230

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
