### PR TITLE
Fix test_allow_volume_creation_with_degraded_availability_restore

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3381,6 +3381,7 @@ def test_allow_volume_creation_with_degraded_availability_restore(set_random_bac
     common.wait_for_replica_scheduled(client, dst_vol_name,
                                       to_nodes=[node1.name],
                                       expect_success=1,
+                                      expect_fail=2,
                                       chk_vol_healthy=False,
                                       chk_replica_running=False)
 


### PR DESCRIPTION
At the time of `wait_for_replica_scheduled` check there are 1 running replica and 2 failed replicas. So, expect_fail should be 2.

Signed-off-by: Khushboo <fnu.khushboo@suse.com>