### PR TITLE
Add Priority Class to test deploy

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -13,6 +13,9 @@ rules:
   resources: ["nodes", "nodes/status", "pods", "pods/exec", "persistentvolumes", "persistentvolumeclaims",
               "persistentvolumeclaims/status", "secrets", "services", "serviceaccounts", "namespaces", "configmaps"]
   verbs: ["*"]
+- apiGroups: ["scheduling.k8s.io"]
+  resources: ["priorityclasses"]
+  verbs: ["*"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["*"]


### PR DESCRIPTION
This PR adds `Priority Classes` to the set of resources accessible by the `longhorn-manager` integration tests via the `Cluster Role` that it uses. This fixes the issue where the `Priority Class` tests would fail due to not having the correct permissions for creating and deleting `Priority Classes`.