### PR TITLE
Check longhorn-nfs installed on worker node

### DIFF
--- a/manager/integration/tests/test_rwx.py
+++ b/manager/integration/tests/test_rwx.py
@@ -47,7 +47,12 @@ def nfs(request):
     cmd = ["kubectl", "apply", "-f", LONGHORN_NFS_INSTALLATION_URL]
     subprocess.check_output(cmd)
 
+    worker_cnt = 0
     node_list = api.list_node()
+    for node in node_list.items:
+        if "csi.volume.kubernetes.io/nodeid" in node.metadata.annotations:
+            worker_cnt = worker_cnt + 1
+
     cmd = ["kubectl get pod -l app={} | "
            "awk 'NR>1 {{print $1}}'".format(LONGHORN_NFS_DAEMONSET_NAME)]
     for i in range(RETRY_COUNTS):
@@ -60,7 +65,7 @@ def nfs(request):
                 api.read_namespaced_pod(name=pod_name,
                                         namespace='default').status.phase
 
-        if len(nfs_pods) == len(node_list.items):
+        if len(nfs_pods) == worker_cnt:
             if all(value == "Running" for value in nfs_pods.values()):
                 break
 
@@ -68,7 +73,7 @@ def nfs(request):
 
     if not \
             all(value == "Running" for value in nfs_pods.values()) \
-            or not len(nfs_pods) == len(node_list.items):
+            or not len(nfs_pods) == worker_cnt:
         raise Exception("Longhorn-nfs not installed on all nodes")
 
     def finalizer():

--- a/manager/integration/tests/test_rwx.py
+++ b/manager/integration/tests/test_rwx.py
@@ -41,8 +41,6 @@ def write_data_into_pod(pod_name_and_data_path):
 @pytest.fixture(scope="module", autouse="True")
 def nfs(request):
 
-    apps_api = get_apps_api_client()
-
     cmd = ["kubectl", "apply", "-f", LONGHORN_NFS_INSTALLATION_URL]
     subprocess.check_output(cmd)
 
@@ -51,8 +49,8 @@ def nfs(request):
     subprocess.check_output(cmd)
 
     def finalizer():
-        apps_api.delete_namespaced_daemon_set(name=LONGHORN_NFS_DAEMONSET_NAME,
-                                              namespace='default')
+        cmd = ["kubectl", "delete", "-f", LONGHORN_NFS_INSTALLATION_URL]
+        subprocess.check_output(cmd)
 
     request.addfinalizer(finalizer)
 


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>
From https://github.com/longhorn/longhorn/issues/2748

longhorn-nfs install failed in [nightly build](https://ci.longhorn.io/job/public/job/v1.2.x/job/v1.2.x-lh-tests-ubuntu-amd64/48/testReport/junit/tests/test_rwx/test_rwx_with_statefulset_multi_pods/), because `node_list = api.list_node()` will get non-worker node(we have 1 non-worker node in nightly build), but longhoron-nfs only install on worker node make `if len(nfs_pods) == len(node_list)` raise exception