### PR TITLE
Add assert message in wait_for_volume_status

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1578,7 +1578,8 @@ def wait_for_volume_status(client, name, key, value):
         if volume[key] == value:
             break
         time.sleep(RETRY_INTERVAL)
-    assert volume[key] == value
+    assert volume[key] == value, f" value={value}\n. \
+            volume[key]={volume[key]}\n. volume={volume}"
     return volume
 
 


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

Recently e2e daily build get increased fail number related to backup 
https://ci.longhorn.io/job/public/job/master/job/ubuntu/job/amd64/job/longhorn-tests-ubuntu-amd64/554/
https://ci.longhorn.io/job/public/job/master/job/ubuntu/job/amd64/job/longhorn-tests-ubuntu-amd64/553/

Most error encountered in wait_for_volume_status().
Did try reproduce but the error situation can not be reproduced, so I would like to add assert message to observe when the backup failure happen again. on build pipeline, thank you.

cc @khushboo-rancher 