### PR TITLE
scheduler: Test case for zone anti-affinity

### DIFF
--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -350,6 +350,29 @@ def test_replica_scheduler_no_disks(client):  # NOQA
     common.wait_for_volume_delete(client, vol_name)
 
 
+@pytest.mark.skip(reason="TODO")
+@pytest.mark.node  # NOQA
+def test_replica_zone_anti_affinity(client):  # NOQA
+    """
+    Test replica scheduler with zone anti-affinity
+
+    1. Set zone anti-affinity to hard.
+    2. Label nodes 1 & 2 with same zone label "zone1".
+    Label node 3 with zone label "zone2".
+    3. Create a volume with 3 replicas.
+    4. Wait for volume condition `scheduled` to be false.
+    5. Label node 2 with zone label "zone3".
+    6. Wait for volume condition `scheduled` to be success.
+    7. Clear the volume.
+    8. Set zone anti-affinity to soft.
+    9. Change the zone labels on node 1 & 2 & 3 to "zone1".
+    10. Create a volume.
+    11. Wait for volume condition `scheduled` to be success.
+    12. Clean up the replica count, the zone labels and the volume.
+    """
+    pass
+
+
 @pytest.mark.node  # NOQA
 @pytest.mark.mountdisk # NOQA
 def test_replica_scheduler_large_volume_fit_small_disk(client):  # NOQA


### PR DESCRIPTION
This test case is to cover zone anti-affinity.

zone hard anti-affinity means the scheduler should not schedule replica on the same zone
zone soft anti-affinity means the scheduler can schedule replica on the same zone

https://github.com/longhorn/longhorn/issues/1052

Signed-off-by: Bo Tao <bo.tao@rancher.com>