### PR TITLE
Fix pytest warning

### DIFF
--- a/manager/integration/pytest.ini
+++ b/manager/integration/pytest.ini
@@ -10,3 +10,5 @@ markers =
   stress
   csi_expansion
   upgrade
+  cloning
+  migration


### PR DESCRIPTION
This is to solve below pytest warning for v1.2.x
```
/usr/local/lib/python3.9/site-packages/_pytest/mark/structures.py:323
  /usr/local/lib/python3.9/site-packages/_pytest/mark/structures.py:323: PytestUnknownMarkWarning: Unknown pytest.mark.cloning - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    warnings.warn(

/usr/local/lib/python3.9/site-packages/_pytest/mark/structures.py:323
  /usr/local/lib/python3.9/site-packages/_pytest/mark/structures.py:323: PytestUnknownMarkWarning: Unknown pytest.mark.migration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    warnings.warn(
```


Signed-off-by: Khushboo <fnu.khushboo@suse.com>