### PR TITLE
[v1.2.x-backport] Flakiness test case : test_node_config_annotation_missing

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2815,7 +2815,7 @@ def wait_for_all_instance_manager_running(client):
                                                        im.name, "Running",
                                                        True)
             break
-        except ApiException:
+        except Exception:
             continue
 
 


### PR DESCRIPTION
back port #736 to v1.2.x