### PR TITLE
Fix backup store type handling

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1413,27 +1413,11 @@ def get_backupstore_poll_interval():
     return poll_interval
 
 
-def get_backupstore_config():
-    try:
-        return os.environ.get('BACKUP_STORE_TYPE')
-    except KeyError:
-        return None
-
-
 def get_backupstores():
     # The try is added to avoid the pdoc3 error while publishing this on
     # https://longhorn.github.io/longhorn-tests
-    backupstores = []
     try:
-        backupstore_config = get_backupstore_config()
-        if backupstore_config == 'nfs':
-            backupstores[0] = "nfs"
-            return backupstores
-        elif backupstore_config == 's3':
-            backupstores[0] = "s3"
-            return backupstores
-        else:
-            backupstore = os.environ['LONGHORN_BACKUPSTORES']
+        backupstore = os.environ['LONGHORN_BACKUPSTORES']
     except KeyError:
         return []
 

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -183,8 +183,16 @@ run_longhorn_upgrade_test(){
 
 	## generate upgrade_test pod manifest
     yq e 'select(.spec.containers[0] != null).spec.containers[0].args=['"${PYTEST_COMMAND_ARGS}"']' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}" > ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-	yq e -i 'select(.spec.containers[0] != null).spec.containers[0].image="'${LONGHORN_TESTS_CUSTOM_IMAGE}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-	yq e -i 'select(.spec.containers[0] != null).metadata.name="'${LONGHORN_UPGRADE_TEST_POD_NAME}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].image="'${LONGHORN_TESTS_CUSTOM_IMAGE}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+    yq e -i 'select(.spec.containers[0] != null).metadata.name="'${LONGHORN_UPGRADE_TEST_POD_NAME}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+
+    if [[ $BACKUP_STORE_TYPE = "s3" ]]; then
+        BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $1}' | sed 's/ *//'`
+        yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+      elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
+        BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
+        yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+      fi
 
 	kubectl apply -f ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
 
@@ -226,6 +234,14 @@ run_longhorn_tests(){
 	## generate test pod manifest
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].args=['"${PYTEST_COMMAND_ARGS}"']' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].image="'${LONGHORN_TESTS_CUSTOM_IMAGE}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+
+    if [[ $BACKUP_STORE_TYPE = "s3" ]]; then
+      BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $1}' | sed 's/ *//'`
+      yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+    elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
+      BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
+      yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+    fi
 
 	set +x
 	## inject aws cloudprovider and credentials env variables from created secret


### PR DESCRIPTION
The variable `backup_store_type` is not available directly in the test from the Jenkins, so updating the test.yaml file while the Longhorn setup takes place based on Jenkins variable.


Signed-off-by: Khushboo <fnu.khushboo@suse.com>