### PR TITLE
Fix test_statefulset_recurring_backup

### DIFF
--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -272,8 +272,7 @@ def test_statefulset_backup(set_random_backupstore, client, core_api, storage_cl
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
-                                      statefulset):  # NOQA
+def test_statefulset_recurring_backup(set_random_backupstore, client, core_api, storage_class, statefulset):  # NOQA
     """
     Scenario : test recurring backups on StatefulSets
 
@@ -331,7 +330,7 @@ def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
             if snapshot.removed is False:
                 count += 1
 
-        # one backups + volume-head
+        # one backup + volume-head
         assert count == 2
 
 


### PR DESCRIPTION
Run the test with recurring snapshots since the backup store did not configure.
Otherwise, the orphan Backup CR would be staying in the cluster.

Note that, this PR did not fix the flakiness of this test case. But focus on fixing the orphan Backup CR.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>