### PR TITLE
nightly tests: increase terraform step timeout to 30 min

### DIFF
--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -44,7 +44,7 @@ node {
         }
 
         try {
-            timeout(15) {
+            timeout(30) {
                 stage ('terraform') {
                     sh  " docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/terraform-setup.sh"
                 }


### PR DESCRIPTION
Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>

Increase timeout to insure RHEL & SLES pass without issues.