### PR TITLE
Fix test_backup_labels_with_backing_image

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2850,6 +2850,19 @@ def is_backupTarget_nfs(s):
     return s.startswith("nfs://")
 
 
+def wait_for_backup_volume(client, vol_name, backing_image=""):
+    for _ in range(RETRY_BACKUP_COUNTS):
+        bv = client.by_id_backupVolume(vol_name)
+        if bv is not None:
+            if backing_image == "":
+                break
+            if bv.backingImageName == backing_image \
+                    and bv.backingImageChecksum != "":
+                break
+        time.sleep(RETRY_BACKUP_INTERVAL)
+    assert bv is not None, "failed to find backup volume " + vol_name
+
+
 def find_backup(client, vol_name, snap_name):
     """
     find_backup will look for a backup on the backupstore

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -70,6 +70,7 @@ from common import VOLUME_ROBUSTNESS_HEALTHY, VOLUME_ROBUSTNESS_FAULTED
 from common import DATA_SIZE_IN_MB_2, DATA_SIZE_IN_MB_3
 from common import wait_for_backup_to_start
 from common import SETTING_DEFAULT_LONGHORN_STATIC_SC
+from common import wait_for_backup_volume
 
 from backupstore import backupstore_delete_volume_cfg_file
 from backupstore import backupstore_cleanup
@@ -1290,11 +1291,8 @@ def backup_labels_test(client, random_labels, volume_name, size=SIZE, backing_im
     # If we're running the test with a BackingImage,
     # check field `volumeBackingImageName` is set properly.
     backup = bv.backupGet(name=b.name)
-    if backing_image:
-        assert bv.backingImageName == backing_image
-        assert bv.backingImageChecksum != ""
-        assert backup.volumeBackingImageName == backing_image
     assert len(backup.labels) == len(random_labels)
+    wait_for_backup_volume(client, volume_name, backing_image)
 
 
 @pytest.mark.coretest   # NOQA

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -44,6 +44,7 @@ from common import check_pod_existence
 
 from common import crash_engine_process_with_sigkill
 
+from common import wait_for_backup_volume
 from common import wait_for_backup_completion
 from common import wait_for_backup_count
 from common import wait_for_backup_to_start
@@ -492,10 +493,7 @@ def recurring_job_labels_test(client, labels, volume_name, size=SIZE, backing_im
     assert b.labels.get(RECURRING_JOB_LABEL) == RECURRING_JOB_NAME
     # One extra Label from RecurringJob.
     assert len(b.labels) == len(labels) + 1
-    if backing_image:
-        assert bv.backingImageName == backing_image
-        assert bv.backingImageChecksum != ""
-        assert b.volumeBackingImageName == backing_image
+    wait_for_backup_volume(client, volume_name, backing_image)
 
 
 @pytest.mark.csi  # NOQA


### PR DESCRIPTION
#### Proposal Change
Because the backup volume CR changes to async pull from the remote backup target.
Add retry to get the backing image information from backup volume CR to
verify the backing image name and checksum.

#### Issue
https://github.com/longhorn/longhorn/issues/2876
