### PR TITLE
add backing-image-manager to security scan framework

### DIFF
--- a/secscan/scripts/secscan.sh
+++ b/secscan/scripts/secscan.sh
@@ -5,7 +5,7 @@ SEVERITY=${1}
 mkdir -p /junit-reports /templates
 
 REPO="longhornio"
-IMAGES=("longhorn-manager" "longhorn-engine" "longhorn-instance-manager" "longhorn-ui" "longhorn-share-manager")
+IMAGES=("longhorn-manager" "longhorn-engine" "longhorn-instance-manager" "longhorn-ui" "longhorn-share-manager" "backing-image-manager")
 TAG="master"
 
 wget -O /templates/junit.tpl https://raw.githubusercontent.com/longhorn/longhorn-tests/master/secscan/templates/junit.tpl


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/2006

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>