### PR TITLE
Fix Unbound name errors

### DIFF
--- a/engine/stress/rebuild-test.py
+++ b/engine/stress/rebuild-test.py
@@ -235,7 +235,7 @@ workers = []
 
 nthreads = 10
 
-for thread in xrange(nthreads):
+for thread in range(nthreads):
   p = Process(target = read_write, args = (thread + 1, 100000))
   workers.append(p)
   p.start()

--- a/engine/stress/stress-test.py
+++ b/engine/stress/stress-test.py
@@ -177,7 +177,7 @@ snapshots["livedata"] = 0
 
 workers = []
 
-for i in xrange(10):
+for i in range(10):
   p = Process(target = random_write, args = (snapshots, testdata, 2000000))
   workers.append(p)
   p.start()

--- a/engine/stress/teardown-test.py
+++ b/engine/stress/teardown-test.py
@@ -197,7 +197,7 @@ def run_test(thread, iterations):
 
 workers = []
 
-for thread in xrange(20):
+for thread in range(20):
   p = Process(target = run_test, args = (thread + 1, 1000))
   workers.append(p)
   p.start()

--- a/engine/validation-test/storagetest/core/test_longhorn_basic.py
+++ b/engine/validation-test/storagetest/core/test_longhorn_basic.py
@@ -2,6 +2,7 @@ from common_fixtures import *  # NOQA
 import websocket as ws
 import base64
 
+import pytest
 
 VOLUME_DRIVER = "rancher-longhorn"
 


### PR DESCRIPTION
Signed-off-by: Shatakshi <shatakshi.gupta85@gmail.com>
Related to Bugbash. Fixed unbound name errors as reported by [Sonatype Lift](https://lift.sonatype.com/result/longhorn/longhorn-tests/01FHW2V4T8A6NDXB3MCV0CPHGP?t=CustomTool%20%22Pyre%22%7CUnbound%20name). 