### PR TITLE
Make nfs and s3 selection Jenkins parameterized

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1413,13 +1413,30 @@ def get_backupstore_poll_interval():
     return poll_interval
 
 
+def get_backupstore_config():
+    try:
+        return os.environ.get('BACKUP_STORE_TYPE')
+    except KeyError:
+        return None
+
+
 def get_backupstores():
     # The try is added to avoid the pdoc3 error while publishing this on
     # https://longhorn.github.io/longhorn-tests
+    backupstores = []
     try:
-        backupstore = os.environ['LONGHORN_BACKUPSTORES']
+        backupstore_config = get_backupstore_config()
+        if backupstore_config == 'nfs':
+            backupstores[0] = "nfs"
+            return backupstores
+        elif backupstore_config == 's3':
+            backupstores[0] = "s3"
+            return backupstores
+        else:
+            backupstore = os.environ['LONGHORN_BACKUPSTORES']
     except KeyError:
         return []
+
     try:
         backupstore = backupstore.replace(" ", "")
         backupstores = backupstore.split(",")


### PR DESCRIPTION
1. Based on the Jenkins parameters, the nfs and s3 backupstore is decided.
2. If the Jenkins parameter is not available, nfs and s3 backupstore will be decided on the test yaml file https://github.com/longhorn/longhorn-tests/blob/master/manager/integration/deploy/test.yaml Longhorn_backupstore variable

https://github.com/longhorn/longhorn/issues/3200

Signed-off-by: Khushboo <fnu.khushboo@suse.com>