### PR TITLE
add don't delete tags to nightly tests nodes

### DIFF
--- a/test_framework/terraform/aws/rhel/main.tf
+++ b/test_framework/terraform/aws/rhel/main.tf
@@ -252,6 +252,8 @@ resource "aws_instance" "lh_aws_instance_controlplane" {
 
   tags = {
     Name = "${var.lh_aws_instance_name_controlplane}-${count.index}-${random_string.random_suffix.id}"
+    DoNotDelete	= "true"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -302,6 +304,8 @@ resource "aws_instance" "lh_aws_instance_worker" {
 
   tags = {
     Name = "${var.lh_aws_instance_name_worker}-${count.index}-${random_string.random_suffix.id}"
+    DoNotDelete	= "true"
+    Owner = "longhorn-infra"
   }
 }
 

--- a/test_framework/terraform/aws/sles/main.tf
+++ b/test_framework/terraform/aws/sles/main.tf
@@ -252,6 +252,8 @@ resource "aws_instance" "lh_aws_instance_controlplane" {
 
   tags = {
     Name = "${var.lh_aws_instance_name_controlplane}-${count.index}-${random_string.random_suffix.id}"
+    DoNotDelete	= "true"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -302,6 +304,8 @@ resource "aws_instance" "lh_aws_instance_worker" {
 
   tags = {
     Name = "${var.lh_aws_instance_name_worker}-${count.index}-${random_string.random_suffix.id}"
+    DoNotDelete	= "true"
+    Owner = "longhorn-infra"
   }
 }
 

--- a/test_framework/terraform/aws/ubuntu/main.tf
+++ b/test_framework/terraform/aws/ubuntu/main.tf
@@ -252,6 +252,8 @@ resource "aws_instance" "lh_aws_instance_controlplane" {
 
   tags = {
     Name = "${var.lh_aws_instance_name_controlplane}-${count.index}-${random_string.random_suffix.id}"
+    DoNotDelete	= "true"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -302,6 +304,8 @@ resource "aws_instance" "lh_aws_instance_worker" {
 
   tags = {
     Name = "${var.lh_aws_instance_name_worker}-${count.index}-${random_string.random_suffix.id}"
+    DoNotDelete	= "true"
+    Owner = "longhorn-infra"
   }
 }
 


### PR DESCRIPTION
Sometimes instances will be deleted by automated scripts, we need to tag instances with `DoNotDelete` tag to prevent that.


Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@suse.com>