### PR TITLE
Fix flaky test_replica_failure_during_attaching

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -2453,8 +2453,9 @@ def test_replica_failure_during_attaching(settings_reset, client, core_api, volu
 
     time.sleep(10)
     wait_for_volume_replica_count(client, volume_name_2, 4)
+    common.wait_for_volume_condition_scheduled(client, volume_name_2,
+                                               "status", "False")
     volume_2 = client.by_id_volume(volume_name_2)
-    assert volume_2.conditions.scheduled.status == "False"
     assert volume_2.conditions.scheduled.reason == "ReplicaSchedulingFailure"
 
     update_disks[default_disk_name].allowScheduling = True


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>
At very rare rate(1/20) after step 10, volume.conditions.scheduled.status still True not become False immediately, make our test case flaky.
Since we do not specify timing for volume.conditions.scheduled.status become False, I would like to use `common.wait_for_volume_condition_scheduled ` let status become as expect then go next. If status not become False at end, script still raise Fail. Thanks


Steps:
```
    1. Set a short interval for setting replica-replenishment-wait-interval.
    2. Disable the setting soft-node-anti-affinity.
    3. Create volume1 with 1 replica. and attach it to the host node.
    4. Mount volume1 to a new mount point. then use it as an extra node disk.
    5. Disable the scheduling for the default disk of the host node,
       and make sure the extra disk is the only available disk on the node.
    6. Create and attach volume2, then write data to volume2.
    7. Detach volume2.
    8. Directly unmount volume1 and remove the related mount point directory.
       --> Verify the extra disk becomes unavailable.
    9. Attach volume2.
       --> Verify volume will be attached with state Degraded.
    10. Wait for the replenishment interval.
        --> Verify a new replica will be created but it cannot be scheduled.
    11. Enable the default disk for the host node.
    12. Wait for volume2 becoming Healthy.
    13. Verify data content and r/w capability for volume2.
```