### PR TITLE
Change except type in common:wait_for_all_instance_manager_running 

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2835,7 +2835,7 @@ def wait_for_all_instance_manager_running(client):
                                                        im.name, "Running",
                                                        True)
             break
-        except ApiException:
+        except Exception:
             continue
 
 


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>
From #736 
Should use Exception not ApiException make the the loop wroking