### PR TITLE
Add a manual test for a simulated slow disk.

### DIFF
--- a/docs/content/manual/pre-release/resiliency/_index.md
+++ b/docs/content/manual/pre-release/resiliency/_index.md
@@ -1,0 +1,3 @@
+---
+title: Resiliency
+---

--- a/docs/content/manual/pre-release/resiliency/simulated-slow-disk.md
+++ b/docs/content/manual/pre-release/resiliency/simulated-slow-disk.md
@@ -13,11 +13,21 @@ This case requires the creation of a slow virtual disk with `dmsetup`.
 2. Build longhorn-engine and run it on the slow disk.
     - `make` or use a tag from docker hub in next step.
     - `docker run --privileged -v /dev:/host/dev -v /proc:/host/proc -v /mnt:/volume longhornio/longhorn-engine:<tag> launch-simple-longhorn slow-vol 10g tgt-blockdev`
-3. Perform intense I/O and verify that it doesn't fail.
+3. Perform intense I/O on the block device and verify that it doesn't fail.
     - This uses an iodepth of 16 to maximize the number of threads in tgtd.  An iodepth of 16 or more will maximize the number of threads in tgtd. `fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=1280k --direct=1 --size=3000m --numjobs=1 --filename=/dev/longhorn/slow-vol --iodepth=16 --verify=sha256`
     - This exceeds the number of operations tgtd and longhorn can handle simultaneously. `fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=16k --direct=1 --size=10m --numjobs=4 --filename=/dev/longhorn/slow-vol --iodepth=128 --verify=sha256`
     - This tests performing one I/O operation at a time: `fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=4k --direct=1 --size=10m --numjobs=1 --filename=/dev/longhorn/slow-vol --iodepth=1 --verify=sha256`
+    - This tests with skipping 4k blocks: `fio --name=sparse-writers --ioengine=libaio --rw=write:4k --bs=4k --direct=1 --size=10m --numjobs=1 --filename=/dev/longhorn/slow-vol --iodepth=128 --verify=sha256`
 
+4. Perform intense I/O on a filesystem and verify that it doesn't fail.
+    - `mkfs.ext4 /dev/longhorn/slow-vol`
+    - `mkdir /slow-mnt`
+    - `mount /dev/longhorn/slow-vol /slow-mnt`
+    - Run tests similar to the block device tests:
+        - `fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=1280k --direct=1 --size=3000m --numjobs=1 --filename=/slow-mnt/file.dat --iodepth=16 --verify=sha256`
+        - `fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=16k --direct=1 --size=10m --numjobs=4 --filename=/slow-mnt/file.dat --iodepth=128 --verify=sha256`
+        - `fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=4k --direct=1 --size=10m --numjobs=1 --filename=/slow-mnt/file.dat --iodepth=1 --verify=sha256`
+        - `fio --name=sparse-writers --ioengine=libaio --rw=write:4k --bs=4k --direct=1 --size=10m --numjobs=1 --filename=/slow-mnt/file.dat --iodepth=128 --verify=sha256`
 
 5. Repeat with different filesystems, i.e use `mkfs.xfs` instead of `mkfs.ext4`.
 

--- a/docs/content/manual/pre-release/resiliency/simulated-slow-disk.md
+++ b/docs/content/manual/pre-release/resiliency/simulated-slow-disk.md
@@ -1,0 +1,23 @@
+---
+title: "[#2206](https://github.com/longhorn/longhorn/issues/2206) Fix the spinning disk on Longhorn"
+---
+
+This case requires the creation of a slow virtual disk with `dmsetup`.
+1. Make a slow disk:
+    - Make a disk image file: `truncate -s 10g slow.img`
+    - Create a loopback device: `losetup --show -P -f slow.img`
+    - Get the block size of the loopback device: `blockdev --getsize /dev/loopX`
+    - Create slow device: `echo "0 <blocksize> delay /dev/loopX 0 500" | dmsetup create dm-slow`
+    - Format slow device: `mkfs.ext4 /dev/mapper/dm-slow`
+    - Mount slow device: `mount /dev/mapper/dm-slow /mnt`
+2. Build longhorn-engine and run it on the slow disk.
+    - `make` or use a tag from docker hub in next step.
+    - `docker run --privileged -v /dev:/host/dev -v /proc:/host/proc -v /mnt:/volume longhornio/longhorn-engine:<tag> launch-simple-longhorn slow-vol 10g tgt-blockdev`
+3. Perform intense I/O and verify that it doesn't fail.
+    - This uses an iodepth of 16 to maximize the number of threads in tgtd.  An iodepth of 16 or more will maximize the number of threads in tgtd. `fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=1280k --direct=1 --size=3000m --numjobs=1 --filename=/dev/longhorn/slow-vol --iodepth=16 --verify=sha256`
+    - This exceeds the number of operations tgtd and longhorn can handle simultaneously. `fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=16k --direct=1 --size=10m --numjobs=4 --filename=/dev/longhorn/slow-vol --iodepth=128 --verify=sha256`
+    - This tests performing one I/O operation at a time: `fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=4k --direct=1 --size=10m --numjobs=1 --filename=/dev/longhorn/slow-vol --iodepth=1 --verify=sha256`
+
+
+5. Repeat with different filesystems, i.e use `mkfs.xfs` instead of `mkfs.ext4`.
+

--- a/docs/content/manual/pre-release/resiliency/timeout.md
+++ b/docs/content/manual/pre-release/resiliency/timeout.md
@@ -1,0 +1,87 @@
+---
+title: "Test timeout on loss of network connectivity"
+---
+
+## Ping Timeout
+
+1. Create a docker network:
+
+```shell
+docker network create -d bridge --subnet 192.168.22.0/24 longhorn-network
+```
+
+2. Start a replica:
+
+```shell
+docker run --net longhorn-network --ip 192.168.22.2 \
+         -v /volume longhornio/longhorn-engine:<tag> \
+         longhorn replica --listen 192.168.22.2:9502 --size 10g /volume
+```
+
+3. Start another replica:
+
+```shell
+docker run --net longhorn-network --ip 192.168.22.3 \
+         -v /volume longhornio/longhorn-engine:<tag> \
+         longhorn replica --listen 192.168.22.3:9502 --size 10g /volume
+```
+
+4. In another terminal, start the controller:
+
+```shell
+docker run --net longhorn-network --ip 192.168.22.4 --privileged \
+         -v /dev:/dev -v /proc:/host/proc \
+         longhornio/longhorn-engine:<tag> \
+         longhorn controller --replica tcp://192.168.22.2:9502 \
+         --replica tcp://192.168.22.3:9502 \
+         --frontend tgt-blockdev timeout-test
+```
+
+5. In another terminal, find the name of the container running the replica with `docker ps`
+
+6. Disconnect the replica container from the network:
+
+```shell
+docker network disconnect longhorn-network <container id/name>
+```
+
+7. Note that the controller output displays "Backend tcp://192.168.22.2:9502 monitoring failed, mark as ERR: ping timeout" after eight seconds. 
+
+## R/W Timeout Block Device
+
+1. Perform steps 2-4 from the Ping Timeout Section.
+
+2. In another terminal, perform I/O:
+
+```shell
+fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=16k \
+           --direct=1 --size=1000m --numjobs=1 \
+           --filename=/dev/longhorn/timeout-test --iodepth=1
+```
+3. Stop the network on the replica with steps 5-6 in the Ping Timeout Section.
+
+4. Note that the controller output displays "Setting replica tcp://192.168.22.2:9502 to ERR due to: r/w timeout" after eight seconds.
+
+6. Check `dmesg` to verify that block device did not generate any kernel error messages.
+
+## R/W Timeout Filesystem
+
+1. Perform steps 2-4 from the Ping Timeout Section.
+
+2. In another terminal, perform I/O:
+
+```shell
+mkfs.ext4 /dev/longhorn/timeout-test
+mkdir /timeout-test
+mount /dev/longhorn/timeout-test /timeout-test
+fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=16k \
+           --direct=1 --size=1000m --numjobs=1 \
+           --filename=/timeout-test/fio.dat --iodepth=1
+```
+3. Stop the network on the replica with steps 5-6 in the Ping Timeout Section.
+
+4. Note that the controller output displays "Setting replica tcp://192.168.22.2:9502 to ERR due to: r/w timeout" after eight seconds.
+
+5. Note that the fio operation continues to work and completes without error.
+
+6. Check `dmesg` to verify that block device or filesystem did not generate any kernel error messages.


### PR DESCRIPTION
I added a manual test for a simulated slow disk because I couldn't get dmsetup to work in the docker environment that the python longhorn-engine tests are run in.

https://github.com/longhorn/longhorn/issues/2206

Signed-off-by: Keith Lucas <keith.lucas@suse.com>