### PR TITLE
tests: add test_backup_volume_list to make sure that listing volume does not fail even there are bad names in backups folder.

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3512,6 +3512,329 @@ def set_backupstore_nfs(client):
     client.update(backup_target_credential_setting, value="")
 
 
+def backupstore_cleanup(client):
+    backup_volumes = client.list_backup_volume()
+
+    for backup_volume in backup_volumes:
+        backups = backup_volume.backupList()
+
+        for backup in backups:
+            backup_name = backup.name
+            backup_volume.backupDelete(name=backup_name)
+            wait_for_backup_volume_delete(client, backup_name)
+
+        client.delete(backup_volume)
+
+    backup_volumes = client.list_backup_volume()
+    assert backup_volumes.data == []
+
+
+def get_backupstore_bucket_name(client):
+    backup_target_setting = client.by_id_setting(SETTING_BACKUP_TARGET)
+    backupstore = backup_target_setting.value
+
+    assert is_backupTarget_s3(backupstore)
+
+    bucket_name = urlparse(backupstore).netloc.split('@')[0]
+
+    return bucket_name
+
+
+def get_backupstore_path(client):
+    backup_target_setting = client.by_id_setting(SETTING_BACKUP_TARGET)
+    backupstore = backup_target_setting.value
+
+    assert is_backupTarget_s3(backupstore)
+
+    backupstore_path = urlparse(backupstore).path.split('$')[0].strip("/")
+
+    return backupstore_path
+
+
+def get_minio_api(client, core_api, minio_secret_name):
+    secret = core_api.read_namespaced_secret(name=minio_secret_name,
+                                             namespace=LONGHORN_NAMESPACE)
+
+    base64_minio_access_key = secret.data['AWS_ACCESS_KEY_ID']
+    base64_minio_secret_key = secret.data['AWS_SECRET_ACCESS_KEY']
+    base64_minio_endpoint_url = secret.data['AWS_ENDPOINTS']
+    base64_minio_cert = secret.data['AWS_CERT']
+
+    minio_access_key = \
+        base64.b64decode(base64_minio_access_key).decode("utf-8")
+    minio_secret_key = \
+        base64.b64decode(base64_minio_secret_key).decode("utf-8")
+
+    minio_endpoint_url = \
+        base64.b64decode(base64_minio_endpoint_url).decode("utf-8")
+    minio_endpoint_url = minio_endpoint_url.replace('https://', '')
+
+    minio_cert_file_path = "/tmp/minio_cert.crt"
+    with open(minio_cert_file_path, 'w') as minio_cert_file:
+        base64_minio_cert = \
+            base64.b64decode(base64_minio_cert).decode("utf-8")
+        minio_cert_file.write(base64_minio_cert)
+
+    os.environ["SSL_CERT_FILE"] = minio_cert_file_path
+
+    return Minio(minio_endpoint_url,
+                 access_key=minio_access_key,
+                 secret_key=minio_secret_key,
+                 secure=True)
+
+
+def minio_get_volume_backup_prefix(volume_name):
+    client = get_longhorn_api_client()
+
+    volume_name_sha512 = \
+        hashlib.sha512(volume_name.encode('utf-8')).hexdigest()
+
+    backup_prefix = get_backupstore_path(client) + "/backupstore/volumes"
+    volume_dir_level_1 = volume_name_sha512[0:2]
+    volume_dir_level_2 = volume_name_sha512[2:4]
+
+    prefix = backup_prefix + "/" + \
+        volume_dir_level_1 + "/" + \
+        volume_dir_level_2 + "/" + \
+        volume_name
+
+    return prefix
+
+
+def get_backupstore_secret(client):
+    backup_target_credential_setting = client.by_id_setting(
+        SETTING_BACKUP_TARGET_CREDENTIAL_SECRET)
+
+    return backup_target_credential_setting.value
+
+
+def minio_delete_random_backup_block(client, core_api, volume_name):
+    secret_name = get_backupstore_secret(client)
+
+    assert secret_name != ''
+
+    minio_api = get_minio_api(client, core_api, secret_name)
+
+    bucket_name = get_backupstore_bucket_name(client)
+    prefix = minio_get_volume_backup_prefix(volume_name) + "/blocks"
+
+    block_object_files = minio_api.list_objects(bucket_name,
+                                                prefix=prefix,
+                                                recursive=True)
+
+    object_file = block_object_files.__next__().object_name
+
+    try:
+        minio_api.remove_object(bucket_name, object_file)
+    except ResponseError as err:
+        print(err)
+
+
+# TODO: implement nfs_delete_random_backup_block
+def nfs_delete_random_backup_block(client, core_api, volume_name):
+    raise NotImplementedError
+
+
+def backupstore_count_backup_block_files(client, core_api, volume_name):
+    backup_target_setting = client.by_id_setting(SETTING_BACKUP_TARGET)
+    backupstore = backup_target_setting.value
+
+    if is_backupTarget_s3(backupstore):
+        return minio_count_backup_block_files(client, core_api, volume_name)
+
+    elif is_backupTarget_nfs(backupstore):
+        return nfs_count_backup_block_files()
+
+
+# TODO: implement nfs_count_backup_block_files
+def nfs_count_backup_block_files():
+    raise NotImplementedError
+
+
+def minio_count_backup_block_files(client, core_api, volume_name):
+    backup_target_credential_setting = client.by_id_setting(
+            SETTING_BACKUP_TARGET_CREDENTIAL_SECRET)
+
+    secret_name = backup_target_credential_setting.value
+
+    minio_api = get_minio_api(client, core_api, secret_name)
+    bucket_name = get_backupstore_bucket_name(client)
+    prefix = minio_get_volume_backup_prefix(volume_name) + "/blocks"
+
+    block_object_files = minio_api.list_objects(bucket_name,
+                                                prefix=prefix,
+                                                recursive=True)
+    block_object_files_list = list(block_object_files)
+
+    return len(block_object_files_list)
+
+
+def backupstore_create_dummy_in_progress_backup(client, core_api, volume_name):
+    backup_target_setting = client.by_id_setting(SETTING_BACKUP_TARGET)
+    backupstore = backup_target_setting.value
+
+    if is_backupTarget_s3(backupstore):
+        return minio_create_dummy_in_progress_backup(client,
+                                                     core_api,
+                                                     volume_name)
+
+    elif is_backupTarget_nfs(backupstore):
+        return nfs_create_dummy_in_progress_backup()
+
+
+# TODO: implement nfs_create_dummy_in_progress_backup
+def nfs_create_dummy_in_progress_backup():
+    raise NotImplementedError
+
+
+def backupstore_create_file(client, core_api, prefix, file_name, data={}):
+    backup_target_setting = client.by_id_setting(SETTING_BACKUP_TARGET)
+    backupstore = backup_target_setting.value
+
+    if is_backupTarget_s3(backupstore):
+        return mino_create_file_in_backupstore(client,
+                                               core_api,
+                                               prefix,
+                                               file_name,
+                                               data)
+    else:
+        raise NotImplementedError
+
+
+def mino_create_file_in_backupstore(client, core_api, prefix, file_name, data={}): # NOQA
+    backup_target_credential_setting = client.by_id_setting(
+        SETTING_BACKUP_TARGET_CREDENTIAL_SECRET)
+
+    secret_name = backup_target_credential_setting.value
+
+    minio_api = get_minio_api(client, core_api, secret_name)
+    bucket_name = get_backupstore_bucket_name(client)
+
+    if len(data) == 0:
+        data = {"testkey": "test data from mino_create_file_in_backupstore()"}
+
+    temp_file_path = "/tmp/temp_file.cfg"
+
+    with open(temp_file_path, 'w') as temp_file:
+        json.dump(data, temp_file)
+
+    try:
+        with open(temp_file_path, 'rb') as temp_file:
+            temp_file_stat = os.stat(temp_file_path)
+            minio_api.put_object(bucket_name,
+                                 prefix + "/" + file_name,
+                                 temp_file,
+                                 temp_file_stat.st_size)
+    except ResponseError as err:
+        print(err)
+
+
+def minio_create_dummy_in_progress_backup(client, core_api, volume_name):
+    backup_target_credential_setting = client.by_id_setting(
+            SETTING_BACKUP_TARGET_CREDENTIAL_SECRET)
+
+    secret_name = backup_target_credential_setting.value
+
+    minio_api = get_minio_api(client, core_api, secret_name)
+    bucket_name = get_backupstore_bucket_name(client)
+    prefix = minio_get_volume_backup_prefix(volume_name) + "/backups"
+
+    dummy_backup_cfg_data = {"Name": "dummy_backup",
+                             "VolumeName": volume_name,
+                             "CreatedTime": ""}
+
+    backup_cfg_file = "/tmp/backup_backup-dummy.cfg"
+
+    with open(backup_cfg_file, 'w') as bkp_cfg_file:
+        json.dump(dummy_backup_cfg_data, bkp_cfg_file)
+
+    try:
+        with open(backup_cfg_file, 'rb') as bkp_cfg_file:
+            bkp_cfg_file_stat = os.stat(backup_cfg_file)
+            minio_api.put_object(bucket_name,
+                                 prefix + "/backup_backup-dummy.cfg",
+                                 bkp_cfg_file,
+                                 bkp_cfg_file_stat.st_size)
+    except ResponseError as err:
+        print(err)
+
+
+def backupstore_delete_file(client, core_api, prefix, file_name):
+    backup_target_setting = client.by_id_setting(SETTING_BACKUP_TARGET)
+    backupstore = backup_target_setting.value
+
+    if is_backupTarget_s3(backupstore):
+        return mino_delete_file_in_backupstore(client,
+                                               core_api,
+                                               prefix,
+                                               file_name)
+
+    elif is_backupTarget_nfs(backupstore):
+        raise NotImplementedError
+
+
+def mino_delete_file_in_backupstore(client, core_api, prefix, file_name):
+    backup_target_credential_setting = client.by_id_setting(
+        SETTING_BACKUP_TARGET_CREDENTIAL_SECRET)
+
+    secret_name = backup_target_credential_setting.value
+
+    minio_api = get_minio_api(client, core_api, secret_name)
+    bucket_name = get_backupstore_bucket_name(client)
+
+    try:
+        minio_api.remove_object(bucket_name,
+                                prefix + "/" + file_name)
+    except ResponseError as err:
+        print(err)
+
+
+def backupstore_delete_dummy_in_progress_backup(client, core_api, volume_name):
+    backup_target_setting = client.by_id_setting(SETTING_BACKUP_TARGET)
+    backupstore = backup_target_setting.value
+
+    if is_backupTarget_s3(backupstore):
+        return minio_delete_dummy_in_progress_backup(client,
+                                                     core_api,
+                                                     volume_name)
+
+    elif is_backupTarget_nfs(backupstore):
+        return nfs_delete_dummy_in_progress_backup()
+
+
+# TODO: implement nfs_delete_dummy_in_progress_backup
+def nfs_delete_dummy_in_progress_backup():
+    raise NotImplementedError
+
+
+def minio_delete_dummy_in_progress_backup(client, core_api, volume_name):
+    backup_target_credential_setting = client.by_id_setting(
+            SETTING_BACKUP_TARGET_CREDENTIAL_SECRET)
+
+    secret_name = backup_target_credential_setting.value
+
+    minio_api = get_minio_api(client, core_api, secret_name)
+    bucket_name = get_backupstore_bucket_name(client)
+    prefix = minio_get_volume_backup_prefix(volume_name) + "/backups"
+
+    try:
+        minio_api.remove_object(bucket_name,
+                                prefix + "/backup_backup-dummy.cfg")
+    except ResponseError as err:
+        print(err)
+
+
+def delete_random_backup_block(client, core_api, volume_name):
+    backup_target_setting = client.by_id_setting(SETTING_BACKUP_TARGET)
+    backupstore = backup_target_setting.value
+
+    if is_backupTarget_s3(backupstore):
+        minio_delete_random_backup_block(client, core_api, volume_name)
+
+    elif is_backupTarget_nfs(backupstore):
+        nfs_delete_random_backup_block(volume_name)
+
+
 def crash_engine_process_with_sigkill(client, core_api, volume_name):
     volume = client.by_id_volume(volume_name)
     ins_mgr_name = volume.controllers[0].instanceManagerName


### PR DESCRIPTION
test_backup_volume_list() make sure that instead of erroring the backup list should ignore the badly named files in backups folder.

longhorn/longhorn#1410

