### PR TITLE
Fix all recurring job related test failed

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4255,7 +4255,8 @@ def check_recurring_jobs(client, recurring_jobs):
         recurring_job = client.by_id_recurring_job(name)
         assert recurring_job.name == name
         assert recurring_job.task == spec["task"]
-        assert recurring_job.groups == spec["groups"]
+        if len(spec["groups"]) > 0:
+            assert recurring_job.groups == spec["groups"]
         assert recurring_job.cron == spec["cron"]
         assert recurring_job.retain == spec["retain"]
         assert recurring_job.concurrency == spec["concurrency"]


### PR DESCRIPTION
https://ci.longhorn.io/job/public/job/v1.2.x/job/v1.2.x-longhorn-tests-ubuntu-amd64/2/

The recurring job `spec.groups` is an optional field https://github.com/longhorn/longhorn-manager/blob/3df7b91/types/resource.go#L190

Check the argument contains the `groups` field and then verify it's equal compares to the recurring job `spec.groups`.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>