### PR TITLE
Use JOB_BASE_NAME instead of JOB_NAME in build scripts

### DIFF
--- a/secscan/scripts/build.sh
+++ b/secscan/scripts/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build --no-cache -f ./secscan/Dockerfile.setup -t "${JOB_NAME}${BUILD_NUMBER}" .
+docker build --no-cache -f ./secscan/Dockerfile.setup -t "${JOB_BASE_NAME}${BUILD_NUMBER}" .

--- a/test_framework/scripts/build.sh
+++ b/test_framework/scripts/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build --no-cache -f ./test_framework/Dockerfile.setup -t "${JOB_NAME}${BUILD_NUMBER}" .
+docker build --no-cache -f ./test_framework/Dockerfile.setup -t "${JOB_BASE_NAME}${BUILD_NUMBER}" .


### PR DESCRIPTION
Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>