### PR TITLE
Increase timeout for big backup creation

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2120,9 +2120,10 @@ def get_volume_attached_nodes(v):
     return nodes
 
 
-def wait_for_backup_completion(client, volume_name, snapshot_name):
+def wait_for_backup_completion(client, volume_name, snapshot_name,
+                               retry_count=RETRY_BACKUP_COUNTS):
     completed = False
-    for i in range(RETRY_BACKUP_COUNTS):
+    for i in range(retry_count):
         v = client.by_id_volume(volume_name)
         for b in v.backupStatus:
             if b.snapshot == snapshot_name and b.state == "complete":

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -993,7 +993,8 @@ def test_inc_restoration_with_multiple_rebuild_and_expansion(
     snap2 = create_snapshot(client, std_volume_name)
     std_volume = client.by_id_volume(std_volume_name)
     std_volume.snapshotBackup(name=snap2.name)
-    wait_for_backup_completion(client, std_volume_name, snap2.name)
+    wait_for_backup_completion(client, std_volume_name, snap2.name,
+                               retry_count=1200)
     bv, b2 = find_backup(client, std_volume_name, snap2.name)
 
     # Trigger rebuild and the incremental restoration
@@ -1663,7 +1664,8 @@ def test_engine_crash_for_restore_volume(
     volume = client.by_id_volume(volume_name)
     snap = create_snapshot(client, volume_name)
     volume.snapshotBackup(name=snap.name)
-    wait_for_backup_completion(client, volume_name, snap.name)
+    wait_for_backup_completion(client, volume_name, snap.name,
+                               retry_count=1200)
     bv, b = find_backup(client, volume_name, snap.name)
 
     res_name = "res-" + volume_name


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/1721

The timeout for waiting for backup to be created successfully is increased to 10 mins from 5 mins as backup creation takes ~8 mins to complete if the data size is about 800 Mi.

