### PR TITLE
wait 30 seconds for docker to completetly start

### DIFF
--- a/test_framework/scripts/terraform-setup.sh
+++ b/test_framework/scripts/terraform-setup.sh
@@ -7,6 +7,7 @@ if [[ ${TF_VAR_arch} == "amd64" ]]; then
 	terraform apply -auto-approve -no-color ${TF_VAR_tf_workspace}/terraform/aws/${DISTRO}
 	terraform refresh ${TF_VAR_tf_workspace}/terraform/aws/${DISTRO}
 	terraform output rke_config > ${TF_VAR_tf_workspace}/rke.yml
+	sleep 30
 	rke up --config ${TF_VAR_tf_workspace}/rke.yml
 	exit $?
 else


### PR DESCRIPTION
Ref: https://github.com/longhorn/longhorn/issues/2375
Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>

RKE somtimes fails to run on worker nodes because the delayed start of docker service.