### PR TITLE
[v1.2.x-backport] Not count error state backup anymore

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -359,7 +359,14 @@ def create_backup(client, volname, data={}, labels={}):
 def wait_for_backup_count(backup_volume, number, retry_counts=120):
     ok = False
     for _ in range(retry_counts):
-        if len(backup_volume.backupList()) == number:
+
+        complete_backup_cnt = 0
+        for single_backup in backup_volume.backupList():
+            if single_backup.state == "Completed" and \
+                                        int(single_backup.volumeSize) > 0:
+                complete_backup_cnt = complete_backup_cnt + 1
+
+        if complete_backup_cnt == number:
             ok = True
             break
         time.sleep(RETRY_BACKUP_INTERVAL)


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>
Back port [PR #761](https://github.com/longhorn/longhorn-tests/pull/761#issuecomment-953583796) to v1.2.x