### PR TITLE
Wait for csi backup completion before trying to find the backup

### DIFF
--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -219,6 +219,7 @@ def backupstore_test(client, core_api, csi_pv, pvc, pod_make, pod_name, base_ima
     snap = create_snapshot(client, vol_name)
     volume.snapshotBackup(name=snap.name)
 
+    common.wait_for_backup_completion(client, vol_name, snap.name)
     bv, b = common.find_backup(client, vol_name, snap.name)
 
     pod2_name = 'csi-backup-test-' + str(i)


### PR DESCRIPTION
The backup completion check has a longer timeout and is actually the
intended behavior since it doesn't make sense to proceed with
restoration of a in progress backup.

longhorn/longhorn#820

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
