### PR TITLE
Add case skeleton for checking kubelet status while workload with subpath

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4564,9 +4564,10 @@ def restart_k3s_agent():
     subprocess.check_call(cmd)
 
 def check_k3s_agent_log(keyword, minutes=60*3):
-    # Check the keyword in k3s-agent log for x minutes every second of the output
+    # Check the keyword in k3s-agent log for 3 minutes then check RETRY_COMMAND_COUNT times of the log
     cmd = ['journalctl -u k3s-agent | grep -i ' + keyword]
-    for _ in range(minutes*60):
+    time.sleep(minutes*60)
+    for _ in range(RETRY_COMMAND_COUNT):
         output = subprocess.check_output(cmd)
         if keyword in output:
             return True

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4563,9 +4563,12 @@ def restart_k3s_agent():
     cmd = ['service k3s-agent restart']
     subprocess.check_call(cmd)
 
-def check_k3s_agent_log(keyword):
-    cmd = ['journalctl -u k3s-agent']
-    output = subprocess.check_output(cmd)
-    if keyword in output:
-        return True
+def check_k3s_agent_log(keyword, minutes=60*3):
+    # Check the keyword in k3s-agent log for x minutes every second of the output
+    cmd = ['journalctl -u k3s-agent | grep -i ' + keyword]
+    for _ in range(minutes*60):
+        output = subprocess.check_output(cmd)
+        if keyword in output:
+            return True
+        time.sleep(1)
     return False

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4558,3 +4558,14 @@ def restore_backup_and_get_data_checksum(client, core_api, backup, pod,
                                      'default')
 
     return data_checksum, output, restore_pod_name
+
+def restart_k3s_agent():
+    cmd = ['service k3s-agent restart']
+    subprocess.check_call(cmd)
+
+def check_k3s_agent_log(keyword):
+    cmd = ['journalctl -u k3s-agent']
+    output = subprocess.check_output(cmd)
+    if keyword in output:
+        return True
+    return False

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4558,18 +4558,3 @@ def restore_backup_and_get_data_checksum(client, core_api, backup, pod,
                                      'default')
 
     return data_checksum, output, restore_pod_name
-
-def restart_k3s_agent():
-    cmd = ['service k3s-agent restart']
-    subprocess.check_call(cmd)
-
-def check_k3s_agent_log(keyword, minutes=60*3):
-    # Check the keyword in k3s-agent log for 3 minutes then check RETRY_COMMAND_COUNT times of the log
-    cmd = ['journalctl -u k3s-agent | grep -i ' + keyword]
-    time.sleep(minutes*60)
-    for _ in range(RETRY_COMMAND_COUNT):
-        output = subprocess.check_output(cmd)
-        if keyword in output:
-            return True
-        time.sleep(1)
-    return False

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -2141,6 +2141,23 @@ def test_auto_remount_with_subpath(client, core_api, storage_class, sts_name, st
     assert expect_md5sum == md5sum
 
 
+@pytest.mark.skip(reason="WAIT_FOR_UPSTREAM_FIX") # NOQA
+@pytest.mark.skipif( "k3s" not in k8s_api_client.status.node_info.kubelet_version, reason='This test is only compaitable with k3s')  # NOQA
+def test_restart_kubelete_when_pod_with_subpath():
+    """
+    Related issue 3080:
+    https://github.com/longhorn/longhorn/issues/3080
+
+    Steps:
+    0. Check if the cluster runs with k3s
+    1. Create deployment with subpath with pods on the same targeting-node
+    2. Wait for pods become Running
+    3. Restart k3s kubelet-agent service
+    4. Wait for new pods become Running
+    5. Check kubelet log from the targeting-node
+    """
+
+
 def test_reuse_failed_replica(client, core_api, volume_name): # NOQA
     """
     Steps:


### PR DESCRIPTION
Context: https://github.com/longhorn/longhorn/issues/3080

Competition checklist:
- [X] Manual steps
- [X] Case skeleton
- [ ] Working test case
  - [ ] Deploy the testing workload programmatically 
  - [X] Functions to restart and check k3s kubelet agent logs