### PR TITLE
Recurring job start just after minute start

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -20,6 +20,7 @@ from kubernetes.client import Configuration
 from kubernetes.stream import stream
 
 from kubernetes.client.rest import ApiException
+from datetime import datetime
 
 Ki = 1024
 Mi = (1024 * 1024)
@@ -4326,6 +4327,12 @@ def update_setting(client, name, value):
 
 
 def create_recurring_jobs(client, recurring_jobs):
+    for i in range(60):
+        current_time = datetime.utcnow()
+        if current_time.second == 0:
+            break
+        time.sleep(1)
+
     for name, spec in recurring_jobs.items():
         client.create_recurring_job(Name=name,
                                     Task=spec["task"],

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4327,11 +4327,7 @@ def update_setting(client, name, value):
 
 
 def create_recurring_jobs(client, recurring_jobs):
-    for i in range(60):
-        current_time = datetime.utcnow()
-        if current_time.second == 0:
-            break
-        time.sleep(1)
+    time.sleep(60 - datetime.utcnow().second)
 
     for name, spec in recurring_jobs.items():
         client.create_recurring_job(Name=name,

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -86,6 +86,8 @@ LABELS = "labels"
 DEFAULT = "default"
 SCHEDULE_1MIN = "* * * * *"
 
+WRITE_DATA_INTERVAL = 10
+
 
 def wait_until_begin_of_a_minute():
     while True:
@@ -421,7 +423,7 @@ def test_recurring_job_in_storageclass(set_random_backupstore, client, core_api,
     for pod_name in pod_names:
         write_pod_volume_random_data(core_api, pod_name, volume_data_path, 2)
 
-    time.sleep(140)  # 2.5 minutes - 10 secends
+    time.sleep(150)  # 2.5 minutes
 
     for volume_name in volume_info:  # NOQA
         volume = client.by_id_volume(volume_name)
@@ -471,7 +473,7 @@ def recurring_job_labels_test(client, labels, volume_name, size=SIZE, backing_im
 
     write_volume_random_data(volume)
 
-    time.sleep(65)  # 1 minute 15 second
+    time.sleep(75 - WRITE_DATA_INTERVAL)  # 1 minute 15 second
     labels["we-added-this-label"] = "definitely"
     update_recurring_job(client, RECURRING_JOB_NAME,
                          recurring_jobs[RECURRING_JOB_NAME][GROUPS],
@@ -658,7 +660,7 @@ def test_recurring_job_detached_volume(client, batch_v1_beta_api, volume_name): 
     check_recurring_jobs(client, recurring_jobs)
     wait_for_cron_job_count(batch_v1_beta_api, 1)
 
-    time.sleep(60 * 2 - 10)
+    time.sleep(60 * 2 - WRITE_DATA_INTERVAL)
     volume.attach(hostId=self_host)
     volume = wait_for_volume_healthy(client, volume_name)
     wait_for_snapshot_count(volume, 1)
@@ -1017,7 +1019,7 @@ def test_recurring_job_groups(set_random_backupstore, client, batch_v1_beta_api)
 
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
-    time.sleep(60 * 2 - 10)
+    time.sleep(60 * 2 - WRITE_DATA_INTERVAL)
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
     time.sleep(60)
@@ -1420,7 +1422,7 @@ def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1
 
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
-    time.sleep(60)
+    time.sleep(70 - WRITE_DATA_INTERVAL)
     wait_for_backup_count(client.by_id_backupVolume(volume2_name), 2)
     wait_for_backup_count(client.by_id_backupVolume(volume1_name), 1)
 
@@ -1551,13 +1553,13 @@ def test_recurring_job_backup(set_random_backupstore, client, batch_v1_beta_api)
     # 1st job
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
-    time.sleep(50)
+    time.sleep(60 - WRITE_DATA_INTERVAL)
     wait_for_backup_count(client.by_id_backupVolume(volume1_name), 1)
     wait_for_backup_count(client.by_id_backupVolume(volume2_name), 1)
 
     # 2nd job
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
-    time.sleep(60)
+    time.sleep(60 - WRITE_DATA_INTERVAL)
     wait_for_backup_count(client.by_id_backupVolume(volume1_name), 2)
     wait_for_backup_count(client.by_id_backupVolume(volume2_name), 2)

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -421,7 +421,7 @@ def test_recurring_job_in_storageclass(set_random_backupstore, client, core_api,
     for pod_name in pod_names:
         write_pod_volume_random_data(core_api, pod_name, volume_data_path, 2)
 
-    time.sleep(150)  # 2.5 minutes
+    time.sleep(140)  # 2.5 minutes - 10 secends
 
     for volume_name in volume_info:  # NOQA
         volume = client.by_id_volume(volume_name)
@@ -471,7 +471,7 @@ def recurring_job_labels_test(client, labels, volume_name, size=SIZE, backing_im
 
     write_volume_random_data(volume)
 
-    time.sleep(75)  # 1 minute 15 second
+    time.sleep(65)  # 1 minute 15 second
     labels["we-added-this-label"] = "definitely"
     update_recurring_job(client, RECURRING_JOB_NAME,
                          recurring_jobs[RECURRING_JOB_NAME][GROUPS],
@@ -658,9 +658,7 @@ def test_recurring_job_detached_volume(client, batch_v1_beta_api, volume_name): 
     check_recurring_jobs(client, recurring_jobs)
     wait_for_cron_job_count(batch_v1_beta_api, 1)
 
-    time.sleep(60 * 2)
-    wait_until_begin_of_a_minute()
-    time.sleep(5)
+    time.sleep(60 * 2 - 10)
     volume.attach(hostId=self_host)
     volume = wait_for_volume_healthy(client, volume_name)
     wait_for_snapshot_count(volume, 1)
@@ -1017,10 +1015,9 @@ def test_recurring_job_groups(set_random_backupstore, client, batch_v1_beta_api)
 
     wait_for_cron_job_count(batch_v1_beta_api, 2)
 
-    wait_until_begin_of_a_minute()
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
-    time.sleep(60 * 2)
+    time.sleep(60 * 2 - 10)
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
     time.sleep(60)
@@ -1423,7 +1420,7 @@ def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1
 
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
-    time.sleep(70)
+    time.sleep(60)
     wait_for_backup_count(client.by_id_backupVolume(volume2_name), 2)
     wait_for_backup_count(client.by_id_backupVolume(volume1_name), 1)
 
@@ -1554,7 +1551,7 @@ def test_recurring_job_backup(set_random_backupstore, client, batch_v1_beta_api)
     # 1st job
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
-    time.sleep(60)
+    time.sleep(50)
     wait_for_backup_count(client.by_id_backupVolume(volume1_name), 1)
     wait_for_backup_count(client.by_id_backupVolume(volume2_name), 1)
 


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>
From https://github.com/longhorn/longhorn/issues/3233, we have some flaky recurring job cases in daily run.

Most cases fail reason was timing issue. Longhorn recurring job started at  beginning of a minute, but our test cases will set recurring job directly (maybe at 55th second), then do some test steps then do sleep **whole** minute and check result in the end

Modified `create_recurring_jobs` and reduce sleep time in test cases.
