### PR TITLE
Fix: test_auto_remount_with_subpath test case

### DIFF
--- a/manager/integration/tests/test_kubernetes.py
+++ b/manager/integration/tests/test_kubernetes.py
@@ -64,7 +64,7 @@ def delete_and_wait_statefulset_only(api, ss):
     assert not found
 
     for p in pod_data:
-        wait_delete_pod(api, p['pod_name'])
+        wait_delete_pod(api, p['pod_uid'])
 
 
 def provision_and_wait_pv(client, core_api, storage_class, pvc): # NOQA


### PR DESCRIPTION
The `test_auto_remount_with_subpath` sometime fails. Make some modifications:

1. I think we don't need data locality in this test since it doesn't make any impact. 
1. Fixed some timing issues.

longhorn/longhorn#1719