### PR TITLE
integration: fix wait_for_engine_image_deletion()

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3386,6 +3386,8 @@ def wait_for_engine_image_deletion(client, core_api, engine_image_name):
         if len(ei_pod_list) != 0:
             deleted = False
             continue
+        if deleted:
+            break
 
     assert deleted
 


### PR DESCRIPTION
There is no need to continue waiting if the deletion is done.

Before this fix, `test_engine_live_upgrade` takes 223s. After the fix, the test spends 62s only.