### PR TITLE
Replace create_pv_for_volume and create_pvc_for_volume with fixture

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -38,7 +38,7 @@ from common import wait_for_volume_restoration_completed
 from common import read_volume_data
 from common import pvc_name # NOQA
 from common import storage_class # NOQA
-from common import pod_make # NOQA
+from common import pod_make, csi_pv, pvc # NOQA
 from common import set_random_backupstore
 from common import create_snapshot
 from common import expand_attached_volume
@@ -2630,7 +2630,7 @@ def test_expansion_with_scheduling_failure(
 
 
 def test_dr_volume_with_last_backup_deletion(
-        client, core_api, volume_name, pod_make):  # NOQA
+        client, core_api, csi_pv, pvc, volume_name, pod_make):  # NOQA
     """
     Test if the DR volume can be activated
     after deleting the lastest backup. There are two cases to the last
@@ -2664,7 +2664,7 @@ def test_dr_volume_with_last_backup_deletion(
     data_path1 = "/data/test1"
     std_pod_name, std_pv_name, std_pvc_name, std_md5sum1 = \
         prepare_pod_with_data_in_mb(
-            client, core_api, pod_make, std_volume_name,
+            client, core_api, csi_pv, pvc, pod_make, std_volume_name,
             data_path=data_path1, data_size_in_mb=DATA_SIZE_IN_MB_1)
 
     std_volume = client.by_id_volume(std_volume_name)

--- a/manager/integration/tests/test_upgrade.py
+++ b/manager/integration/tests/test_upgrade.py
@@ -23,7 +23,7 @@ from common import wait_statefulset
 from common import create_pvc_spec
 from common import create_and_wait_pod
 from common import get_pod_data_md5sum
-from common import pod_make # NOQA
+from common import pod_make, csi_pv, pvc # NOQA
 from common import statefulset # NOQA
 from common import storage_class # NOQA
 from common import SETTING_AUTO_SALVAGE
@@ -54,7 +54,7 @@ def longhorn_upgrade(image_tag):
 
 
 @pytest.mark.upgrade
-def test_upgrade(upgrade_image_tag, settings_reset, volume_name, pod_make, statefulset, storage_class):  # NOQA
+def test_upgrade(upgrade_image_tag, settings_reset, volume_name, csi_pv, pvc, pod_make, statefulset, storage_class): # NOQA
     """
     Test Longhorn upgrade
 
@@ -103,7 +103,7 @@ def test_upgrade(upgrade_image_tag, settings_reset, volume_name, pod_make, state
 
     # Create Volume used by Pod
     pod_name, pv_name, pvc_name, pod_md5sum = \
-        prepare_pod_with_data_in_mb(client, core_api,
+        prepare_pod_with_data_in_mb(client, core_api, csi_pv, pvc,
                                     pod_make, pod_volume_name,
                                     data_path=pod_data_path,
                                     add_liveness_prope=False)


### PR DESCRIPTION
Replaced the create_pv_for_volume and create_pvc_for_volume in method 'prepare_pod_with_data_in_mb'.
Identified few more cases where 'create_pv_for_volume' and 'create_pvc_for_volume' are used(not straight though). Will change them too if this approach is right.

https://github.com/longhorn/longhorn/issues/1462