### PR TITLE
Refactor test to always use backup_delete / backup_volume_delete

### DIFF
--- a/manager/integration/tests/backupstore.py
+++ b/manager/integration/tests/backupstore.py
@@ -15,7 +15,8 @@ from common import LONGHORN_NAMESPACE
 from common import is_backupTarget_s3
 from common import is_backupTarget_nfs
 from common import get_longhorn_api_client
-from common import wait_for_backup_volume_delete
+from common import delete_backup
+from common import delete_backup_volume
 
 BACKUPSTORE_BV_PREFIX = "/backupstore/volumes/"
 
@@ -30,11 +31,9 @@ def backupstore_cleanup(client):
         backups = backup_volume.backupList()
 
         for backup in backups:
-            backup_name = backup.name
-            backup_volume.backupDelete(name=backup_name)
-            wait_for_backup_volume_delete(client, backup_name)
+            delete_backup(client, backup_volume.name, backup.name)
 
-        client.delete(backup_volume)
+        delete_backup_volume(client, backup_volume.name)
 
     backup_volumes = client.list_backup_volume()
     assert backup_volumes.data == []

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -289,26 +289,16 @@ def create_backup(client, volname, data={}, labels={}):
     return bv, b, snap, data
 
 
-def delete_backup(backup_volume, backup_name):
+def delete_backup(client, volume_name, backup_name):
+    backup_volume = client.by_id_backupVolume(volume_name)
     backup_volume.backupDelete(name=backup_name)
+    wait_for_backup_delete(client, volume_name, backup_name)
 
-    found = False
-    for i in range(RETRY_COMMAND_COUNT):
-        found = False
-        try:
-            backups = backup_volume.backupList().data
-        except longhorn.ApiError:
-            continue
 
-        for b in backups:
-            if b.name == backup_name:
-                found = True
-                break
-        if not found:
-            break
-        time.sleep(RETRY_INTERVAL)
-
-    assert not found
+def delete_backup_volume(client, volume_name):
+    bv = client.by_id_backupVolume(volume_name)
+    client.delete(bv)
+    wait_for_backup_volume_delete(client, volume_name)
 
 
 def create_and_check_volume(client, volume_name, num_of_replicas=3, size=SIZE,

--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -229,7 +229,7 @@ def backupstore_test(client, core_api, csi_pv, pvc, pod_make, pod_name, base_ima
     resp = read_volume_data(core_api, pod2_name)
     assert resp == test_data
 
-    delete_backup(bv, b.name)
+    delete_backup(client, bv.name, b.name)
 
 @pytest.mark.csi  # NOQA
 def test_csi_block_volume(client, core_api, storage_class, pvc, pod_manifest):  # NOQA

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -753,7 +753,8 @@ def test_rebuild_with_restoration(
     md5sum = get_pod_data_md5sum(core_api, restore_pod_name, data_path)
     assert original_md5sum == md5sum
 
-    bv.backupDelete(name=b.name)
+    # cleanup
+    backupstore_cleanup(client)
     delete_and_wait_pod(core_api, original_pod_name)
     delete_and_wait_pvc(core_api, original_pvc_name)
     delete_and_wait_pv(core_api, original_pv_name)
@@ -852,8 +853,8 @@ def test_rebuild_with_inc_restoration(
     md5sum2 = get_pod_data_md5sum(core_api, dr_pod_name, data_path2)
     assert std_md5sum2 == md5sum2
 
-    bv.backupDelete(name=b1.name)
-    bv.backupDelete(name=b2.name)
+    # cleanup
+    backupstore_cleanup(client)
     delete_and_wait_pod(core_api, std_pod_name)
     delete_and_wait_pvc(core_api, std_pvc_name)
     delete_and_wait_pv(core_api, std_pv_name)
@@ -1392,9 +1393,7 @@ def test_dr_volume_with_restore_command_error(
     md5sum2 = get_pod_data_md5sum(core_api, dr_pod_name, data_path2)
     assert std_md5sum2 == md5sum2
 
-    bv.backupDelete(name=b1.name)
-    bv.backupDelete(name=b2.name)
-    client.delete(bv)
+    backupstore_cleanup(client)
 
 
 def test_volume_reattach_after_engine_sigkill(client, core_api, volume_name, pod_make):  # NOQA

--- a/manager/integration/tests/test_kubernetes.py
+++ b/manager/integration/tests/test_kubernetes.py
@@ -23,10 +23,11 @@ from common import SIZE
 from common import KUBERNETES_STATUS_LABEL, SETTING_DEFAULT_LONGHORN_STATIC_SC
 from common import DEFAULT_LONGHORN_STATIC_STORAGECLASS_NAME
 from common import create_snapshot
-from common import set_random_backupstore
+from common import set_random_backupstore, delete_backup
 from common import create_and_check_volume, create_pvc, \
     wait_and_get_pv_for_pvc, wait_delete_pvc
 from common import volume_name # NOQA
+from backupstore import backupstore_cleanup
 
 from kubernetes import client as k8sclient
 from kubernetes.client.rest import ApiException
@@ -631,7 +632,7 @@ def test_backup_kubernetes_status(client, core_api, pod):  # NOQA
     assert restore.kubernetesStatus.lastPodRefAt == ks["lastPodRefAt"]
     assert restore.kubernetesStatus.lastPVCRefAt == ks["lastPVCRefAt"]
 
-    bv.backupDelete(name=b.name)
+    delete_backup(client, bv.name, b.name)
     client.delete(restore)
     wait_for_volume_delete(client, restore_name)
     delete_and_wait_pod(core_api, pod_name)
@@ -707,7 +708,8 @@ def test_backup_kubernetes_status(client, core_api, pod):  # NOQA
     assert restore.kubernetesStatus.lastPodRefAt == ks["lastPodRefAt"]
     assert restore.kubernetesStatus.lastPVCRefAt == ks["lastPVCRefAt"]
 
-    bv.backupDelete(name=b.name)
+    # cleanup
+    backupstore_cleanup(client)
     client.delete(restore)
     cleanup_volume(client, volume)
 


### PR DESCRIPTION
Since both deletion operations are async we need to always wait for
completion of the requested operation before proceeding with our tests.

longhorn/longhorn#710
longhorn/longhorn#1603
longhorn/longhorn#1604

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
