### PR TITLE
Use JOB_BASE_NAME instead of JOB_NAME in Jenkins jobs

### DIFF
--- a/secscan/Jenkinsfile
+++ b/secscan/Jenkinsfile
@@ -1,4 +1,4 @@
-def imageName = "${JOB_NAME}${env.BUILD_NUMBER}"
+def imageName = "${JOB_BASE_NAME}${env.BUILD_NUMBER}"
 
 node {
     notifyBuild('STARTED')
@@ -8,16 +8,16 @@ node {
     withCredentials([string(credentialsId: 'longhorn-tests-do-token', variable: 'TF_VAR_do_token')]) {
         stage('build') {
             sh "secscan/scripts/build.sh"
-            sh "docker run -itd --name ${JOB_NAME}${BUILD_NUMBER} --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} --env TF_VAR_do_token=${env.TF_VAR_do_token} ${imageName}"
+            sh "docker run -itd --name ${JOB_BASE_NAME}${BUILD_NUMBER} --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} --env TF_VAR_do_token=${env.TF_VAR_do_token} ${imageName}"
         }
 
         try {
             stage ('scan images') {
-                sh  " docker exec ${JOB_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/terraform-setup.sh"
+                sh  " docker exec ${JOB_BASE_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/terraform-setup.sh"
             }
 
             stage ('report generation') {
-                sh "docker cp ${JOB_NAME}${BUILD_NUMBER}:${TF_VAR_tf_workspace}/junit-reports ."
+                sh "docker cp ${JOB_BASE_NAME}${BUILD_NUMBER}:${TF_VAR_tf_workspace}/junit-reports ."
                 def summary = junit "junit-reports/*.xml"
             }
 
@@ -26,9 +26,9 @@ node {
             throw e
         } finally {
             stage('releasing resources') {
-                sh  " docker exec ${JOB_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/cleanup.sh"
-                sh "docker stop ${JOB_NAME}${BUILD_NUMBER}"
-                sh "docker rm -v ${JOB_NAME}${BUILD_NUMBER}"
+                sh  " docker exec ${JOB_BASE_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/cleanup.sh"
+                sh "docker stop ${JOB_BASE_NAME}${BUILD_NUMBER}"
+                sh "docker rm -v ${JOB_BASE_NAME}${BUILD_NUMBER}"
                 sh "docker rmi ${imageName}"
                 notifyBuild(currentBuild.result)
             }
@@ -44,7 +44,7 @@ def notifyBuild(String buildStatus = 'STARTED') {
   // Default values
   def colorName = 'RED'
   def colorCode = '#FF0000'
-  def subject = "${buildStatus}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'"
+  def subject = "${buildStatus}: Job '${env.JOB_BASE_NAME} [${env.BUILD_NUMBER}]'"
   def summary = "${subject} (${env.BUILD_URL})"
 
   // Override default values based on build status

--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -1,4 +1,4 @@
-def imageName = "${JOB_NAME}${env.BUILD_NUMBER}"
+def imageName = "${JOB_BASE_NAME}${env.BUILD_NUMBER}"
 def summary
 
 node {
@@ -9,27 +9,27 @@ node {
     withCredentials([string(credentialsId: 'longhorn-tests-do-token', variable: 'TF_VAR_do_token')]) {
         stage('build') {
             sh "test_framework/scripts/build.sh"
-            sh "docker run -itd --name ${JOB_NAME}${BUILD_NUMBER} --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} --env LONGHORN_INFRA_TEST=${LONGHORN_INFRA_TEST} --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} --env TF_VAR_do_token=${env.TF_VAR_do_token} --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} --env TF_VAR_hostname_prefix=${JOB_NAME} ${imageName}"
+            sh "docker run -itd --name ${JOB_BASE_NAME}${BUILD_NUMBER} --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} --env LONGHORN_INFRA_TEST=${LONGHORN_INFRA_TEST} --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} --env TF_VAR_do_token=${env.TF_VAR_do_token} --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} --env TF_VAR_hostname_prefix=${JOB_BASE_NAME} ${imageName}"
         }
 
         try {
             stage ('terraform') {
-                sh  " docker exec ${JOB_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/terraform-setup.sh"
+                sh  " docker exec ${JOB_BASE_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/terraform-setup.sh"
             }
 
             stage ('rke') {
-                sh  " docker exec ${JOB_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/rke-setup.sh ${JOB_NAME}"  
+                sh  " docker exec ${JOB_BASE_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/rke-setup.sh ${JOB_BASE_NAME}"  
             }
 
             stage ('longhorn setup & tests') {
-                sh  " docker exec ${JOB_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/longhorn-setup.sh"
+                sh  " docker exec ${JOB_BASE_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/longhorn-setup.sh"
             }
             stage ('report generation') {
-                sh "docker cp ${JOB_NAME}${BUILD_NUMBER}:${TF_VAR_tf_workspace}/longhorn-test-junit-report.xml ."
+                sh "docker cp ${JOB_BASE_NAME}${BUILD_NUMBER}:${TF_VAR_tf_workspace}/longhorn-test-junit-report.xml ."
                 summary = junit 'longhorn-test-junit-report.xml'
 
                 if(params.LONGHORN_UPGRADE_TEST) {
-                    sh "docker cp ${JOB_NAME}${BUILD_NUMBER}:${TF_VAR_tf_workspace}/longhorn-test-upgrade-junit-report.xml ."
+                    sh "docker cp ${JOB_BASE_NAME}${BUILD_NUMBER}:${TF_VAR_tf_workspace}/longhorn-test-upgrade-junit-report.xml ."
                     summary = junit 'longhorn-test-upgrade-junit-report.xml'
                 }
 
@@ -40,9 +40,9 @@ node {
             throw e
         } finally {
             stage('releasing resources') {
-                sh  " docker exec ${JOB_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/cleanup.sh"
-                sh "docker stop ${JOB_NAME}${BUILD_NUMBER}"
-                sh "docker rm -v ${JOB_NAME}${BUILD_NUMBER}"
+                sh  " docker exec ${JOB_BASE_NAME}${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/cleanup.sh"
+                sh "docker stop ${JOB_BASE_NAME}${BUILD_NUMBER}"
+                sh "docker rm -v ${JOB_BASE_NAME}${BUILD_NUMBER}"
                 sh "docker rmi ${imageName}"
                 if(summary){
                     summary_msg = "\nTest Summary - Failures: ${summary.failCount}, Skipped: ${summary.skipCount}, Passed: ${summary.passCount}  -- Job completed in ${currentBuild.durationString.replace(' and counting', '')}"
@@ -65,7 +65,7 @@ def notifyBuild(String buildStatus = 'STARTED', String summary_msg) {
   // Default values
   def colorName = 'RED'
   def colorCode = '#FF0000'
-  def subject = "${buildStatus}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'"
+  def subject = "${buildStatus}: Job '${env.JOB_BASE_NAME} [${env.BUILD_NUMBER}]'"
   def summary = "${subject} (${env.BUILD_URL})" + summary_msg
 
   // Override default values based on build status


### PR DESCRIPTION
Migrating Jenkins jobs to folders caused test docker images build to fail.

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>