### PR TITLE
Fix test statefulset recurring backup

### DIFF
--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -318,8 +318,8 @@ def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
             if snapshot.removed is False:
                 count += 1
 
-        # two backups + volume-head
-        assert count == 3
+        # one backups + volume-head
+        assert count == 2
 
 
 def test_statefulset_restore(set_random_backupstore, client, core_api, storage_class, statefulset):  # NOQA


### PR DESCRIPTION
#### Proposed Changes ####

Fix test statefulset recurring backup as only keep one backup snapshot to resolve issue '[BUG] Nightly Test: test_statefulset_recurring_backup sometimes failed'

TEST_FILE=test_statefulset.py
TEST_CASE=test_statefulset_recurring_backup

#### Types of Changes ####

#### Verification ####

Test case update in 

#### Linked Issues ####

Refs: https://github.com/longhorn/longhorn/issues/1238
Refs: https://github.com/longhorn/longhorn-manager/pull/904

#### Further Comments ####

None

Signed-off-by: Clark Hsu <clark.hsu@suse.com>