### PR TITLE
test framework: add ability to customize deployment images

### DIFF
--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -9,7 +9,21 @@ node {
     withCredentials([string(credentialsId: 'longhorn-tests-do-token', variable: 'TF_VAR_do_token')]) {
         stage('build') {
             sh "test_framework/scripts/build.sh"
-            sh "docker run -itd --name ${JOB_BASE_NAME}${BUILD_NUMBER} --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} --env LONGHORN_INFRA_TEST=${LONGHORN_INFRA_TEST} --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} --env TF_VAR_do_token=${env.TF_VAR_do_token} --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} --env TF_VAR_hostname_prefix=${JOB_BASE_NAME} ${imageName}"
+
+            sh """ docker run -itd --name ${JOB_BASE_NAME}${BUILD_NUMBER} \
+                              --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} \
+                              --env LONGHORN_INFRA_TEST=${LONGHORN_INFRA_TEST} \
+                              --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} \
+                              --env TF_VAR_do_token=${env.TF_VAR_do_token} \
+                              --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} \
+                              --env LONGHORN_REPO_URL=${LONGHORN_REPO_URL} \
+                              --env LONGHORN_REPO_BRANCH=${LONGHORN_REPO_BRANCH} \
+                              --env CUSTOM_LONGHORN_MANAGER_IMAGE=${CUSTOM_LONGHORN_MANAGER_IMAGE} \
+                              --env CUSTOM_LONGHORN_ENGINE_IMAGE=${CUSTOM_LONGHORN_ENGINE_IMAGE} \
+                              --env CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE=${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE} \
+                              --env TF_VAR_hostname_prefix=${JOB_BASE_NAME} \
+                              ${imageName}
+            """
         }
 
         try {

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -4,11 +4,14 @@ set  -x
 
 RETRY_COUNTS=10
 
-LONGHORN_MANAGER_REPO_URI="https://github.com/longhorn/longhorn-manager.git"
-LONGHORN_MANAGER_BRANCH="master"
+LONGHORN_MANAGER_REPO_URI=${LONGHORN_MANAGER_REPO_URI:-"https://github.com/longhorn/longhorn-manager.git"}
+LONGHORN_MANAGER_BRANCH=${LONGHORN_MANAGER_BRANCH:-"master"}
 LONGHORN_MANAGER_TMPDIR="/tmp/longhorn-manager"
 LONGHORN_STABLE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml"
 
+CUSTOM_LONGHORN_MANAGER_IMAGE=${CUSTOM_LONGHORN_MANAGER_IMAGE:-"longhornio/longhorn-manager:master"}
+CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE=${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE:-"longhornio/longhorn-instance-manager:master"}
+CUSTOM_LONGHORN_ENGINE_IMAGE=${CUSTOM_LONGHORN_ENGINE_IMAGE:-"longhornio/longhorn-engine:master"}
 
 check_longhorn_status() {
   export KUBECONFIG="${TF_VAR_tf_workspace}/templates/kube_config_3-nodes-k8s.yml"
@@ -34,13 +37,13 @@ for FILE in `find "${LONGHORN_MANAGER_TMPDIR}/deploy/install" -type f -name "*\.
 done
 
 
-LONGHORN_MANAGER_IMAGE_TAG=`grep -io "longhornio\/longhorn-manager:.*$" longhorn.yaml | head -1 | awk -F ":" '{print $2}'`
-LONGHORN_ENGINE_IMAGE_TAG=`grep -io "longhornio\/longhorn-engine:.*$" longhorn.yaml | head -1 | awk -F ":" '{print $2}'`
+LONGHORN_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-manager:.*$" longhorn.yaml | head -1`
+LONGHORN_ENGINE_IMAGE=`grep -io "longhornio\/longhorn-engine:.*$" longhorn.yaml | head -1`
+LONGHORN_INSTANCE_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-instance-manager:.*$" longhorn.yaml | head -1`
 
-
-sed -i 's/longhornio\/longhorn-manager:'${LONGHORN_MANAGER_IMAGE_TAG}'/longhornio\/longhorn-manager:master/' longhorn.yaml
-sed -i 's/longhornio\/longhorn-engine:'${LONGHORN_ENGINE_IMAGE_TAG}'/longhornio\/longhorn-engine:master/' longhorn.yaml
-
+sed -i 's#'${LONGHORN_MANAGER_IMAGE}'#'${CUSTOM_LONGHORN_MANAGER_IMAGE}'#' longhorn.yaml
+sed -i 's#'${LONGHORN_ENGINE_IMAGE}'#'${CUSTOM_LONGHORN_ENGINE_IMAGE}'#' longhorn.yaml
+sed -i 's#'${LONGHORN_INSTANCE_MANAGER_IMAGE}'#'${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE}'#' longhorn.yaml
 
 export KUBECONFIG="${TF_VAR_tf_workspace}/templates/kube_config_3-nodes-k8s.yml"
 


### PR DESCRIPTION
This change introduce the ability to specify different images for Longhorn components for running integration tests.
This change is introduced to be able to verify changes that likely to cause regressions in integration tests.

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>