### PR TITLE
test framework: install nfs-common package

### DIFF
--- a/test_framework/terraform/aws/user-data-scripts/provision_amd64.sh
+++ b/test_framework/terraform/aws/user-data-scripts/provision_amd64.sh
@@ -3,7 +3,7 @@
 DOCKER_VERSION=19.03
 
 sudo apt-get update 
-sudo apt-get install -y build-essential git 
+sudo apt-get install -y build-essential git nfs-common
 
 until (curl https://releases.rancher.com/install-docker/${DOCKER_VERSION}.sh | sudo sh); do
   echo 'docker did not install correctly'                                          

--- a/test_framework/terraform/aws/user-data-scripts/provision_arm64_agent.sh.tpl
+++ b/test_framework/terraform/aws/user-data-scripts/provision_arm64_agent.sh.tpl
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+apt-get update
+apt-get install -y nfs-common
+
 until (curl -sfL https://get.k3s.io | K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do
   echo 'k3s agent did not install correctly'
   sleep 2

--- a/test_framework/terraform/aws/user-data-scripts/provision_arm64_server.sh.tpl
+++ b/test_framework/terraform/aws/user-data-scripts/provision_arm64_server.sh.tpl
@@ -1,5 +1,9 @@
 #!/bin/bash 
 
+
+apt-get update
+apt-get install -y nfs-common
+
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable-agent --tls-san ${k3s_server_public_ip}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do
   echo 'k3s server did not install correctly'
   sleep 2


### PR DESCRIPTION
RWX tests requires nfs-common package to be installed on the instance

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>