### PR TITLE
Fix test_salvage_auto_crash_all_replicas test case

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -488,7 +488,6 @@ def wait_pod_for_auto_salvage(
 
     wait_for_volume_healthy(client, volume_name)
 
-    common.wait_for_pod_phase(core_api, pod_name, pod_phase="Pending")
     common.wait_for_pod_phase(core_api, pod_name, pod_phase="Running")
 
     wait_for_pod_remount(core_api, pod_name)


### PR DESCRIPTION
It is hard to capture the pending state of the workload pod. Moreover, we only need to make sure that the pod is in `running` state and `wait_for_pod_remount()` returns true. That is enough to conclude that the pod was restarted and the volume was remount. Therefore, we removed the `wait_for_pod_phase(core_api, pod_name, pod_phase="Pending")`

After this PR is merged, this test case sometimes still fails because of the issue https://github.com/longhorn/longhorn/issues/1942

longhorn/longhorn#1914