### PR TITLE
Build test engine image for amd64 and arm 64 

### DIFF
--- a/test_engine/.gitignore
+++ b/test_engine/.gitignore
@@ -1,0 +1,18 @@
+.tox
+.cache
+__pycache__
+*.pyc
+MANIFEST
+validationTestsJunit.xml
+.bash_history
+*.DS_Store
+terraform/aws/ubuntu/*.hcl
+terraform/aws/ubuntu/*.tfstate
+
+# build files
+.dapper
+
+# ignores all goland project folders and files
+.idea/
+*.iml
+*.ipr

--- a/test_engine/build_test_engine.py
+++ b/test_engine/build_test_engine.py
@@ -1,0 +1,244 @@
+import paramiko
+import subprocess
+import yaml
+import os
+import pathlib
+import json
+import time
+
+docker_id = os.getenv("docker_id")
+docker_pwd = os.getenv("docker_pwd")
+docker_repo = os.getenv("docker_repo")
+
+RETRY_INTERVAL = 0.5
+
+os.environ['TF_VAR_tf_workspace'] \
+    = str(pathlib.Path(__file__).parent.absolute())
+
+# TF_VAR_build_engine_aws_access_key
+# TF_VAR_build_engine_aws_secret_key
+
+
+def get_image_names():
+
+    global CLIAPIVersion
+    global CLIAPIMinVersion
+    global ControllerAPIVersion
+    global ControllerAPIMinVersion
+    global DataFormatVersion
+    global DataFormatMinVersion
+    global docker_tag
+
+    version = subprocess.check_output("{}/scripts/get_version.sh".format(
+                            pathlib.Path(__file__).parent.absolute()))
+
+    version = json.loads(version)
+
+    CLIAPIVersion = \
+        str(version["clientVersion"]["cliAPIVersion"])
+    CLIAPIMinVersion = \
+        str(version["clientVersion"]["cliAPIMinVersion"])
+    ControllerAPIVersion = \
+        str(version["clientVersion"]["controllerAPIVersion"])
+    ControllerAPIMinVersion = \
+        str(version["clientVersion"]["controllerAPIMinVersion"])
+    DataFormatVersion = \
+        str(version["clientVersion"]["dataFormatVersion"])
+    DataFormatMinVersion = \
+        str(version["clientVersion"]["dataFormatMinVersion"])
+
+    docker_tag = "{}-{}.{}-{}.{}-{}".format(
+        CLIAPIVersion, CLIAPIMinVersion,
+        ControllerAPIVersion, ControllerAPIMinVersion,
+        DataFormatVersion, DataFormatMinVersion)
+
+    version_tag1 = "{}-{}.{}-{}.{}-{}".format(
+        int(CLIAPIMinVersion) - 1, int(CLIAPIMinVersion) - 1,
+        ControllerAPIVersion, ControllerAPIMinVersion,
+        DataFormatVersion, DataFormatMinVersion)
+
+    version_tag2 = "{}-{}.{}-{}.{}-{}".format(
+        int(CLIAPIVersion) + 1, int(CLIAPIVersion) + 1,
+        ControllerAPIVersion, ControllerAPIMinVersion,
+        DataFormatVersion, DataFormatMinVersion)
+
+    upgrade_image = "{0}:upgrade-test.{1}".format(docker_repo, docker_tag)
+    version_image1 = "{0}:version-test.{1}".format(docker_repo, version_tag1)
+    version_image2 = "{0}:version-test.{1}".format(docker_repo, version_tag2)
+
+    print(upgrade_image)
+    print(version_image1)
+    print(version_image2)
+
+    return upgrade_image, version_image1, version_image2
+
+
+def __exec_command(ip, username, commands):
+
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.connect(ip, username=username, key_filename=os.path.expanduser(
+                    os.path.join("~", ".ssh", "id_rsa")), timeout=1500)
+
+    stdin, stdout, stderr = client.exec_command(commands)
+
+    while int(stdout.channel.recv_exit_status()) != 0:
+        time.sleep(RETRY_INTERVAL)
+
+    output = stdout.readlines()
+
+    client.close()
+
+    print(output)
+
+    return output
+
+
+def add_manifest(upgrade_image, version_image1, version_image2):
+
+    # upgrade image
+    commands = 'docker login -u={0} -p={1};\
+        docker manifest create {2} \\{2}-amd64 \\{2}-arm64;\
+        docker manifest push {2}'\
+            .format(docker_id, docker_pwd, upgrade_image)
+    print(commands)
+    subprocess.run(commands, shell=True)
+
+    # version image
+    commands = '\
+        docker manifest create {0} \\{0}-amd64 \\{0}-arm64;\
+        docker manifest push {0}'\
+            .format(version_image1)
+    print(commands)
+    subprocess.run(commands, shell=True)
+
+    # version image
+    commands = '\
+        docker manifest create {0} \\{0}-amd64 \\{0}-arm64;\
+        docker manifest push {0}'\
+            .format(version_image2)
+    print(commands)
+    subprocess.run(commands, shell=True)
+
+
+def generate_test_images():
+
+    # arch : amd64 arm64
+    upgrade_image, version_image1, version_image2 = get_image_names()
+    build_images("amd64", upgrade_image, version_image1, version_image2)
+    build_images("arm64", upgrade_image, version_image1, version_image2)
+    add_manifest(upgrade_image, version_image1, version_image2)
+
+
+def build_images(arch, upgrade_image, version_image1, version_image2):
+
+    os.environ['TF_VAR_build_engine_arch'] = arch
+
+    if arch == "amd64":
+
+        os.environ['TF_VAR_build_engine_aws_instance_type'] = 't2.xlarge'
+
+    elif arch == "arm64":
+
+        os.environ['TF_VAR_build_engine_aws_instance_type'] = 'a1.xlarge'
+
+    subprocess.check_output("{}/scripts/terraform_instance.sh".format(
+                            pathlib.Path(__file__).parent.absolute()))
+
+    f = open("{}/config.yml".format(pathlib.Path(__file__).parent.absolute()))
+    data = yaml.safe_load(f)
+    ip = data['nodes'][0]['address']
+    username = data['nodes'][0]['user']
+    f.close()
+
+    # upgrade test image
+    print("Start build {} upgrade test image ...".format(arch))
+    print("This may take awhile...")
+
+    commands = 'git clone https://github.com/longhorn/longhorn-engine.git;\
+            sed -i "s/.*ARG DAPPER_HOST_ARCH=.*/ARG DAPPER_HOST_ARCH={0}/" \
+                longhorn-engine/Dockerfile.dapper;\
+            cd longhorn-engine;\
+            echo -en test >> README.md;\
+            git config --global user.email "mock@gmail.com";\
+            git config --global user.name "mock";\
+            git commit -a -m "make commit number diff";\
+            sleep 30;\
+            sudo usermod -aG docker ubuntu;\
+            sudo make build;\
+            sudo make package'.format(arch)
+
+    __exec_command(ip, username, commands)
+
+    commands = "docker login -u={0} -p={1}; \
+                docker images".format(docker_id, docker_pwd)
+
+    output = __exec_command(ip, username, commands)
+
+    for line in output:
+        if "longhornio/longhorn-engine" in line:
+            image_id = line.split()[2]
+            break
+
+    print("Pushing {} upgrade test image ...".format(arch))
+
+    commands = 'docker tag {0} {1}-{2};\
+                docker push {1}-{2}'.format(
+                    image_id, upgrade_image, arch)
+
+    __exec_command(ip, username, commands)
+
+    print("Pushing {} upgrade test docker image done.".format(arch))
+
+    # version test image
+    print("Start build {} version test image ...".format(arch))
+    print("This may take awhile...")
+
+    # remove sed part after really use longhon-test repo
+    commands = 'git clone https://github.com/longhorn/longhorn-tests.git;\
+            cd ~/longhorn-tests/manager/test_containers/compatibility;\
+            sed -i "s/.*docker build -t longhornio\\/longhorn-test.*/\
+                docker build -t {0}-{1} package/" generate_version_image.sh;\
+            '.format(version_image1.replace('/', '\\/'), arch)
+    __exec_command(ip, username, commands)
+
+    commands = 'cd ~/longhorn-tests/manager/test_containers/compatibility;\
+            ./generate_version_image.sh {0} {1} {2} {3} {4} {5}'\
+                .format(int(CLIAPIMinVersion) - 1, int(CLIAPIMinVersion) - 1,
+                        ControllerAPIVersion, ControllerAPIMinVersion,
+                        DataFormatVersion, DataFormatMinVersion)
+    __exec_command(ip, username, commands)
+
+    print("Pushing {} version test image ...".format(arch))
+    commands = 'docker push {}-{}'.format(version_image1, arch)
+    __exec_command(ip, username, commands)
+
+    commands = 'rm -rf longhorn-tests'
+    __exec_command(ip, username, commands)
+
+    # remove sed part after really use longhon-test repo
+    commands = 'git clone https://github.com/longhorn/longhorn-tests.git;\
+            cd ~/longhorn-tests/manager/test_containers/compatibility;\
+            sed -i "s/.*docker build -t longhornio\\/longhorn-test.*/\
+                docker build -t {0}-{1} package/" generate_version_image.sh;\
+            '.format(version_image2.replace('/', '\\/'), arch)
+    __exec_command(ip, username, commands)
+
+    commands = 'cd ~/longhorn-tests/manager/test_containers/compatibility;\
+            ./generate_version_image.sh {0} {1} {2} {3} {4} {5}'\
+                .format(int(CLIAPIVersion) + 1, int(CLIAPIVersion) + 1,
+                        ControllerAPIVersion, ControllerAPIMinVersion,
+                        DataFormatVersion, DataFormatMinVersion)
+    __exec_command(ip, username, commands)
+
+    print("Pushing {} version test image ...".format(arch))
+    commands = 'docker push {}-{}'.format(version_image2, arch)
+    __exec_command(ip, username, commands)
+
+    subprocess.check_output("{}/scripts/cleanup.sh".format(
+                            pathlib.Path(__file__).parent.absolute()))
+
+
+if __name__ == "__main__":
+
+    generate_test_images()

--- a/test_engine/config.yml
+++ b/test_engine/config.yml
@@ -1,0 +1,4 @@
+"nodes":
+- "address": "3.135.100.63"
+  "hostname_override": "build_test_engine_node-0-x1saborr"
+  "user": "ubuntu"

--- a/test_engine/requirements.txt
+++ b/test_engine/requirements.txt
@@ -1,0 +1,3 @@
+paramiko==2.9.2
+pytest==5.3.1
+pytest-repeat==0.9.1

--- a/test_engine/scripts/cleanup.sh
+++ b/test_engine/scripts/cleanup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [[ ! -v TF_VAR_tf_workspace ]]; then
+	export TF_VAR_tf_workspace="$(dirname $(dirname -- $(readlink -fn -- "$0")))"
+fi
+
+# terminate any terraform processes
+TERRAFORM_PIDS=( `ps aux | grep -i terraform | grep -v grep | awk '{printf("%s ",$1)}'` )
+if [[ -n ${TERRAFORM_PIDS[@]} ]] ; then
+	for PID in "${TERRAFORM_PIDS[@]}"; do
+		kill "${TERRAFORM_PIDS}"
+	done
+fi
+
+# wait 30 seconds for graceful terraform termination
+sleep 30
+
+terraform -chdir=${TF_VAR_tf_workspace}/terraform/aws/ubuntu destroy -auto-approve -no-color

--- a/test_engine/scripts/flake8-check.sh
+++ b/test_engine/scripts/flake8-check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+source test_engine/.venv/bin/activate
+
+pip install -r test_engine/requirements.txt
+
+flake8 test_engine/
+
+if [[ $? -eq 0 ]] ; then
+    echo "flake8 check succeed"
+    exit 0
+else
+    echo "flake8 check failed"
+    exit 1
+fi

--- a/test_engine/scripts/provision.sh
+++ b/test_engine/scripts/provision.sh
@@ -1,0 +1,9 @@
+#!/bin/bash 
+
+DOCKER_VERSION=19.03
+
+apt-get update 
+
+apt-get install -y build-essential git 
+
+curl https://releases.rancher.com/install-docker/${DOCKER_VERSION}.sh | sh

--- a/test_engine/terraform/aws/ubuntu/data.tf
+++ b/test_engine/terraform/aws/ubuntu/data.tf
@@ -1,0 +1,10 @@
+# Query AWS for Ubuntu AMI
+data "aws_ami" "aws_ami_ubuntu" {
+  most_recent      = true
+  owners           = [var.aws_ami_ubuntu_account_number]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu*${var.distro_version}-${var.build_engine_arch}-server-*"]
+  }
+}

--- a/test_engine/terraform/aws/ubuntu/main.tf
+++ b/test_engine/terraform/aws/ubuntu/main.tf
@@ -1,0 +1,321 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  access_key = var.build_engine_aws_access_key
+  secret_key = var.build_engine_aws_secret_key
+}
+
+# Create a random string suffix for instance names
+resource "random_string" "random_suffix" {
+  length           = 8
+  special          = false
+  lower            = true
+  upper            = false
+}
+
+# Create a VPC
+resource "aws_vpc" "build_engine_aws_vpc" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "${var.build_engine_aws_vpc_name}-${random_string.random_suffix.id}"
+  }
+}
+
+# Create internet gateway
+resource "aws_internet_gateway" "build_engine_aws_igw" {
+  vpc_id = aws_vpc.build_engine_aws_vpc.id
+
+  tags = {
+    Name = "build_engine_igw"
+  }
+}
+
+# Create controlplane security group
+resource "aws_security_group" "build_engine_aws_secgrp_controlplane" {
+  name        = "build_engine_aws_secgrp_controlplane"
+  description = "Allow all inbound traffic"
+  vpc_id      = aws_vpc.build_engine_aws_vpc.id
+
+  ingress {
+    description = "Allow SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow k8s API server port"
+    from_port   = 6443
+    to_port     = 6443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow k8s API server port"
+    from_port   = 2379
+    to_port     = 2379
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow UDP connection for longhorn-webhooks"
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "udp"
+    cidr_blocks = ["10.0.0.0/8"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "build_engine_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+  }
+}
+
+
+# Create worker security group
+resource "aws_security_group" "build_engine_aws_secgrp_worker" {
+  name        = "build_engine_aws_secgrp_worker"
+  description = "Allow all inbound traffic"
+  vpc_id      = aws_vpc.build_engine_aws_vpc.id
+
+  ingress {
+    description = "Allow All Traffic from VPC CIDR block"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [aws_vpc.build_engine_aws_vpc.cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "build_engine_aws_sec_grp_worker-${random_string.random_suffix.id}"
+  }
+}
+
+
+# Create Public subnet
+resource "aws_subnet" "build_engine_aws_public_subnet" {
+  vpc_id     = aws_vpc.build_engine_aws_vpc.id
+  availability_zone = var.aws_availability_zone
+  cidr_block = "10.0.1.0/24"
+
+  tags = {
+    Name = "build_engine_public_subnet-${random_string.random_suffix.id}"
+  }
+}
+
+# Create private subnet
+resource "aws_subnet" "build_engine_aws_private_subnet" {
+  vpc_id     = aws_vpc.build_engine_aws_vpc.id
+  availability_zone = var.aws_availability_zone
+  cidr_block = "10.0.2.0/24"
+
+  tags = {
+    Name = "build_engine_private_subnet-${random_string.random_suffix.id}"
+  }
+}
+
+# Create EIP for NATGW
+resource "aws_eip" "build_engine_aws_eip_nat_gw" {
+  vpc      = true
+
+  tags = {
+    Name = "build_engine_eip_nat_gw-${random_string.random_suffix.id}"
+  }
+}
+
+# Create nat gateway
+resource "aws_nat_gateway" "build_engine_aws_nat_gw" {
+  depends_on = [
+    aws_internet_gateway.build_engine_aws_igw,
+    aws_eip.build_engine_aws_eip_nat_gw,
+    aws_subnet.build_engine_aws_public_subnet,
+    aws_subnet.build_engine_aws_private_subnet
+  ]
+
+  allocation_id = aws_eip.build_engine_aws_eip_nat_gw.id
+  subnet_id     = aws_subnet.build_engine_aws_public_subnet.id
+
+  tags = {
+    Name = "build_engine_eip_nat_gw-${random_string.random_suffix.id}"
+  }
+}
+
+
+# Create route table for public subnets
+resource "aws_route_table" "build_engine_aws_public_rt" {
+  depends_on = [
+    aws_internet_gateway.build_engine_aws_igw,
+  ]
+
+  vpc_id = aws_vpc.build_engine_aws_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.build_engine_aws_igw.id
+  }
+
+  tags = {
+    Name = "build_engine_aws_public_rt-${random_string.random_suffix.id}"
+  }
+}
+
+# Create route table for private subnets
+resource "aws_route_table" "build_engine_aws_private_rt" {
+  depends_on = [
+    aws_nat_gateway.build_engine_aws_nat_gw
+  ]
+
+  vpc_id = aws_vpc.build_engine_aws_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_nat_gateway.build_engine_aws_nat_gw.id
+  }
+
+  tags = {
+    Name = "build_engine_aws_private_rt-${random_string.random_suffix.id}"
+  }
+}
+
+# Assciate public subnet to public route table
+resource "aws_route_table_association" "build_engine_aws_public_subnet_rt_association" {
+  depends_on = [
+    aws_subnet.build_engine_aws_public_subnet,
+    aws_route_table.build_engine_aws_public_rt
+  ]
+
+  subnet_id      = aws_subnet.build_engine_aws_public_subnet.id
+  route_table_id = aws_route_table.build_engine_aws_public_rt.id
+}
+
+# Assciate private subnet to private route table
+resource "aws_route_table_association" "build_engine_aws_private_subnet_rt_association" {
+  depends_on = [
+    aws_subnet.build_engine_aws_private_subnet,
+    aws_route_table.build_engine_aws_private_rt
+  ]
+
+  subnet_id      = aws_subnet.build_engine_aws_private_subnet.id
+  route_table_id = aws_route_table.build_engine_aws_private_rt.id
+}
+
+# Create AWS key pair
+resource "aws_key_pair" "build_engine_aws_pair_key" {
+  key_name   = format("%s_%s", "build_engine_aws_key_pair", "${random_string.random_suffix.id}")
+  public_key = file(var.aws_ssh_public_key_file_path)
+}
+
+/*
+# Create cluster secret (used for k3s on arm64 only)
+resource "random_password" "k3s_cluster_secret" {
+  length = var.arch == "arm64" ? 64 : 0
+  special = false
+}
+*/
+
+# Create controlplane instances
+resource "aws_instance" "build_engine_aws_instance" {
+ depends_on = [
+    aws_subnet.build_engine_aws_public_subnet,
+  ]
+
+  count = var.build_engine_aws_instance_count
+
+  availability_zone = var.aws_availability_zone
+
+  ami           = data.aws_ami.aws_ami_ubuntu.id
+  instance_type = var.build_engine_aws_instance_type
+
+  subnet_id = aws_subnet.build_engine_aws_public_subnet.id
+  vpc_security_group_ids = [
+    aws_security_group.build_engine_aws_secgrp_controlplane.id
+  ]
+
+  root_block_device {
+    delete_on_termination = true
+    volume_size = var.build_engine_aws_instance_root_block_device_size
+  }
+
+  key_name = aws_key_pair.build_engine_aws_pair_key.key_name
+  user_data = file("${path.module}/user-data-scripts/provision_amd64.sh")
+  #user_data = file("${var.tf_workspace}/terraform/aws/ubuntu/user-data-scripts/provision_amd64.sh")
+
+  tags = {
+    Name = "${var.build_engine_aws_instance_name}-${count.index}-${random_string.random_suffix.id}"
+    DoNotDelete	= "true"
+    Owner = "longhorn-infra"
+  }
+}
+
+resource "aws_eip" "build_engine_aws_eip_controlplane" {
+  count    = var.build_engine_aws_instance_count
+  vpc      = true
+}
+
+# Associate every EIP with controlplane instance
+resource "aws_eip_association" "build_engine_aws_eip_assoc" {
+  depends_on = [
+    aws_instance.build_engine_aws_instance,
+    aws_eip.build_engine_aws_eip_controlplane
+  ]
+
+  count    = var.build_engine_aws_instance_count
+
+  instance_id   = element(aws_instance.build_engine_aws_instance, count.index).id
+  allocation_id = element(aws_eip.build_engine_aws_eip_controlplane, count.index).id
+}
+
+
+output "ssh_key" {
+  value = var.aws_ssh_private_key_file_path
+}
+
+
+# wait for docker to start on instances (for rke on amd64 only)
+resource "null_resource" "wait_for_docker_start" {
+  depends_on = [
+    aws_instance.build_engine_aws_instance,
+    aws_eip.build_engine_aws_eip_controlplane,
+    aws_eip_association.build_engine_aws_eip_assoc
+  ]
+
+  count = var.build_engine_aws_instance_count
+
+  provisioner "remote-exec" {
+    #inline = var.arch == "amd64" ? ["until( systemctl is-active docker.service ); do echo \"waiting for docker to start \"; sleep 2; done"] : null
+    inline = ["until( systemctl is-active docker.service ); do echo \"waiting for docker to start \"; sleep 2; done"]
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      host     = element(aws_eip.build_engine_aws_eip_controlplane, count.index).public_ip
+      private_key = file(var.aws_ssh_private_key_file_path)
+    }
+  }
+}
+

--- a/test_engine/terraform/aws/ubuntu/output.tf
+++ b/test_engine/terraform/aws/ubuntu/output.tf
@@ -1,0 +1,20 @@
+output "config" {
+  depends_on = [
+    aws_instance.build_engine_aws_instance,
+    aws_eip.build_engine_aws_eip_controlplane,
+    aws_eip_association.build_engine_aws_eip_assoc,
+    null_resource.wait_for_docker_start
+  ]
+
+  value = yamlencode({
+    "nodes": concat(
+     [
+      for controlplane_instance in aws_instance.build_engine_aws_instance : {
+           "address": controlplane_instance.public_ip,
+           "hostname_override": controlplane_instance.tags.Name,
+           "user": "ubuntu",
+          }
+     ]
+    ),
+  })
+}

--- a/test_engine/terraform/aws/ubuntu/user-data-scripts/provision_amd64.sh
+++ b/test_engine/terraform/aws/ubuntu/user-data-scripts/provision_amd64.sh
@@ -1,0 +1,13 @@
+#!/bin/bash 
+
+DOCKER_VERSION=20.10
+
+sudo apt-get update 
+sudo apt-get install -y build-essential git nfs-common
+
+until (curl https://releases.rancher.com/install-docker/${DOCKER_VERSION}.sh | sudo sh); do
+  echo 'docker did not install correctly'                                          
+  sleep 2   
+done
+
+sudo usermod -aG docker ubuntu

--- a/test_engine/terraform/aws/ubuntu/variables.tf
+++ b/test_engine/terraform/aws/ubuntu/variables.tf
@@ -1,0 +1,74 @@
+variable "build_engine_aws_access_key" {
+  type        = string
+  description = "AWS ACCESS_KEY"
+}
+
+variable "build_engine_aws_secret_key" {
+  type        = string
+  description = "AWS SECRET_KEY"
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "tf_workspace" {
+  type        = string
+}
+
+variable "aws_availability_zone" {
+  type        = string
+  default     = "us-east-2a"
+}
+
+variable "build_engine_aws_vpc_name" {
+  type        = string
+  #default     = "vpc-lh-tests"
+  default     = "vpc-build-test-engine"
+}
+
+variable "build_engine_arch" {
+  type        = string
+  description = "available values (amd64, arm64)"
+}
+
+variable "distro_version" {
+  type        = string
+  default     = "20.04"
+}
+
+variable "aws_ami_ubuntu_account_number" {
+  type        = string
+  default     = "099720109477"
+}
+
+variable "build_engine_aws_instance_count" {
+  type        = number
+  default     = 1
+}
+
+variable "build_engine_aws_instance_name" {
+  type        = string
+  default     = "build_test_engine_node"
+}
+
+variable "build_engine_aws_instance_type" {
+  type        = string
+  description = "Recommended instance types t2.xlarge for amd64 & a1.xlarge  for arm64"
+}
+
+variable "build_engine_aws_instance_root_block_device_size" {
+  type        = number
+  default     = 40
+}
+
+variable "aws_ssh_public_key_file_path" {
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+variable "aws_ssh_private_key_file_path" {
+  type        = string
+  default     = "~/.ssh/id_rsa"
+}


### PR DESCRIPTION
For https://github.com/longhorn/longhorn/issues/1961
After below environment set complete

- docker_id
- docker_pwd
- docker_repo
- docker_tag (need to automatically get) 
- TF_VAR_build_engine_aws_access_key
- TF_VAR_build_engine_aws_secret_key

Simple run `python3 ./test_engine/build_test_engine.py` script will create arm64 / amd64 longhorn-engine docker images and push to docker hub for testing, and use dock manifest to combine two images into one as `<docker_repo>:<docker_tag>`

And we can use `<docker_repo>:<docker_tag>` to do engine upgrade e2e test.