### PR TITLE
Fix test_recurring_jobs_when_volume_detached_unexpectedly

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -2828,7 +2828,7 @@ def test_backup_lock_deletion_during_backup(set_random_backupstore, client, core
     std_md5sum2 = get_pod_data_md5sum(core_api, std_pod_name, "/data/test2")
     snap2 = create_snapshot(client, std_volume_name)
     std_volume.snapshotBackup(name=snap2.name)
-    wait_for_backup_to_start(client, std_volume_name, snap2.name)
+    wait_for_backup_to_start(client, std_volume_name, snapshot_name=snap2.name)
 
     backup_volume.backupDelete(name=b1.name)
 


### PR DESCRIPTION
* Remove the intermediate status check after backup resume.
* Add wait for lock expiration before backupstore cleanup.

https://github.com/longhorn/longhorn/issues/2369