### PR TITLE
Remove the special toleration that tolerates everything from the test case test_setting_toleration_extra

### DIFF
--- a/manager/integration/tests/test_settings.py
+++ b/manager/integration/tests/test_settings.py
@@ -220,17 +220,23 @@ def test_setting_toleration_extra(core_api, apps_api):  # NOQA
                 },
             ],
         },
-        {
-            "value": ":",
-            "expect": [
-                {
-                    "key": None,
-                    "value": None,
-                    "operator": "Exists",
-                    "effect": None,
-                },
-            ]
-        },
+        # Skip the this special toleration for now because it makes
+        # Longhorn deploy manager pods on control/etcd nodes
+        # and the control/etcd nodes become "down" after the test
+        # clear this toleration.
+        # We will enable this test once we implement logic for
+        # deleting failed nodes.
+        # {
+        #     "value": ":",
+        #     "expect": [
+        #         {
+        #             "key": None,
+        #             "value": None,
+        #             "operator": "Exists",
+        #             "effect": None,
+        #         },
+        #     ]
+        # },
         {
             "value": "",
             "expect": [],


### PR DESCRIPTION
The special toleration `:` makes Longhorn deploy manager pods on control/etcd nodes and when the test clears the toleration the control/etcd nodes become "down" in the Longhorn system. The result is that Longhorn has 4 nodes with 1 failed node. This breaks other test cases.

We will re-enable this special toleration once we implement the logic for deleting failed nodes

longhorn/longhorn#2024