### PR TITLE
Fix pdoc failure

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1412,9 +1412,9 @@ def get_backupstores():
     try:
         backupstore = os.environ['LONGHORN_BACKUPSTORES']
     except KeyError:
-        return None
-    backupstore = backupstore.replace(" ", "")
+        return []
     try:
+        backupstore = backupstore.replace(" ", "")
         backupstores = backupstore.split(",")
         for i in range(len(backupstores)):
             backupstores[i] = backupstores[i].split(":")[0]


### PR DESCRIPTION
Instead of returning `None` for keyerror in get_backupstore method, now returning empty list as we have skip condition based on backupstore type which become non-iterable if set None.

Signed-off-by: Khushboo <fnu.khushboo@suse.com>