### PR TITLE
Fix test volume creation with degraded availability

### DIFF
--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -600,7 +600,7 @@ def test_allow_volume_creation_with_degraded_availability_csi(
     data_path = "/data/test"
     pod = common.wait_and_get_any_deployment_pod(core_api, deployment_name)
     common.write_pod_volume_random_data(core_api, pod.metadata.name,
-                                        data_path, common.DATA_SIZE_IN_MB_1)
+                                        data_path, common.DATA_SIZE_IN_MB_2)
     created_md5sum = get_pod_data_md5sum(core_api, pod.metadata.name,
                                          data_path)
 


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/2766

**Cause of failure** : 
The rebuilding for 100MB is too fast that test is unable to capture the `inProgress` state.

**Proposed Solution**:
Increased the data to 300MB in the volume so that the rebuilding takes more time and test can get the rebuilding status.

Signed-off-by: Khushboo <fnu.khushboo@suse.com>