### PR TITLE
Fix timing issue of the recurring job

### DIFF
--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -107,14 +107,14 @@ def test_recurring_job(set_random_backupstore, client, volume_name):  # NOQA
 
     # wait until the beginning of an even minute
     wait_until_begin_of_an_even_minute()
-    # wait until the 10th second of an even minute
+    # wait until the 20th second of an even minute
     # make sure that snapshot job happens before the backup job
-    time.sleep(10)
+    time.sleep(20)
 
     write_volume_random_data(volume)
-    time.sleep(150)  # 2.5 minutes
+    time.sleep(120)  # 2 minutes
     write_volume_random_data(volume)
-    time.sleep(150)  # 2.5 minutes
+    time.sleep(120)  # 2 minutes
 
     check_jobs1_result(volume)
 
@@ -123,9 +123,9 @@ def test_recurring_job(set_random_backupstore, client, volume_name):  # NOQA
     volume.recurringUpdate(jobs=[jobs[0], job_backup2])
 
     write_volume_random_data(volume)
-    time.sleep(150)  # 2.5 minutes
+    time.sleep(120)  # 2 minutes
     write_volume_random_data(volume)
-    time.sleep(150)  # 2.5 minutes
+    time.sleep(120)  # 2 minutes
 
     snapshots = volume.snapshotList()
     count = 0


### PR DESCRIPTION
Adjusted some sleep time in the test 'test_recurring_job` according to the time of recurring jobs getting triggered.
https://github.com/longhorn/longhorn/issues/2158

Signed-off-by: khushboo-rancher <khushboo@rancher.com>