### PR TITLE
Cleanup backup related test code

### DIFF
--- a/manager/integration/tests/backupstore.py
+++ b/manager/integration/tests/backupstore.py
@@ -15,7 +15,6 @@ from common import LONGHORN_NAMESPACE
 from common import is_backupTarget_s3
 from common import is_backupTarget_nfs
 from common import get_longhorn_api_client
-from common import delete_backup
 from common import delete_backup_volume
 
 BACKUPSTORE_BV_PREFIX = "/backupstore/volumes/"
@@ -27,12 +26,8 @@ TEMP_FILE_PATH = "/tmp/temp_file"
 def backupstore_cleanup(client):
     backup_volumes = client.list_backup_volume()
 
+    # we delete the whole backup volume, which skips block gc
     for backup_volume in backup_volumes:
-        backups = backup_volume.backupList()
-
-        for backup in backups:
-            delete_backup(client, backup_volume.name, backup.name)
-
         delete_backup_volume(client, backup_volume.name)
 
     backup_volumes = client.list_backup_volume()

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -257,7 +257,12 @@ def create_backup(client, volname, data={}, labels={}):
         data = write_volume_data(volume, data)
     snap = create_snapshot(client, volname)
     create_snapshot(client, volname)
+
+    # after backup request we need to wait for completion of the backup
+    # since the backup.cfg will only be available once the backup operation
+    # has been completed
     volume.snapshotBackup(name=snap.name, labels=labels)
+    wait_for_backup_completion(client, volname, snap.name)
 
     verified = False
     for i in range(RETRY_COMMAND_COUNT):
@@ -281,7 +286,6 @@ def create_backup(client, volname, data={}, labels={}):
     for key, val in iter(labels.items()):
         assert new_b.labels.get(key) == val
 
-    volume = wait_for_backup_completion(client, volname, snap.name)
     volume = wait_for_volume_status(client, volname,
                                     "lastBackup",
                                     b.name)

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -728,22 +728,26 @@ def pod_make(request):
         def finalizer():
             api = get_core_api_client()
             try:
-                delete_and_wait_pod(api, pod_manifest['metadata']['name'])
+                pod_name = pod_manifest['metadata']['name']
+                delete_and_wait_pod(api, pod_name)
             except Exception as e:
-                print("Exception when waiting for pod deletion", e)
+                print("\nException when waiting for pod deletion")
+                print(e)
                 return
             try:
                 volume_details = pod_manifest['spec']['volumes'][0]
                 pvc_name = volume_details['persistentVolumeClaim']['claimName']
                 delete_and_wait_pvc(api, pvc_name)
             except Exception as e:
-                print("Exception when waiting for PVC deletion", e)
+                print("\nException when waiting for PVC deletion")
+                print(e)
             try:
                 pv = wait_and_get_pv_for_pvc(api, pvc_name)
                 pv_name = pv.metadata.name
                 delete_and_wait_pv(api, pv_name)
             except Exception as e:
-                print("Exception when waiting for PV deletion", e)
+                print("\nException when waiting for PV deletion")
+                print(e)
 
         request.addfinalizer(finalizer)
         return pod_manifest
@@ -1181,7 +1185,8 @@ def cleanup_client():
         try:
             client.delete(v)
         except Exception as e:
-            print("Exception when cleanup volume ", v, e)
+            print("\nException when cleanup volume ", v)
+            print(e)
             pass
     images = client.list_engine_image()
     for img in images:
@@ -1190,7 +1195,8 @@ def cleanup_client():
             try:
                 client.delete(img)
             except Exception as e:
-                print("Exception when cleanup image", img, e)
+                print("\nException when cleanup image", img)
+                print(e)
                 pass
 
     # enable nodes scheduling
@@ -2234,7 +2240,8 @@ def reset_node(client):
             wait_for_node_update(client, node.id,
                                  "allowScheduling", True)
         except Exception as e:
-            print("Exception when reset node schedulding and tags", node, e)
+            print("\nException when reset node schedulding and tags", node)
+            print(e)
 
 
 def cleanup_test_disks(client):
@@ -2258,7 +2265,8 @@ def cleanup_test_disks(client):
                     wait_for_disk_status(client, host_id, name,
                                          "allowScheduling", False)
     except Exception as e:
-        print("Exception when update node disks", node, e)
+        print("\nException when update node disks", node)
+        print(e)
         pass
 
     # delete test disks
@@ -2271,14 +2279,16 @@ def cleanup_test_disks(client):
         node.diskUpdate(disks=update_disks)
         wait_for_disk_update(client, host_id, len(update_disks))
     except Exception as e:
-        print("Exception when delete node test disks", node, e)
+        print("\nException when delete node test disks", node)
+        print(e)
         pass
     # cleanup host disks
     for del_dir in del_dirs:
         try:
             cleanup_host_disk(del_dir)
         except Exception as e:
-            print("Exception when cleanup host disk", del_dir, e)
+            print("\nException when cleanup host disk", del_dir)
+            print(e)
             pass
 
 
@@ -2332,9 +2342,10 @@ def reset_settings(client):
         client.update(minimal_setting,
                       value=DEFAULT_STORAGE_MINIMAL_AVAILABLE_PERCENTAGE)
     except Exception as e:
-        print("Exception when update "
+        print("\nException when update "
               "storage minimal available percentage settings",
-              minimal_setting, e)
+              minimal_setting)
+        print(e)
         pass
 
     over_provisioning_setting = client.by_id_setting(
@@ -2343,9 +2354,10 @@ def reset_settings(client):
         client.update(over_provisioning_setting,
                       value=DEFAULT_STORAGE_OVER_PROVISIONING_PERCENTAGE)
     except Exception as e:
-        print("Exception when update "
+        print("\nException when update "
               "storage over provisioning percentage settings",
-              over_provisioning_setting, e)
+              over_provisioning_setting)
+        print(e)
 
     default_data_path_setting = client.by_id_setting(
         SETTING_DEFAULT_DATA_PATH)
@@ -2353,9 +2365,10 @@ def reset_settings(client):
         client.update(default_data_path_setting,
                       value=DEFAULT_DISK_PATH)
     except Exception as e:
-        print("Exception when update "
+        print("\nException when update "
               "default data path setting",
-              default_data_path_setting, e)
+              default_data_path_setting)
+        print(e)
 
     create_default_disk_labeled_nodes_setting = client.by_id_setting(
         SETTING_CREATE_DEFAULT_DISK_LABELED_NODES)
@@ -2363,9 +2376,10 @@ def reset_settings(client):
         client.update(create_default_disk_labeled_nodes_setting,
                       value="false")
     except Exception as e:
-        print("Exception when update "
+        print("\nException when update "
               "create default disk labeled nodes setting",
-              create_default_disk_labeled_nodes_setting, e)
+              create_default_disk_labeled_nodes_setting)
+        print(e)
 
     replica_node_soft_anti_affinity_setting = \
         client.by_id_setting(SETTING_REPLICA_NODE_SOFT_ANTI_AFFINITY)
@@ -2373,9 +2387,10 @@ def reset_settings(client):
         client.update(replica_node_soft_anti_affinity_setting,
                       value="false")
     except Exception as e:
-        print("Exception when update "
+        print("\nException when update "
               "Replica Node Level Soft Anti-Affinity setting",
-              replica_node_soft_anti_affinity_setting, e)
+              replica_node_soft_anti_affinity_setting)
+        print(e)
 
     replica_zone_soft_anti_affinity_setting = \
         client.by_id_setting(SETTING_REPLICA_ZONE_SOFT_ANTI_AFFINITY)
@@ -2383,9 +2398,10 @@ def reset_settings(client):
         client.update(replica_zone_soft_anti_affinity_setting,
                       value="true")
     except Exception as e:
-        print("Exception when update "
+        print("\nException when update "
               "Replica Zone Level Soft Anti-Affinity setting",
-              replica_zone_soft_anti_affinity_setting, e)
+              replica_zone_soft_anti_affinity_setting)
+        print(e)
 
     disable_scheduling_on_cordoned_node_setting = \
         client.by_id_setting(SETTING_DISABLE_SCHEDULING_ON_CORDONED_NODE)
@@ -2393,15 +2409,17 @@ def reset_settings(client):
         client.update(disable_scheduling_on_cordoned_node_setting,
                       value="true")
     except Exception as e:
-        print("Exception when update "
+        print("\nException when update "
               "Disable Scheduling On Cordoned Node setting",
-              disable_scheduling_on_cordoned_node_setting, e)
+              disable_scheduling_on_cordoned_node_setting)
+        print(e)
     auto_salvage_setting = client.by_id_setting(SETTING_AUTO_SALVAGE)
     try:
         client.update(auto_salvage_setting, value="true")
     except Exception as e:
-        print("Exception when update Auto Salvage setting",
-              auto_salvage_setting, e)
+        print("\nException when update Auto Salvage setting",
+              auto_salvage_setting)
+        print(e)
 
     guaranteed_engine_cpu_setting = \
         client.by_id_setting(SETTING_GUARANTEED_ENGINE_CPU)
@@ -2409,9 +2427,10 @@ def reset_settings(client):
         client.update(guaranteed_engine_cpu_setting,
                       value="0.25")
     except Exception as e:
-        print("Exception when update "
+        print("\nException when update "
               "Guaranteed Engine CPU setting",
-              guaranteed_engine_cpu_setting, e)
+              guaranteed_engine_cpu_setting)
+        print(e)
 
     instance_managers = client.list_instance_manager()
     core_api = get_core_api_client()

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -338,14 +338,15 @@ def create_and_check_volume(client, volume_name, num_of_replicas=3, size=SIZE,
 def wait_pod(pod_name):
     api = get_core_api_client()
 
+    pod = None
     for i in range(DEFAULT_POD_TIMEOUT):
         pod = api.read_namespaced_pod(
             name=pod_name,
             namespace='default')
-        if pod.status.phase != 'Pending':
+        if pod is not None and pod.status.phase != 'Pending':
             break
         time.sleep(DEFAULT_POD_INTERVAL)
-    assert pod.status.phase == 'Running'
+    assert pod is not None and pod.status.phase == 'Running'
 
 
 def create_and_wait_pod(api, pod_manifest):

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -42,8 +42,8 @@ RETRY_COMMAND_COUNT = 3
 RETRY_COUNTS = 300
 RETRY_INTERVAL = 0.5
 RETRY_INTERVAL_LONG = 2
-RETRY_BACKUP_COUNTS = 600
-RETRY_BACKUP_INTERVAL = 0.5
+RETRY_BACKUP_COUNTS = 300
+RETRY_BACKUP_INTERVAL = 1
 RETRY_EXEC_COUNTS = 30
 RETRY_EXEC_INTERVAL = 5
 
@@ -2138,9 +2138,10 @@ def wait_for_backup_completion(client, volume_name, snapshot_name,
     return v
 
 
-def wait_for_backup_state(client, volume_name, predicate):
+def wait_for_backup_state(client, volume_name, predicate,
+                          retry_count=RETRY_BACKUP_COUNTS):
     completed = False
-    for i in range(RETRY_BACKUP_COUNTS):
+    for i in range(retry_count):
         v = client.by_id_volume(volume_name)
         for b in v.backupStatus:
             if predicate(b):

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2300,7 +2300,7 @@ def reset_disks_for_all_nodes(client):  # NOQA
         # on the node.
         if len(node.disks) > 1:
             update_disks = get_update_disks(node.disks)
-            for disk_name, disk in update_disks:
+            for disk_name, disk in iter(update_disks.items()):
                 disk.allowScheduling = False
                 update_disks[disk_name] = disk
                 node = node.diskUpdate(disks=update_disks)

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -1466,35 +1466,11 @@ def test_listing_backup_volume(client, base_image=""):   # NOQA
     subprocess.check_output(cmd)
     subprocess.check_output(["sync"])
 
-    found = False
-    for i in range(RETRY_COMMAND_COUNT):
-        try:
-            bv1, b1 = common.find_backup(client, volume1_name, snap1.name)
-            found = True
-            break
-        except Exception:
-            time.sleep(1)
-    assert found
-    bv1.backupDelete(name=b1.name)
-    for i in range(RETRY_COMMAND_COUNT):
-        found = False
-        backups1 = bv1.backupList().data
-        for b in backups1:
-            if b.snapshotName == snap1.name:
-                found = True
-                break
-    assert not found
+    bv1, b1 = common.find_backup(client, volume1_name, snap1.name)
+    common.delete_backup(client, volume1_name, b1.name)
 
     bv2, b2 = common.find_backup(client, volume2_name, snap2.name)
-    bv2.backupDelete(name=b2.name)
-    for i in range(RETRY_COMMAND_COUNT):
-        found = False
-        backups2 = bv2.backupList().data
-        for b in backups2:
-            if b.snapshotName == snap2.name:
-                found = True
-                break
-    assert not found
+    common.delete_backup(client, volume2_name, b2.name)
 
     # corrupt backup for snap4
     bv4, b4 = common.find_backup(client, volume3_name, snap4.name)
@@ -1530,20 +1506,11 @@ def test_listing_backup_volume(client, base_image=""):   # NOQA
     subprocess.check_output(["sync"])
 
     bv3, b3 = common.find_backup(client, volume3_name, snap3.name)
-    bv3.backupDelete(name=b3.name)
+    common.delete_backup(client, volume3_name, b3.name)
     bv4, b4 = common.find_backup(client, volume3_name, snap4.name)
-    bv4.backupDelete(name=b4.name)
+    common.delete_backup(client, volume3_name, b4.name)
     bv5, b5 = common.find_backup(client, volume3_name, snap5.name)
-    bv5.backupDelete(name=b5.name)
-    snaps = [snap3.name, snap4.name, snap5.name]
-    for i in range(RETRY_COMMAND_COUNT):
-        found = False
-        backups3 = bv3.backupList().data
-        for b in backups3:
-            if b.snapshotName in snaps:
-                found = True
-                break
-    assert not found
+    common.delete_backup(client, volume3_name, b5.name)
 
     volume1.detach()
     volume1 = common.wait_for_volume_detached(client, volume1_name)

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -1824,10 +1824,8 @@ def test_storage_class_from_backup(volume_name, pvc_name, storage_class, client,
     snapshot = volume_id.snapshotCreate()
 
     volume_id.snapshotBackup(name=snapshot.name)
-
-    bv, b = find_backup(client, volume_name, snapshot.name)
-
     wait_for_backup_completion(client, volume_name, snapshot.name)
+    bv, b = find_backup(client, volume_name, snapshot.name)
 
     backup_url = b.url
 

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -1262,6 +1262,9 @@ def restore_inc_test(client, core_api, volume_name, pod):  # NOQA
     data2 = {'len': 1 * 1024 * 1024, 'pos': 0}
     data2['content'] = common.generate_random_data(data2['len'])
     _, backup2, _, data2 = create_backup(client, volume_name, data2)
+
+    # HACK: #558 we use a side effect of the list call
+    # to update the volumes last backup field
     client.list_backupVolume()
     check_volume_last_backup(client, sb_volume2_name, backup2.name)
     activate_standby_volume(client, sb_volume2_name)

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -994,7 +994,7 @@ def test_inc_restoration_with_multiple_rebuild_and_expansion(
     std_volume = client.by_id_volume(std_volume_name)
     std_volume.snapshotBackup(name=snap2.name)
     wait_for_backup_completion(client, std_volume_name, snap2.name,
-                               retry_count=1200)
+                               retry_count=600)
     bv, b2 = find_backup(client, std_volume_name, snap2.name)
 
     # Trigger rebuild and the incremental restoration
@@ -1665,7 +1665,7 @@ def test_engine_crash_for_restore_volume(
     snap = create_snapshot(client, volume_name)
     volume.snapshotBackup(name=snap.name)
     wait_for_backup_completion(client, volume_name, snap.name,
-                               retry_count=1200)
+                               retry_count=600)
     bv, b = find_backup(client, volume_name, snap.name)
 
     res_name = "res-" + volume_name

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -290,7 +290,7 @@ def ha_backup_deletion_recovery_test(client, volume_name, size, base_image=""): 
         create_snapshot(client, volume_name)
 
         volume.snapshotBackup(name=snap2.name)
-
+        wait_for_backup_completion(client, volume_name, snap2.name)
         _, b = common.find_backup(client, volume_name, snap2.name)
 
         res_name = common.generate_volume_name()

--- a/manager/integration/tests/test_kubernetes.py
+++ b/manager/integration/tests/test_kubernetes.py
@@ -6,8 +6,8 @@ from common import csi_pv, pvc, pod  # NOQA
 from common import generate_volume_name, get_apps_api_client
 from common import create_and_wait_statefulset
 from common import update_statefulset_manifests
-from common import create_storage_class, delete_storage_class, \
-    find_backup
+from common import create_storage_class, delete_storage_class
+from common import wait_for_backup_completion, find_backup
 from common import get_self_host_id, get_statefulset_pod_info
 from common import create_and_wait_pod
 from common import delete_and_wait_pod, wait_delete_pod
@@ -597,6 +597,7 @@ def test_backup_kubernetes_status(client, core_api, pod):  # NOQA
     # is not guaranteed to mount our Volume to the test host.
     snap = create_snapshot(client, volume_name)
     volume.snapshotBackup(name=snap.name)
+    wait_for_backup_completion(client, volume_name, snap.name)
     bv, b = find_backup(client, volume_name, snap.name)
     new_b = bv.backupGet(name=b.name)
     status = loads(new_b.labels.get(KUBERNETES_STATUS_LABEL))
@@ -664,6 +665,7 @@ def test_backup_kubernetes_status(client, core_api, pod):  # NOQA
 
     snap = create_snapshot(client, volume_name)
     volume.snapshotBackup(name=snap.name)
+    volume = wait_for_backup_completion(client, volume_name, snap.name)
     bv, b = find_backup(client, volume_name, snap.name)
     new_b = bv.backupGet(name=b.name)
     status = loads(new_b.labels.get(KUBERNETES_STATUS_LABEL))


### PR DESCRIPTION
There where issues in the test code
- we where not waiting for the backup deletion during the backup_list test
- we where trying to find the backup before waiting for the backup completion in the create_backup function
- there is a couple of spots where we call find_backup but where not waiting for backup completion, since the backup.cfg only shows up once the backup is completed this would not work correctly all the time and introduce timing dependent flaky test behavior.

Since backup operations needs to be thought of as async, we always need to wait for completion of the backup operation. We do this in the utility functions delete_backup, create_backup, etc.

This is only tangentially related to the backup locks longhorn/longhorn#612