### PR TITLE
fix rhel missing architecture variable

### DIFF
--- a/test_framework/terraform/aws/rhel/data.tf
+++ b/test_framework/terraform/aws/rhel/data.tf
@@ -1,6 +1,6 @@
 # Query AWS for RHEL AMI
 locals {
-  aws_ami_centos_arch = var.arch == "amd64" ? "x86_64" : var.arch
+  aws_ami_rhel_arch = var.arch == "amd64" ? "x86_64" : var.arch
 }
 
 data "aws_ami" "aws_ami_rhel" {


### PR DESCRIPTION
Fixes https://ci.longhorn.io/job/public/job/master/job/rhel/job/amd64/job/longhorn-tests-rhel-amd64/35/console

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@suse.com>