### PR TITLE
update test pod clusterrole resources

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -23,12 +23,14 @@ rules:
   resources: ["statefulsets", "deployments", "daemonsets"]
   verbs: ["*"]
 - apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterroles", "clusterrolebindings"]
+  resources: ["clusterroles", "clusterrolebindings", "rolebindings", "roles"]
   verbs: ["*"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["*"]
-
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Longhorn test pod doesn't have access to the following resources (rolebindings, roles, podsecuritypolicies) which affects `test_upgrade`

```
Resource: "policy/v1beta1, Resource=podsecuritypolicies", GroupVersionKind: "policy/v1beta1, Kind=PodSecurityPolicy"
Name: "longhorn-psp", Namespace: ""
Object: &{map["apiVersion":"policy/v1beta1" "kind":"PodSecurityPolicy" "metadata":map["annotations":map["kubectl.kubernetes.io/last-applied-configuration":""] "name":"longhorn-psp"] "spec":map["allowPrivilegeEscalation":%!q(bool=true) "allowedCapabilities":["SYS_ADMIN"] "fsGroup":map["rule":"RunAsAny"] "hostIPC":%!q(bool=false) "hostNetwork":%!q(bool=false) "hostPID":%!q(bool=true) "privileged":%!q(bool=true) "requiredDropCapabilities":["NET_RAW"] "runAsUser":map["rule":"RunAsAny"] "seLinux":map["rule":"RunAsAny"] "supplementalGroups":map["rule":"RunAsAny"] "volumes":["configMap" "downwardAPI" "emptyDir" "secret" "projected" "hostPath"]]]}
from server for: "/tmp/longhorn-master.yml": podsecuritypolicies.policy "longhorn-psp" is forbidden: User "system:serviceaccount:default:longhorn-test-service-account" cannot get resource "podsecuritypolicies" in API group "policy" at the cluster scope
Error from server (Forbidden): error when retrieving current configuration of:
Resource: "rbac.authorization.k8s.io/v1, Resource=roles", GroupVersionKind: "rbac.authorization.k8s.io/v1, Kind=Role"
Name: "longhorn-psp-role", Namespace: "longhorn-system"
Object: &{map["apiVersion":"rbac.authorization.k8s.io/v1" "kind":"Role" "metadata":map["annotations":map["kubectl.kubernetes.io/last-applied-configuration":""] "name":"longhorn-psp-role" "namespace":"longhorn-system"] "rules":[map["apiGroups":["policy"] "resourceNames":["longhorn-psp"] "resources":["podsecuritypolicies"] "verbs":["use"]]]]}
from server for: "/tmp/longhorn-master.yml": roles.rbac.authorization.k8s.io "longhorn-psp-role" is forbidden: User "system:serviceaccount:default:longhorn-test-service-account" cannot get resource "roles" in API group "rbac.authorization.k8s.io" in the namespace "longhorn-system"
Error from server (Forbidden): error when retrieving current configuration of:
Resource: "rbac.authorization.k8s.io/v1, Resource=rolebindings", GroupVersionKind: "rbac.authorization.k8s.io/v1, Kind=RoleBinding"
Name: "longhorn-psp-binding", Namespace: "longhorn-system"
Object: &{map["apiVersion":"rbac.authorization.k8s.io/v1" "kind":"RoleBinding" "metadata":map["annotations":map["kubectl.kubernetes.io/last-applied-configuration":""] "name":"longhorn-psp-binding" "namespace":"longhorn-system"] "roleRef":map["apiGroup":"rbac.authorization.k8s.io" "kind":"Role" "name":"longhorn-psp-role"] "subjects":[map["kind":"ServiceAccount" "name":"longhorn-service-account" "namespace":"longhorn-system"] map["kind":"ServiceAccount" "name":"default" "namespace":"longhorn-system"]]]}
from server for: "/tmp/longhorn-master.yml": rolebindings.rbac.authorization.k8s.io "longhorn-psp-binding" is forbidden: User "system:serviceaccount:default:longhorn-test-service-account" cannot get resource "rolebindings" in API group "rbac.authorization.k8s.io" in the namespace "longhorn-system"
```

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>