### PR TITLE
fix nightly tests issues

### DIFF
--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -44,7 +44,7 @@ node {
         }
 
         try {
-            timeout(30) {
+            timeout(60) {
                 stage ('terraform') {
                     sh  " docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/terraform-setup.sh"
                 }

--- a/test_framework/terraform/aws/rhel/variables.tf
+++ b/test_framework/terraform/aws/rhel/variables.tf
@@ -50,7 +50,7 @@ variable "lh_aws_instance_count_worker" {
 
 variable "lh_aws_instance_name_controlplane" {
   type        = string
-  default     = "longhorn-tests-controlplane"
+  default     = "lh-tests-controlplane"
 }
 
 variable "lh_aws_instance_type_controlplane" {
@@ -80,7 +80,7 @@ variable "aws_ssh_private_key_file_path" {
 
 variable "lh_aws_instance_name_worker" {
   type        = string
-  default     = "longhorn-tests-worker"
+  default     = "lh-tests-worker"
 }
 
 variable "lh_aws_instance_root_block_device_size_worker" {

--- a/test_framework/terraform/aws/sles/variables.tf
+++ b/test_framework/terraform/aws/sles/variables.tf
@@ -51,7 +51,7 @@ variable "lh_aws_instance_count_worker" {
 
 variable "lh_aws_instance_name_controlplane" {
   type        = string
-  default     = "longhorn-tests-controlplane"
+  default     = "lh-tests-controlplane"
 }
 
 variable "lh_aws_instance_type_controlplane" {
@@ -81,7 +81,7 @@ variable "aws_ssh_private_key_file_path" {
 
 variable "lh_aws_instance_name_worker" {
   type        = string
-  default     = "longhorn-tests-worker"
+  default     = "lh-tests-worker"
 }
 
 variable "lh_aws_instance_root_block_device_size_worker" {

--- a/test_framework/terraform/aws/ubuntu/variables.tf
+++ b/test_framework/terraform/aws/ubuntu/variables.tf
@@ -50,7 +50,7 @@ variable "lh_aws_instance_count_worker" {
 
 variable "lh_aws_instance_name_controlplane" {
   type        = string
-  default     = "longhorn-tests-controlplane"
+  default     = "lh-tests-controlplane"
 }
 
 variable "lh_aws_instance_type_controlplane" {
@@ -81,7 +81,7 @@ variable "aws_ssh_private_key_file_path" {
 
 variable "lh_aws_instance_name_worker" {
   type        = string
-  default     = "longhorn-tests-worker"
+  default     = "lh-tests-worker"
 }
 
 variable "lh_aws_instance_root_block_device_size_worker" {


### PR DESCRIPTION
 - Reduce instance name length to fix failing jenkins jobs to Fix v1.2.1 nightly upgrade tests.
Ref: https://ci.longhorn.io/job/public/job/v1.2.x/job/v1.2.x-longhorn-upgrade-tests-ubuntu-amd64/9/console

- Increase timeout for terraform setup step to 60 min
RHEL 8.4.0 will take longer time to install docker than other OS`s


Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@suse.com>