### PR TITLE
[v1.2.x] backports fix test_statefulset_recurring_backup and test_backup_kubernetes_status flakiness

### DIFF
--- a/manager/integration/tests/test_kubernetes.py
+++ b/manager/integration/tests/test_kubernetes.py
@@ -599,11 +599,18 @@ def test_backup_kubernetes_status(set_random_backupstore, client, core_api, pod)
     snap = create_snapshot(client, volume_name)
     volume.snapshotBackup(name=snap.name)
     wait_for_backup_completion(client, volume_name, snap.name)
-    bv, b = find_backup(client, volume_name, snap.name)
-    status = loads(bv.labels.get(KUBERNETES_STATUS_LABEL))
+    _, b = find_backup(client, volume_name, snap.name)
+    # Check backup label
+    status = loads(b.labels.get(KUBERNETES_STATUS_LABEL))
     assert status == ks
-    new_b = bv.backupGet(name=b.name)
-    status = loads(new_b.labels.get(KUBERNETES_STATUS_LABEL))
+    # Check backup volume label
+    for _ in range(RETRY_COUNTS):
+        bv = client.by_id_backupVolume(volume_name)
+        if bv is not None and bv.labels is not None:
+            break
+        time.sleep(RETRY_INTERVAL)
+    assert bv is not None and bv.labels is not None
+    status = loads(bv.labels.get(KUBERNETES_STATUS_LABEL))
     assert status == ks
 
     restore_name = generate_volume_name()

--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -272,8 +272,7 @@ def test_statefulset_backup(set_random_backupstore, client, core_api, storage_cl
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
-                                      statefulset):  # NOQA
+def test_statefulset_recurring_backup(set_random_backupstore, client, core_api, storage_class, statefulset):  # NOQA
     """
     Scenario : test recurring backups on StatefulSets
 
@@ -331,7 +330,7 @@ def test_statefulset_recurring_backup(client, core_api, storage_class,  # NOQA
             if snapshot.removed is False:
                 count += 1
 
-        # one backups + volume-head
+        # one backup + volume-head
         assert count == 2
 
 


### PR DESCRIPTION
This PR backports #692 and #701 to v1.2.x branch