### PR TITLE
Fix pdoc error

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1407,7 +1407,12 @@ def get_backupstore_poll_interval():
 
 
 def get_backupstores():
-    backupstore = os.environ['LONGHORN_BACKUPSTORES']
+    # The try is added to avoid the pdoc3 error while publishing this on
+    # https://longhorn.github.io/longhorn-tests
+    try:
+        backupstore = os.environ['LONGHORN_BACKUPSTORES']
+    except KeyError:
+        return None
     backupstore = backupstore.replace(" ", "")
     try:
         backupstores = backupstore.split(",")


### PR DESCRIPTION
Fix for pdoc error

Reason of failure : the hardcoded fixes `nfs.s3` got replaced by a var which requires the env variable. At the time when pdoc is running the env variable is unavailable.
Fix: Returning None if the env variable can’t be found

Signed-off-by: Khushboo <fnu.khushboo@suse.com>