### PR TITLE
Fix test_restore_inc_*

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1513,7 +1513,7 @@ def wait_for_volume_delete(client, name):
 
 
 def wait_for_backup_volume_delete(client, name):
-    for i in range(RETRY_COUNTS):
+    for _ in range(RETRY_COUNTS):
         bvs = client.list_backupVolume()
         found = False
         for bv in bvs:


### PR DESCRIPTION
* Replace inconsistent setting of backupstore with set_random_backupstore to ensure both s3 and nfs are tested.
* Remove resource cleanup as already handled by cleanup_client and set_random_backupstore.

https://github.com/longhorn/longhorn/issues/2305