### PR TITLE
test framework: use job name as instance name

### DIFF
--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -8,7 +8,7 @@ node {
     withCredentials([string(credentialsId: 'longhorn-tests-do-token', variable: 'TF_VAR_do_token')]) {
         stage('build') {
             sh "test_framework/scripts/build.sh"
-            sh "docker run -itd --name ${JOB_NAME}${BUILD_NUMBER} --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} --env LONGHORN_INFRA_TEST=${LONGHORN_INFRA_TEST} --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} --env TF_VAR_do_token=${env.TF_VAR_do_token} --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} ${imageName}"
+            sh "docker run -itd --name ${JOB_NAME}${BUILD_NUMBER} --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} --env LONGHORN_INFRA_TEST=${LONGHORN_INFRA_TEST} --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} --env TF_VAR_do_token=${env.TF_VAR_do_token} --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} --env TF_VAR_hostname_prefix=${JOB_NAME} ${imageName}"
         }
 
         try {
@@ -17,7 +17,7 @@ node {
             }
 
             stage ('rke') {
-                sh  " docker exec ${JOB_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/rke-setup.sh"
+                sh  " docker exec ${JOB_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/rke-setup.sh ${JOB_NAME}"  
             }
 
             stage ('longhorn setup & tests') {

--- a/test_framework/scripts/rke-setup.sh
+++ b/test_framework/scripts/rke-setup.sh
@@ -2,28 +2,30 @@
 
 set  -x
 
+HOSTNAME_PREFIX=${1:-"longhorn-tests"}
+
 K8S_CONTROLLER_IP=`grep controller "${TF_VAR_tf_workspace}/terraform.output"  | awk '{print $3}'`
 sed -i 's/K8S_CONTROLLER_IP/'${K8S_CONTROLLER_IP}'/' "${TF_VAR_tf_workspace}/templates/3-nodes-k8s.yml"
 
-K8S_CONTROLLER_HOSTNAME="longhorn-tests-00"
+K8S_CONTROLLER_HOSTNAME="${HOSTNAME_PREFIX}-00"
 sed -i 's/K8S_CONTROLLER_HOSTNAME/'${K8S_CONTROLLER_HOSTNAME}'/' "${TF_VAR_tf_workspace}/templates/3-nodes-k8s.yml"
 
 K8S_WORKER_1_IP=`grep worker-1 "${TF_VAR_tf_workspace}/terraform.output"  | awk '{print $3}'`
 sed -i 's/K8S_WORKER_1_IP/'${K8S_WORKER_1_IP}'/' "${TF_VAR_tf_workspace}/templates/3-nodes-k8s.yml"
 
-K8S_WORKER_1_HOSTNAME="longhorn-tests-01"
+K8S_WORKER_1_HOSTNAME="${HOSTNAME_PREFIX}-01"
 sed -i 's/K8S_WORKER_1_HOSTNAME/'${K8S_WORKER_1_HOSTNAME}'/' "${TF_VAR_tf_workspace}/templates/3-nodes-k8s.yml"
 
 K8S_WORKER_2_IP=`grep worker-2 "${TF_VAR_tf_workspace}/terraform.output"  | awk '{print $3}'`
 sed -i 's/K8S_WORKER_2_IP/'${K8S_WORKER_2_IP}'/' "${TF_VAR_tf_workspace}/templates/3-nodes-k8s.yml"
 
-K8S_WORKER_2_HOSTNAME="longhorn-tests-02"
+K8S_WORKER_2_HOSTNAME="${HOSTNAME_PREFIX}-02"
 sed -i 's/K8S_WORKER_2_HOSTNAME/'${K8S_WORKER_2_HOSTNAME}'/' "${TF_VAR_tf_workspace}/templates/3-nodes-k8s.yml"
 
 K8S_WORKER_3_IP=`grep worker-3 "${TF_VAR_tf_workspace}/terraform.output"  | awk '{print $3}'`
 sed -i 's/K8S_WORKER_3_IP/'${K8S_WORKER_3_IP}'/' "${TF_VAR_tf_workspace}/templates/3-nodes-k8s.yml"
 
-K8S_WORKER_3_HOSTNAME="longhorn-tests-03"
+K8S_WORKER_3_HOSTNAME="${HOSTNAME_PREFIX}-03"
 sed -i 's/K8S_WORKER_3_HOSTNAME/'${K8S_WORKER_3_HOSTNAME}'/' "${TF_VAR_tf_workspace}/templates/3-nodes-k8s.yml"
 
 rke up --config "${TF_VAR_tf_workspace}/templates/3-nodes-k8s.yml"

--- a/test_framework/terraform/digitalocean/do.tf
+++ b/test_framework/terraform/digitalocean/do.tf
@@ -18,7 +18,7 @@ resource "digitalocean_droplet" "longhorn-tests" {
   region   = "nyc3"
   size     = "s-4vcpu-8gb"
   ssh_keys = ["${digitalocean_ssh_key.do-ssh-key.fingerprint}"]
-  tags     = ["longhorn-tests", "k8s-controller"]
+  tags     = ["longhorn-tests"]
 
 }
 

--- a/test_framework/terraform/digitalocean/do.tf
+++ b/test_framework/terraform/digitalocean/do.tf
@@ -1,5 +1,6 @@
 variable "do_token" {}
 variable "tf_workspace" {}
+variable "hostname_prefix" {}
 
 provider "digitalocean" {
   token = "${var.do_token}"
@@ -13,7 +14,7 @@ resource "digitalocean_ssh_key" "do-ssh-key" {
 resource "digitalocean_droplet" "longhorn-tests" {
   count    = 4
   image    = "ubuntu-18-04-x64"
-  name     = "longhorn-tests-0${count.index}"
+  name     = "${var.hostname_prefix}-0${count.index}"
   region   = "nyc3"
   size     = "s-4vcpu-8gb"
   ssh_keys = ["${digitalocean_ssh_key.do-ssh-key.fingerprint}"]


### PR DESCRIPTION
Offline node test cases using instance name to identify instance ID
    on cloud provider, using same instance names in both nightly test jobs
    w/o upgrade caused offline node test to accidentally shut down other job
    instances causing unexpected job failure.

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>