### PR TITLE
Fix flaky case : test_engine_image_daemonset_restart

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1784,6 +1784,20 @@ def wait_for_engine_image_state(client, image_name, state):
     return image
 
 
+def wait_for_engine_image_condition(client, image_name, state):
+    """
+    state: "True", "False"
+    """
+    for i in range(RETRY_COUNTS):
+        wait_for_engine_image_creation(client, image_name)
+        image = client.by_id_engine_image(image_name)
+        if image['conditions']['ready']['status'] == state:
+            break
+        time.sleep(RETRY_INTERVAL_LONG)
+    assert image['conditions']['ready']['status'] == state
+    return image
+
+
 def wait_for_engine_image_ref_count(client, image_name, count):
     wait_for_engine_image_creation(client, image_name)
     for i in range(RETRY_COUNTS):

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -75,7 +75,6 @@ from common import wait_for_backup_volume
 from common import create_and_wait_statefulset
 from common import create_backup_from_volume_attached_to_pod
 from common import restore_backup_and_get_data_checksum
-from common import RETRY_EXEC_INTERVAL
 
 from backupstore import backupstore_delete_volume_cfg_file
 from backupstore import backupstore_cleanup

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -75,6 +75,7 @@ from common import wait_for_backup_volume
 from common import create_and_wait_statefulset
 from common import create_backup_from_volume_attached_to_pod
 from common import restore_backup_and_get_data_checksum
+from common import RETRY_EXEC_INTERVAL
 
 from backupstore import backupstore_delete_volume_cfg_file
 from backupstore import backupstore_cleanup
@@ -2410,13 +2411,15 @@ def test_engine_image_daemonset_restart(client, apps_api, volume_name):  # NOQA
     # The engine image DaemonSet will be recreated/restarted automatically
     apps_api.delete_namespaced_daemon_set(ds_name, common.LONGHORN_NAMESPACE)
 
+    # Let DaemonSet really restarted
+    time.sleep(RETRY_EXEC_INTERVAL)
+
     # The Longhorn volume is still available
     # during the engine image DaemonSet restarting
     check_volume_data(volume, snap1_data)
 
     # Wait for the restart complete
-    ei_state = common.get_engine_image_status_value(client, default_img.name)
-    common.wait_for_engine_image_state(client, default_img.name, ei_state)
+    common.wait_for_engine_image_condition(client, default_img.name, "True")
 
     # Longhorn is still able to use the corresponding engine binary to
     # operate snapshot

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -2412,7 +2412,7 @@ def test_engine_image_daemonset_restart(client, apps_api, volume_name):  # NOQA
     apps_api.delete_namespaced_daemon_set(ds_name, common.LONGHORN_NAMESPACE)
 
     # Let DaemonSet really restarted
-    time.sleep(RETRY_EXEC_INTERVAL)
+    common.wait_for_engine_image_condition(client, default_img.name, "False")
 
     # The Longhorn volume is still available
     # during the engine image DaemonSet restarting


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

After delete the engine image daemonset, we should wait a moment let engine image restart automatically
And use `image['conditions']['ready']['status']` to track engine image status

In origin we use `image.state` to track engine image status but it's always get "deployed" so test case flaky
 