### PR TITLE
Set poll interval to 0 to test backup/restore works correctly

### DIFF
--- a/manager/integration/deploy/stress.yml
+++ b/manager/integration/deploy/stress.yml
@@ -51,7 +51,7 @@ spec:
         - name: LONGHORN_BACKUPSTORES
           value: "s3://backupbucket@us-east-1/backupstore$minio-secret, nfs://longhorn-test-nfs-svc.default:/opt/backupstore"
         - name: LONGHORN_BACKUPSTORE_POLL_INTERVAL
-          value: "30"
+          value: "0"
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -78,7 +78,7 @@ spec:
     - name: LONGHORN_BACKUPSTORES
       value: "s3://backupbucket@us-east-1/backupstore$minio-secret, nfs://longhorn-test-nfs-svc.default:/opt/backupstore"
     - name: LONGHORN_BACKUPSTORE_POLL_INTERVAL
-      value: "30"
+      value: "0"
     - name: NODE_NAME
       valueFrom:
         fieldRef:


### PR DESCRIPTION
The backup/restore function _must_ works correctly when configuring poll interval to 0 excepts for the DR volume feature.

However, the current E2E tests did not launch 2 clusters and running the DR volume testing.
So, change the poll interval to 0 won't affect the DR volume related tests.

If we could test DR volume with 2 clusters in E2E tests in the future, we should different poll interval setting
- poll interval = 0 for normal backup/restore function
- poll interval > 0 (e.g. 300 secs) for DR volume function

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>