### PR TITLE
Generate support bundle when e2e case fail

### DIFF
--- a/manager/integration/tests/conftest.py
+++ b/manager/integration/tests/conftest.py
@@ -7,7 +7,7 @@ from common import get_longhorn_api_client, \
     NODE_CONDITION_MOUNTPROPAGATION, CONDITION_STATUS_TRUE
 from common import wait_for_node_mountpropagation_condition
 from common import check_longhorn, check_csi_expansion
-
+from common import generate_support_bundle
 
 SKIP_BACKING_IMAGE_OPT = "--skip-backing-image-test"
 SKIP_RECURRING_JOB_OPT = "--skip-recurring-job-test"
@@ -173,3 +173,16 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "upgrade" in item.keywords:
                 item.add_marker(skip_upgrade)
+
+
+def pytest_exception_interact(call, report):
+
+    # Only work on TestReport, not on CollectReport
+    if type(report).__name__ != "TestReport":
+        return
+
+    # Get case name
+    case_name = str(report).split()[1]
+    case_name = case_name.split('/')[1].replace('\'', '')
+
+    generate_support_bundle(case_name)


### PR DESCRIPTION
For https://github.com/longhorn/longhorn/issues/3557
Add feature to generate support bundle in longhorn-test pod when e2e test case fail

When test case fail , script will create folder `support_bundle` which the abs path is `/integration/tests/support_bundle` in pod
And will generate support bundle renamed `"test case name.zip"` into folder support_bundle

This is current design, for become Jenkins artifact for download, @meldafrawi  could you advise me should I modify code to match your Jenkins design, thank you

![Screenshot from 2022-02-09 16-44-54](https://user-images.githubusercontent.com/73337386/153158543-04921cf2-b806-4bcb-87c2-6529c3d0e6cb.png)

cc @innobead , @khushboo-rancher 