### PR TITLE
Change backup count to reflect retain count in test_recurring_job

### DIFF
--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -259,12 +259,11 @@ def test_recurring_job(set_random_backupstore, client, volume_name):  # NOQA
         elif "backup2-" in b.snapshot:
             complete_backup_2_count += 1
 
-    # 2 completed backups from backup1
-    # 2 or more completed backups from backup2
+    # 1 completed backups from backup1
+    # 2 completed backups from backup2
     # NOTE: NFS backup can be slow sometimes and error prone
-    assert complete_backup_1_count == 2
-    assert complete_backup_2_count >= 2
-    assert complete_backup_2_count < 4
+    assert complete_backup_1_count == 1
+    assert complete_backup_2_count == 2
 
 
 @pytest.mark.recurring_job  # NOQA


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>
After https://github.com/longhorn/longhorn/issues/627 and https://github.com/longhorn/longhorn/issues/3035 closed, backup count in recurring job will reflect by retain count correctly.

Modified test_recurring_job(), make it match longhorn behavior.