### PR TITLE
csi: Change driver name to 'driver.longhorn.io'

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -808,7 +808,7 @@ def csi_pv(request):
             'accessModes': ['ReadWriteOnce'],
             'persistentVolumeReclaimPolicy': 'Delete',
             'csi': {
-                'driver': 'io.rancher.longhorn',
+                'driver': 'driver.longhorn.io',
                 'fsType': 'ext4',
                 'volumeAttributes': {
                     'numberOfReplicas':

--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -385,7 +385,7 @@ def test_statefulset_restore(client, core_api, storage_class,  # NOQA
     assert csi
 
     pv['spec']['csi'] = {
-        'driver': 'io.rancher.longhorn',
+        'driver': 'driver.longhorn.io',
         'fsType': 'ext4',
         'volumeAttributes': {
             'numberOfReplicas':


### PR DESCRIPTION
This is to update the csi driver name to 'driver.longhorn.io'.

We introduce this driver name in the following issue number:

https://github.com/longhorn/longhorn/issues/347

And we are going to remove the old csi driver name in the following issue number:

https://github.com/longhorn/longhorn/issues/1365

Signed-off-by: Bo Tao <bo.tao@rancher.com>