### PR TITLE
Try except the pod restart intermediate phase

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -488,6 +488,11 @@ def wait_pod_for_auto_salvage(
 
     wait_for_volume_healthy(client, volume_name)
 
+    try:
+        common.wait_for_pod_phase(core_api, pod_name, pod_phase="Pending")
+    except AssertionError:
+        print("\nException waiting for pod pending,"
+              "could have missed it")
     common.wait_for_pod_phase(core_api, pod_name, pod_phase="Running")
 
     wait_for_pod_remount(core_api, pod_name)


### PR DESCRIPTION
Without checking for the intermediate phase could potentially miss the pod restart, try-except to allow enough time for K8s to handle the pod deletion.

https://github.com/longhorn/longhorn-tests/pull/464