### PR TITLE
Add integration test for corrupted S3 backup configs

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -157,6 +157,8 @@ DATA_SIZE_IN_MB_1 = 100
 DATA_SIZE_IN_MB_2 = 300
 DATA_SIZE_IN_MB_3 = 800
 
+MESSAGE_TYPE_ERROR = "error"
+
 
 def load_k8s_config():
     c = Configuration()


### PR DESCRIPTION
This verifies that we can list other backups and also return error
messages for missing or corrupted backups.

longhorn/longhorn#1212

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
