### PR TITLE
Fix test_restore_volume_with_invalid_backupstore

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -1237,27 +1237,17 @@ def test_single_replica_failed_during_engine_start(client, core_api, volume_name
 
 def test_restore_volume_with_invalid_backupstore(client, volume_name, backupstore_s3): # NOQA
     """
-    [HA] Test if the invalid backup target will lead to the restore volume
-    becoming Faulted, and if the auto salvage feature is disabled for
-    the faulted restore volume.
+    [HA] Test if the invalid backup target will lead to to volume restore.
 
     1. Enable auto-salvage.
     2. Set a S3 backupstore. (Cannot use NFS server here before fixing #1295)
     3. Create a volume then a backup.
     4. Invalidate the target URL.
        (e.g.: s3://backupbucket-invalid@us-east-1/backupstore-invalid)
-    5. Restore a volume from the backup.
+    5. Restore a volume from the backup should return error.
        (The fromBackup fields of the volume create API should consist of
        the invalid target URL and the valid backup volume info)
-    6. Wait for the restore volume Faulted.
-    7. Check if the volume condition "restore":
-       `volume.conditions[restore].status == False &&
-       volume.conditions[restore].reason == "RestoreFailure".`
-    8. Check if `volume.ready` is false.
-    9. Make sure auto-salvage is not triggered even the feature is enabled.
-    10. Verify if PV/PVC cannot be created from Longhorn.
-    11. Verify the faulted volume cannot be attached to a node.
-    12. Verify this faulted volume can be deleted.
+    6. Check restore volume not created.
     """
     auto_salvage_setting = client.by_id_setting(SETTING_AUTO_SALVAGE)
     assert auto_salvage_setting.name == SETTING_AUTO_SALVAGE
@@ -1267,7 +1257,8 @@ def test_restore_volume_with_invalid_backupstore(client, volume_name, backupstor
     host_id = get_self_host_id()
     volume.attach(hostId=host_id)
     volume = wait_for_volume_healthy(client, volume_name)
-    bv, b, _, _ = create_backup(client, volume_name)
+
+    _, b, _, _ = create_backup(client, volume_name)
 
     res_name = "res-" + volume_name
     invalid_backup_target_url = \
@@ -1277,28 +1268,14 @@ def test_restore_volume_with_invalid_backupstore(client, volume_name, backupstor
     backup_target_setting = client.update(backup_target_setting,
                                           value=invalid_backup_target_url)
 
-    res_volume = client.create_volume(name=res_name,
-                                      fromBackup=b.url)
+    with pytest.raises(Exception) as e:
+        client.create_volume(name=res_name,
+                             fromBackup=b.url)
+    assert "unable to create volume" in str(e.value)
 
-    wait_for_volume_faulted(client, res_name)
-
-    res_volume = client.by_id_volume(res_name)
-
-    assert res_volume.conditions['restore'].status == "False"
-    assert res_volume.conditions['restore'].reason == "RestoreFailure"
-    assert res_volume.ready is False
-
-    for i in range(10):
-        res_volume = client.by_id_volume(res_name)
-        assert res_volume.state == "detached"
-        time.sleep(0.5)
-
-    assert hasattr(res_volume, 'pvCreate') is False
-    assert hasattr(res_volume, 'pvcCreate') is False
-    assert hasattr(res_volume, 'attach') is False
-
-    client.delete(res_volume)
-    wait_for_volume_delete(client, res_name)
+    volumes = client.list_volume()
+    for v in volumes:
+        assert v.name != res_name
 
 
 def test_all_replica_restore_failure(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA


### PR DESCRIPTION
Volume does not get created with an invalid backupstore URL.
Update test to address to change from https://github.com/longhorn/longhorn/issues/2006.

https://github.com/longhorn/longhorn/issues/2343