### PR TITLE
Fix flaky test_statefulset_restore

### DIFF
--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -70,7 +70,7 @@ def create_and_test_backups(api, cli, pod_info):
             backups = bv.backupList().data
             for b in backups:
                 if b['snapshotName'] == pod['backup_snapshot']['name']\
-                                     and len(b.url) > 0:
+                        and b['state'] == 'Completed':
                     found = True
                     break
             if found:

--- a/manager/integration/tests/test_statefulset.py
+++ b/manager/integration/tests/test_statefulset.py
@@ -69,7 +69,8 @@ def create_and_test_backups(api, cli, pod_info):
         for i in range(DEFAULT_BACKUP_TIMEOUT):
             backups = bv.backupList().data
             for b in backups:
-                if b['snapshotName'] == pod['backup_snapshot']['name']:
+                if b['snapshotName'] == pod['backup_snapshot']['name']\
+                                     and len(b.url) > 0:
                     found = True
                     break
             if found:


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

From https://github.com/longhorn/longhorn/issues/3451

From script point of view, this case was flaky was due to when we search backup to restore(the backup just completed by test scenario), we should wait backup URL generated then go to do next step. 

Or we will restore an snapshot without backupstore url as below, and will cause e2e cases error
`'created': '', 'error': '', 'labels': None, 'messages': None, 'name': 'backup-a0eb0c351efc4668', 'progress': 0, 'size': '', 'snapshotCreated': '', 'snapshotName': '953a4c79-89e0-400b-b449-d956780ea5b5', 'state': '', 'url': '', 'volumeBackingImageName': '', 'volumeCreated': '', 'volumeName': 'pvc-084a2fc0-f29f-45fd-843e-9105cc4549fb', 'volumeSize': ''}`  

Correct format will be something like below
`{'created': '2022-01-04T06:49:47Z', 'error': '', 'labels': {'KubernetesStatus': '{"pvName":"pvc-c8cf017a-1aac-4f8c-86df-73f6072324b4","pvStatus":"Bound","namespace":"default","pvcName":"pod-data-statefulset-restore-test-1","lastPVCRefAt":"","workloadsStatus":[{"podName":"statefulset-restore-test-1","podStatus":"Running","workloadName":"statefulset-restore-test","workloadType":"StatefulSet"}],"lastPodRefAt":""}'}, 'messages': None, 'name': 'backup-7f89fabd1b19412c', 'progress': 100, 'size': '134217728', 'snapshotCreated': '2022-01-04T06:49:44Z', 'snapshotName': '3576c2da-91ce-4a25-951f-14044bfd3638', 'state': 'Completed', 'url': 'nfs://longhorn-test-nfs-svc.default:/opt/backupstore?backup=backup-7f89fabd1b19412c&volume=pvc-c8cf017a-1aac-4f8c-86df-73f6072324b4', 'volumeBackingImageName': '', 'volumeCreated': '2022-01-04T06:49:44Z', 'volumeName': 'pvc-c8cf017a-1aac-4f8c-86df-73f6072324b4', 'volumeSize': '3221225472'}`