### PR TITLE
Fix failing Nightly tests

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -606,7 +606,7 @@ def backup_status_for_unavailable_replicas_test(client, volume_name,  # NOQA
     cleanup_volume(client, volume)
 
 
-def test_backup_block_deletion(client, core_api, volume_name, set_random_backupstore):  # NOQA
+def test_backup_block_deletion(set_random_backupstore, client, core_api, volume_name):  # NOQA
     """
     Test backup block deletion
 
@@ -703,7 +703,7 @@ def test_backup_block_deletion(client, core_api, volume_name, set_random_backups
     delete_backup_volume(client, volume_name)
 
 
-def test_backup_volume_list(client, core_api, set_random_backupstore):  # NOQA
+def test_backup_volume_list(set_random_backupstore ,client, core_api):  # NOQA
     """
     Test backup volume list
     Context:
@@ -785,7 +785,7 @@ def test_backup_volume_list(client, core_api, set_random_backupstore):  # NOQA
     backupstore_cleanup(client)
 
 
-def test_backup_metadata_deletion(client, core_api, volume_name, set_random_backupstore):  # NOQA
+def test_backup_metadata_deletion(set_random_backupstore, client, core_api, volume_name):  # NOQA
     """
     Test backup metadata deletion
 
@@ -1985,7 +1985,7 @@ def test_expansion_basic(client, volume_name):  # NOQA
 
 
 @pytest.mark.coretest   # NOQA
-def test_restore_inc_with_expansion(client, core_api, volume_name, pod, set_random_backupstore):  # NOQA
+def test_restore_inc_with_expansion(set_random_backupstore, client, core_api, volume_name, pod):  # NOQA
     """
     Test restore from disaster recovery volume with volume expansion
 
@@ -2617,7 +2617,7 @@ def test_expansion_with_scheduling_failure(
     delete_and_wait_pv(core_api, test_pv_name)
 
 
-def test_dr_volume_with_last_backup_deletion(client, core_api, csi_pv, pvc, volume_name, pod_make, set_random_backupstore):  # NOQA
+def test_dr_volume_with_last_backup_deletion(set_random_backupstore, client, core_api, csi_pv, pvc, volume_name, pod_make):  # NOQA
     """
     Test if the DR volume can be activated
     after deleting the lastest backup. There are two cases to the last
@@ -2752,7 +2752,7 @@ def test_dr_volume_with_last_backup_deletion(client, core_api, csi_pv, pvc, volu
     client.delete(bv)
 
 
-def test_backup_lock_deletion_during_restoration(client, core_api, volume_name, csi_pv, pvc, pod_make, set_random_backupstore):  # NOQA
+def test_backup_lock_deletion_during_restoration(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     Test backup locks
     Context:
@@ -2816,7 +2816,7 @@ def test_backup_lock_deletion_during_restoration(client, core_api, volume_name, 
     assert b is not None
 
 
-def test_backup_lock_deletion_during_backup(client, core_api, volume_name, csi_pv, pvc, pod_make, set_random_backupstore):  # NOQA
+def test_backup_lock_deletion_during_backup(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     Test backup locks
     Context:
@@ -2915,7 +2915,7 @@ def test_backup_lock_deletion_during_backup(client, core_api, volume_name, csi_p
     assert std_md5sum2 == md5sum2
 
 
-def test_backup_lock_creation_during_deletion(client, core_api, volume_name, csi_pv, pvc, pod_make, set_random_backupstore):  # NOQA
+def test_backup_lock_creation_during_deletion(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     Test backup locks
     Context:
@@ -2972,7 +2972,7 @@ def test_backup_lock_creation_during_deletion(client, core_api, volume_name, csi
 
 
 @pytest.mark.skip(reason="This test takes more than 20 mins to run")  # NOQA
-def test_backup_lock_restoration_during_deletion(client, core_api, volume_name, csi_pv, pvc, pod_make, set_random_backupstore):  # NOQA
+def test_backup_lock_restoration_during_deletion(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     Test backup locks
     Context:

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -678,9 +678,7 @@ def test_rebuild_replica_and_from_replica_on_the_same_node(
     assert original_md5sum == md5sum
 
 
-def test_rebuild_with_restoration(
-        client, core_api, volume_name, csi_pv, pvc, pod_make, # NOQA
-        set_random_backupstore):  # NOQA
+def test_rebuild_with_restoration(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make): # NOQA
     """
     [HA] Test if the rebuild is disabled for the restoring volume
     1. Setup a random backupstore.
@@ -765,9 +763,7 @@ def test_rebuild_with_restoration(
     backupstore_cleanup(client)
 
 
-def test_rebuild_with_inc_restoration(
-        client, core_api, volume_name, csi_pv, pvc, pod_make, # NOQA
-        set_random_backupstore):  # NOQA
+def test_rebuild_with_inc_restoration(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     [HA] Test if the rebuild is disabled for the DR volume
     1. Setup a random backupstore.
@@ -869,9 +865,7 @@ def test_rebuild_with_inc_restoration(
     backupstore_cleanup(client)
 
 
-def test_inc_restoration_with_multiple_rebuild_and_expansion(
-        set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make, # NOQA
-        ):  # NOQA
+def test_inc_restoration_with_multiple_rebuild_and_expansion(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make): # NOQA
     """
     [HA] Test if the rebuild is disabled for the DR volume
     1. Setup a random backupstore.
@@ -1308,9 +1302,7 @@ def test_restore_volume_with_invalid_backupstore(client, volume_name, backupstor
     wait_for_volume_delete(client, res_name)
 
 
-def test_all_replica_restore_failure(
-        client, core_api, volume_name, csi_pv, pvc, pod_make, # NOQA
-        set_random_backupstore):  # NOQA
+def test_all_replica_restore_failure(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     [HA] Test if all replica restore failure will lead to the restore volume
     becoming Faulted, and if the auto salvage feature is disabled for
@@ -1391,9 +1383,7 @@ def test_all_replica_restore_failure(
     wait_for_volume_delete(client, res_name)
 
 
-def test_single_replica_restore_failure(
-        client, core_api, volume_name, csi_pv, pvc, pod_make, # NOQA
-        set_random_backupstore):  # NOQA
+def test_single_replica_restore_failure(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     [HA] Test if one replica restore failure will lead to the restore volume
     becoming Degraded, and if the restore volume is still usable after
@@ -1514,9 +1504,7 @@ def test_single_replica_restore_failure(
     backupstore_cleanup(client)
 
 
-def test_dr_volume_with_restore_command_error(
-        client, core_api, volume_name, csi_pv, pvc, pod_make, # NOQA
-        set_random_backupstore):  # NOQA
+def test_dr_volume_with_restore_command_error(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     Test if Longhorn can capture and handle the restore command error
     rather than the error triggered the data restoring.
@@ -1630,9 +1618,7 @@ def test_dr_volume_with_restore_command_error(
     backupstore_cleanup(client)
 
 
-def test_engine_crash_for_restore_volume(
-        client, core_api, volume_name, csi_pv, pvc, pod_make, # NOQA
-        set_random_backupstore):  # NOQA
+def test_engine_crash_for_restore_volume(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     [HA] Test volume can successfully retry restoring after
     the engine crashes unexpectedly.
@@ -1728,9 +1714,7 @@ def test_engine_crash_for_restore_volume(
     backupstore_cleanup(client)
 
 
-def test_engine_crash_for_dr_volume(
-        client, core_api, volume_name, csi_pv, pvc, pod_make, # NOQA
-        set_random_backupstore):  # NOQA
+def test_engine_crash_for_dr_volume(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     [HA] Test DR volume can be recovered after
     the engine crashes unexpectedly.

--- a/manager/integration/tests/test_kubernetes.py
+++ b/manager/integration/tests/test_kubernetes.py
@@ -515,7 +515,7 @@ def test_pvc_creation_with_default_sc_set(
 
 
 @pytest.mark.csi
-def test_backup_kubernetes_status(client, core_api, pod, set_random_backupstore):  # NOQA
+def test_backup_kubernetes_status(set_random_backupstore, client, core_api, pod):  # NOQA
     """
     Test that Backups have KubernetesStatus stored properly when there is an
     associated PersistentVolumeClaim and Pod.

--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -2082,7 +2082,7 @@ def test_node_config_annotation_missing(client, core_api,  # NOQA
 
 
 @pytest.mark.node  # NOQA
-def test_replica_scheduler_rebuild_restore_is_too_big(client, set_random_backupstore):  # NOQA
+def test_replica_scheduler_rebuild_restore_is_too_big(set_random_backupstore, client):  # NOQA
     """
     Test replica scheduler: rebuild/restore can be too big to fit a disk
 

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -56,7 +56,7 @@ def wait_until_begin_of_an_even_minute():
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job(client, volume_name, set_random_backupstore):  # NOQA
+def test_recurring_job(set_random_backupstore, client, volume_name):  # NOQA
     """
     Test recurring job
 
@@ -164,7 +164,7 @@ def test_recurring_job(client, volume_name, set_random_backupstore):  # NOQA
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_in_volume_creation(client, volume_name, set_random_backupstore):  # NOQA
+def test_recurring_job_in_volume_creation(set_random_backupstore, client, volume_name):  # NOQA
     """
     Test create volume with recurring jobs
 
@@ -211,7 +211,7 @@ def test_recurring_job_in_volume_creation(client, volume_name, set_random_backup
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_in_storageclass(client, core_api, storage_class, statefulset, set_random_backupstore):  # NOQA
+def test_recurring_job_in_storageclass(set_random_backupstore, client, core_api, storage_class, statefulset):  # NOQA
     """
     Test create volume with StorageClass contains recurring jobs
 
@@ -254,7 +254,7 @@ def test_recurring_job_in_storageclass(client, core_api, storage_class, stateful
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_labels(client, random_labels, volume_name, set_random_backupstore):  # NOQA
+def test_recurring_job_labels(set_random_backupstore, client, random_labels, volume_name):  # NOQA
     """
     Test a RecurringJob with labels
 
@@ -265,10 +265,10 @@ def test_recurring_job_labels(client, random_labels, volume_name, set_random_bac
     5. Verify the recurring jobs run correctly.
     6. Verify the labels on the backup are correct.
     """
-    recurring_job_labels_test(client, random_labels, volume_name, set_random_backupstore)  # NOQA
+    recurring_job_labels_test(client, random_labels, volume_name)  # NOQA
 
 
-def recurring_job_labels_test(client, labels, volume_name, set_random_backupstore, size=SIZE, base_image=""):  # NOQA
+def recurring_job_labels_test(client, labels, volume_name, size=SIZE, base_image=""):  # NOQA
     host_id = get_self_host_id()
     client.create_volume(name=volume_name, size=size,
                          numberOfReplicas=2)
@@ -329,7 +329,7 @@ def recurring_job_labels_test(client, labels, volume_name, set_random_backupstor
 
 @pytest.mark.csi  # NOQA
 @pytest.mark.recurring_job
-def test_recurring_job_kubernetes_status(client, core_api, volume_name, set_random_backupstore):  # NOQA
+def test_recurring_job_kubernetes_status(set_random_backupstore, client, core_api, volume_name):  # NOQA
     """
     Test RecurringJob properly backs up the KubernetesStatus
 
@@ -444,7 +444,7 @@ def test_recurring_jobs_maximum_retain(client, core_api, volume_name): # NOQA
     assert volume.recurringJobs[1]['retain'] == 20
 
 
-def test_recurring_jobs_for_detached_volume(client, core_api, apps_api, volume_name, make_deployment_with_pvc, set_random_backupstore):  # NOQA
+def test_recurring_jobs_for_detached_volume(set_random_backupstore, client, core_api, apps_api, volume_name, make_deployment_with_pvc):  # NOQA
     """
     Test recurring jobs for detached volume
 

--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -15,6 +15,8 @@ from common import create_and_wait_statefulset, wait_statefulset
 from common import update_statefulset_manifests, create_storage_class
 from common import create_snapshot
 
+from backupstore import set_random_backupstore # NOQA
+
 from kubernetes import client as k8sclient
 
 Gi = (1 * 1024 * 1024 * 1024)
@@ -238,7 +240,7 @@ def test_statefulset_pod_deletion(core_api, storage_class, statefulset):  # NOQA
     assert resp == test_data
 
 
-def test_statefulset_backup(client, core_api, storage_class, statefulset):  # NOQA
+def test_statefulset_backup(set_random_backupstore, client, core_api, storage_class, statefulset):  # NOQA
     """
     Test that backups on StatefulSet volumes work properly.
 
@@ -320,8 +322,7 @@ def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
         assert count == 3
 
 
-def test_statefulset_restore(client, core_api, storage_class,  # NOQA
-                             statefulset):  # NOQA
+def test_statefulset_restore(set_random_backupstore, client, core_api, storage_class, statefulset):  # NOQA
     """
     Test that data can be restored into volumes usable by a StatefulSet.
 


### PR DESCRIPTION
- `pytest` fixtures are called in the order provided, and teardown is happens in reverse of that specific order, 
Calling set_random_backpustore first, will ensure backupstore_cleanup happens after every volume gets deleted at test teardown.

- some `statefulset` tests was lacking `set_random_backupstore` fixture.