### PR TITLE
Fix recurring job integration tests

### DIFF
--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -299,7 +299,14 @@ def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
         write_pod_volume_data(core_api, pod['pod_name'], pod['data'])
         volume.recurringUpdate(jobs=[job_backup])
 
-    time.sleep(300)
+    time.sleep(150)
+
+    for pod in pod_data:
+        volume = client.by_id_volume(pod['pv_name'])
+        write_pod_volume_data(core_api, pod['pod_name'], pod['data'])
+        volume.recurringUpdate(jobs=[job_backup])
+
+    time.sleep(150)
 
     for pod in pod_data:
         volume = client.by_id_volume(pod['pv_name'])


### PR DESCRIPTION
We changed the recurring jobs' logic: recurring jobs only take backup/snapshot when the volume has new data since the last backup/snapshot. Therefore, we need to update recurring job integration tests.

Now we can control precisely when recurring snapshot/backup will happen . As the result, this PR fixes longhorn/longhorn#1354 as a side affect

Related issues:
longhorn/longhorn#1858
longhorn/longhorn#1354