### PR TITLE
Update test skeleton for node eviction

### DIFF
--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -2198,8 +2198,7 @@ def test_node_eviction():
     4. Disable scheduling and set 'Eviction Requested' to 'true' on node 1.
     5. Volume 1 should be failed to schedule new replica.
     6. Set 'Eviction Requested' to 'false' to cancel node 1 eviction and
-    check there should be 1 replica on node 1 and node 2. And remove the
-    unscheduled replica.
+    check there should be 1 replica on node 1 and node 2.
     7. Set 'Eviction Requested' to 'true' on node 1.
     8. Set 'Replica Node Level Soft Anti-Affinity' to 'true'.
     9. The eviction should be success, and no replica on node 1, 2 replicas


### PR DESCRIPTION
After [Longhorn #1679](https://github.com/longhorn/longhorn/issues/1679) cleanup replicas fix, the failed to scheduled
replica will be cleaned up automatically, no need for manually cleanup.

https://github.com/longhorn/longhorn/issues/298

Signed-off-by: Bo Tao <bo.tao@rancher.com>