### PR TITLE
Fix arch arm64 test_node_off  fail

### DIFF
--- a/manager/integration/tests/aws.py
+++ b/manager/integration/tests/aws.py
@@ -31,6 +31,18 @@ class aws(cloudprovider):
             aws_secret_access_key=secret_access_key,
             region_name=default_region)
 
+    def instance_id_by_ip(self, instance_ip):
+        response = aws.ec2_client.describe_instances(
+            Filters=[
+                {
+                    'Name': 'private-ip-address',
+                    'Values': [instance_ip]
+                },
+            ],
+        )
+
+        return response['Reservations'][0]['Instances'][0]['InstanceId']
+
     def instance_id(self, instance_name):
         response = aws.ec2_client.describe_instances(
             Filters=[

--- a/manager/integration/tests/test_infra.py
+++ b/manager/integration/tests/test_infra.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import time
+import subprocess
 
 from aws import aws
 
@@ -94,38 +95,90 @@ def wait_for_node_down_longhorn(node_name, longhorn_api_client):
     return longhorn_node_down
 
 
+def wait_for_node_down_aws(cloudprovider, node):
+
+    aws_node_down = False
+    for i in range(RETRY_COUNTS):
+        if cloudprovider.instance_status(node) == 'stopped':
+            aws_node_down = True
+            break
+        else:
+            time.sleep(RETRY_INTERVAL)
+            continue
+
+    return aws_node_down
+
+
+def wait_for_node_up_aws(cloudprovider, node):
+
+    aws_node_up = False
+    for i in range(RETRY_COUNTS):
+        if cloudprovider.instance_status(node) == 'running':
+            aws_node_up = True
+            break
+        else:
+            time.sleep(RETRY_INTERVAL)
+            continue
+
+    return aws_node_up
+
+
+def is_infra_k3s():
+
+    exec_cmd = ["kubectl", "version"]
+    if "k3s" in str(subprocess.check_output(exec_cmd)):
+        return True
+    else:
+        return False
+
+
 @pytest.fixture
 def reset_cluster_ready_status(request):
     yield
     node_worker_label = 'node-role.kubernetes.io/worker'
+    node_controlplane_label = 'node-role.kubernetes.io/control-plane'
+    node_ip_annotation = "flannel.alpha.coreos.com/public-ip"
 
     k8s_api_client = get_core_api_client()
     longhorn_api_client = get_longhorn_api_client()
     cloudprovider = detect_cloudprovider()
 
+    k3s = is_infra_k3s()
+
     for node_item in k8s_api_client.list_node().items:
-        if node_worker_label in node_item.metadata.labels and \
-                node_item.metadata.labels[node_worker_label] == 'true':
-            node_name = node_item.metadata.name
 
-            if is_node_ready_k8s(node_name, k8s_api_client) is False:
-                node = cloudprovider.instance_id(node_name)
-
-                cloudprovider.instance_start(node)
-
-                node_up_k8s = wait_for_node_up_k8s(node_name,
-                                                   k8s_api_client)
-
-                assert node_up_k8s
-
+        if k3s is True:
+            if node_controlplane_label not in node_item.metadata.labels:
+                node_name = node_item.metadata.name
+                node_ip = node_item.metadata.annotations[node_ip_annotation]
+                node = cloudprovider.instance_id_by_ip(node_ip)
             else:
                 continue
 
-            node_up_longhorn =\
-                wait_for_node_up_longhorn(node_name,
-                                          longhorn_api_client)
+        else:
+            if node_worker_label in node_item.metadata.labels and \
+                    node_item.metadata.labels[node_worker_label] == 'true':
+                node_name = node_item.metadata.name
+                node = cloudprovider.instance_id(node_name)
+            else:
+                continue
 
-            assert node_up_longhorn
+        if is_node_ready_k8s(node_name, k8s_api_client) is False:
+
+            cloudprovider.instance_start(node)
+            wait_for_node_up_aws(cloudprovider, node)
+            node_up_k8s =\
+                wait_for_node_up_k8s(node_name, k8s_api_client)
+
+            assert node_up_k8s
+
+        else:
+            continue
+
+        node_up_longhorn =\
+            wait_for_node_up_longhorn(node_name, longhorn_api_client)
+
+        assert node_up_longhorn
 
 
 @pytest.mark.infra
@@ -138,6 +191,8 @@ def test_offline_node(reset_cluster_ready_status):
     """
     node_worker_label = 'node-role.kubernetes.io/worker'
     pod_lable_selector = "longhorn-test=test-job"
+    node_controlplane_label = 'node-role.kubernetes.io/control-plane'
+    node_ip_annotation = "flannel.alpha.coreos.com/public-ip"
 
     k8s_api_client = get_core_api_client()
     longhorn_api_client = get_longhorn_api_client()
@@ -149,19 +204,30 @@ def test_offline_node(reset_cluster_ready_status):
         if pod.metadata.name == "longhorn-test":
             longhorn_test_node_name = pod.spec.node_name
 
-    for node_item in k8s_api_client.list_node().items:
-        if node_worker_label in node_item.metadata.labels and \
-                node_item.metadata.labels[node_worker_label] == 'true':
-            node_name = node_item.metadata.name
-            if node_name == longhorn_test_node_name:
-                continue
-            else:
-                break
+    k3s = is_infra_k3s()
 
-    node = cloudprovider.instance_id(node_name)
+    for node_item in k8s_api_client.list_node().items:
+        if k3s is True:
+            if node_controlplane_label not in node_item.metadata.labels:
+                node_name = node_item.metadata.name
+                node_ip = node_item.metadata.annotations[node_ip_annotation]
+                if node_name == longhorn_test_node_name:
+                    continue
+                else:
+                    node = cloudprovider.instance_id_by_ip(node_ip)
+                    break
+        else:
+            if node_worker_label in node_item.metadata.labels and \
+                    node_item.metadata.labels[node_worker_label] == 'true':
+                node_name = node_item.metadata.name
+                if node_name == longhorn_test_node_name:
+                    continue
+                else:
+                    node = cloudprovider.instance_id(node_name)
+                    break
 
     cloudprovider.instance_stop(node)
-
+    wait_for_node_down_aws(cloudprovider, node)
     k8s_node_down = wait_for_node_down_k8s(node_name, k8s_api_client)
 
     assert k8s_node_down


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

Our E2E test_node_off always fail when ran on arch arm64, that's because we use k3s as infra in arm64 but rke in amd64.

In test steps we use `metadata.labels` from k8s API to select one **worker** node and turn off it to do test.
In rke , label `node-role.kubernetes.io/worker=true` tell script this is worker node, but in k3s there are none label for worker nodes(so script always fail), only label `node-role.kubernetes.io/control-plane` for controlplane

**rke worker node**
```
'labels': { 'beta.kubernetes.io/arch=amd64',
                beta.kubernetes.io/os=linux',
                cattle.io/creator=norman',
                kubernetes.io/arch=amd64',
                kubernetes.io/hostname=worker1',
                kubernetes.io/os=linux',
                node-role.kubernetes.io/worker=true',
                node-role.kubernetes.io/etcd=true'},
```
**k3s controlplane node (no specific label for worker node)**
```
'labels': {'beta.kubernetes.io/arch': 'arm64',
              'beta.kubernetes.io/instance-type': 'k3s',
              'beta.kubernetes.io/os': 'linux',
              'kubernetes.io/arch': 'arm64',
              'kubernetes.io/hostname': 'ip-10-251-3-13',
              'kubernetes.io/os': 'linux',
              'node-role.kubernetes.io/control-plane': 'true',
              'node-role.kubernetes.io/master': 'true',
              'node.kubernetes.io/instance-type': 'k3s'},
```
So I modified code to match k3s infra
And in k3s(arm64), it need use private IP to get aws instance ID, cannot use node_name
Also I added function to wait aws node really down and up for review, thanks.

arm64 test result: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/641/testReport/tests/test_infra/
amd64 test result: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/642/testReport/tests/test_infra/
