### PR TITLE
fix race condition for autosalvage tests

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -441,6 +441,7 @@ def wait_pod_for_auto_salvage(
 
     wait_for_volume_healthy(client, volume_name)
 
+    wait_for_pod_restart(core_api, pod_name)
     wait_for_pod_remount(core_api, pod_name)
 
     md5sum = get_pod_data_md5sum(core_api, pod_name, data_path)


### PR DESCRIPTION
need to wait for pod restart before checking for Longhorn volume re-mounted

fix affect the following tests
  - test_salvage_auto_crash_replicas_short_wait
  - test_salvage_auto_crash_replicas_long_wait

[failed test log](https://ci.longhorn.io/job/public/job/longhorn-upgrade-tests/66/testReport/junit/tests/test_ha/test_salvage_auto_crash_replicas_short_wait/)

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>