### PR TITLE
test framework: redirect pytest output/error to a file in run.sh

### DIFF
--- a/manager/integration/tests/run.sh
+++ b/manager/integration/tests/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $@ =~ "--junitxml=" ]] ; then 
-  pytest -v $@  > /tmp/longhorn-pytest
+  pytest -v $@ > /tmp/longhorn-pytest 2>&1
   
   cat ${LONGHORN_JUNIT_REPORT_PATH}
 else 


### PR DESCRIPTION
Ref: https://github.com/longhorn/longhorn/issues/2333

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>

pytest output/errors need to be directed to a file, so  pod out put will be only the content of 
`cat ${LONGHORN_JUNIT_REPORT_PATH}` command which is the Junit report.