### PR TITLE
Fix engine-image cleanup

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1202,16 +1202,6 @@ def cleanup_client():
             print("\nException when cleanup volume ", v)
             print(e)
             pass
-    images = client.list_engine_image()
-    for img in images:
-        if not img.default:
-            # ignore the error when clean up
-            try:
-                client.delete(img)
-            except Exception as e:
-                print("\nException when cleanup image", img)
-                print(e)
-                pass
 
     # enable nodes scheduling
     reset_node(client)
@@ -2516,6 +2506,7 @@ def reset_engine_image(client):
                 if ei.state != 'ready':
                     ready = False
             else:
+                wait_for_engine_image_ref_count(client, ei.name, 0)
                 client.delete(ei)
                 wait_for_engine_image_deletion(client, core_api, ei.name)
         if ready:

--- a/manager/integration/tests/test_engine_upgrade.py
+++ b/manager/integration/tests/test_engine_upgrade.py
@@ -697,8 +697,4 @@ def test_engine_live_upgrade_with_intensive_data_writing(client, core_api, volum
     delete_and_wait_pvc(core_api, pvc_name)
     delete_and_wait_pv(core_api, pv_name)
 
-    client.delete(volume)
-    wait_for_volume_delete(client, volume_name)
-
-    client.delete(new_img)
-    wait_for_engine_image_deletion(client, core_api, new_img.name)
+    common.cleanup_volume(client, volume)


### PR DESCRIPTION
* Add check for engine image ref count since replicas might take time to delete.
* remove duplicated engine-image removal that is already handled in reset_engine_image.
* remove redundant cleanup for test_engine_live_upgrade_with_intensive_data_writing.
