### PR TITLE
Remove nfs-installation from the test

### DIFF
--- a/manager/integration/tests/test_rwx.py
+++ b/manager/integration/tests/test_rwx.py
@@ -21,14 +21,6 @@ from backupstore import set_random_backupstore # NOQA
 from multiprocessing import Pool
 
 import time
-# import pytest
-# import subprocess
-
-LONGHORN_NFS_INSTALLATION_URL = \
-    "https://raw.githubusercontent.com/longhorn/" \
-    "longhorn/master/deploy/prerequisite/longhorn" \
-    "-nfs-installation.yaml"
-LONGHORN_NFS_DAEMONSET_NAME = "longhorn-nfs-installation"
 
 
 def write_data_into_pod(pod_name_and_data_path):
@@ -36,23 +28,6 @@ def write_data_into_pod(pod_name_and_data_path):
     core_api = get_core_api_client()  # NOQA
     write_pod_volume_random_data(core_api, pod_info[0], pod_info[1],
                                  DATA_SIZE_IN_MB_3)
-
-
-# @pytest.fixture(scope="module", autouse="True")
-# def nfs(request):
-#
-#     cmd = ["kubectl", "apply", "-f", LONGHORN_NFS_INSTALLATION_URL]
-#     subprocess.check_output(cmd)
-#
-#     cmd = ["kubectl", "rollout", "status",
-#            "ds/{}".format(LONGHORN_NFS_DAEMONSET_NAME), "--timeout=5m"]
-#     subprocess.check_output(cmd)
-#
-#     def finalizer():
-#         cmd = ["kubectl", "delete", "-f", LONGHORN_NFS_INSTALLATION_URL]
-#         subprocess.check_output(cmd)
-#
-#     request.addfinalizer(finalizer)
 
 
 def test_rwx_with_statefulset_multi_pods(core_api, statefulset):  # NOQA


### PR DESCRIPTION
We don't need the installation of nfs-common inside the test as the nfs-common installation is taken care in infra set up.

Signed-off-by: Khushboo <fnu.khushboo@suse.com>