### PR TITLE
change aws key pair name to avoid potential naming conflict

### DIFF
--- a/test_framework/terraform/aws/centos/main.tf
+++ b/test_framework/terraform/aws/centos/main.tf
@@ -219,7 +219,7 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 
 # Create AWS key pair
 resource "aws_key_pair" "lh_aws_pair_key" {
-  key_name   = format("%s_%s", "lh_aws_key_pair", md5(timestamp()))
+  key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
 }
 

--- a/test_framework/terraform/aws/oracle/main.tf
+++ b/test_framework/terraform/aws/oracle/main.tf
@@ -219,7 +219,7 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 
 # Create AWS key pair
 resource "aws_key_pair" "lh_aws_pair_key" {
-  key_name   = format("%s_%s", "lh_aws_key_pair", md5(timestamp()))
+  key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
 }
 

--- a/test_framework/terraform/aws/rhel/main.tf
+++ b/test_framework/terraform/aws/rhel/main.tf
@@ -219,7 +219,7 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 
 # Create AWS key pair
 resource "aws_key_pair" "lh_aws_pair_key" {
-  key_name   = format("%s_%s", "lh_aws_key_pair", md5(timestamp()))
+  key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
 }
 

--- a/test_framework/terraform/aws/rockylinux/main.tf
+++ b/test_framework/terraform/aws/rockylinux/main.tf
@@ -219,7 +219,7 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 
 # Create AWS key pair
 resource "aws_key_pair" "lh_aws_pair_key" {
-  key_name   = format("%s_%s", "lh_aws_key_pair", md5(timestamp()))
+  key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
 }
 

--- a/test_framework/terraform/aws/sles/main.tf
+++ b/test_framework/terraform/aws/sles/main.tf
@@ -219,7 +219,7 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 
 # Create AWS key pair
 resource "aws_key_pair" "lh_aws_pair_key" {
-  key_name   = format("%s_%s", "lh_aws_key_pair", md5(timestamp()))
+  key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
 }
 

--- a/test_framework/terraform/aws/ubuntu/main.tf
+++ b/test_framework/terraform/aws/ubuntu/main.tf
@@ -219,7 +219,7 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 
 # Create AWS key pair
 resource "aws_key_pair" "lh_aws_pair_key" {
-  key_name   = format("%s_%s", "lh_aws_key_pair", md5(timestamp()))
+  key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
 }
 


### PR DESCRIPTION
Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@suse.com>