### PR TITLE
fix secscan: disable apt-upgrade timers for secscan provisioning and move upgrade to provision script

### DIFF
--- a/secscan/scripts/provision.sh
+++ b/secscan/scripts/provision.sh
@@ -3,7 +3,13 @@
 DOCKER_VERSION=20.10
 
 systemctl stop apt-daily.service
+systemctl disable apt-daily.service
+systemctl disable apt-daily.timer
+
 systemctl stop apt-daily-upgrade.service
+systemctl disable apt-daily-upgrade.service
+systemctl disable apt-daily-upgrade.timer
+
 systemctl kill --kill-who=all apt-daily.service
 systemctl kill --kill-who=all apt-daily-upgrade.service
 
@@ -17,6 +23,8 @@ do
   sleep 1;
 done
 
-apt-get update && apt-get install -y build-essential git
+apt-get update
+apt-get dist-upgrade
+apt-get install -y build-essential git
 
 curl https://releases.rancher.com/install-docker/${DOCKER_VERSION}.sh | sh

--- a/secscan/terraform/digitalocean/do.tf
+++ b/secscan/terraform/digitalocean/do.tf
@@ -43,8 +43,6 @@ resource "digitalocean_droplet" "longhorn-tests" {
   size     = "s-4vcpu-8gb"
   ssh_keys = [digitalocean_ssh_key.do-ssh-key.fingerprint]
   tags     = ["longhorn-secscan", "DoNotDelete"]
-  user_data = "apt-get update -y && apt-get dist-upgrade -yyq"
-
 }
 
 


### PR DESCRIPTION
Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@suse.com>