### PR TITLE
Fix the integration/README.md ordered list indentation 

### DIFF
--- a/manager/integration/README.md
+++ b/manager/integration/README.md
@@ -4,7 +4,10 @@
 ## Integration test
 
 Requirement:
-1. A Kubernetes cluster with at least 3 nodes
+1. A Kubernetes cluster with at least 3 worker nodes.
+   1.1 And control node(s) with following taints:
+      - `node-role.kubernetes.io/master=true:NoExecute`
+      - `node-role.kubernetes.io/master=true:NoSchedule`
 2. Longhorn system has already been successfully deployed in the cluster.
 3. No volume exists in the Longhorn system.
 4. Need kubernetes 1.10 or higher.

--- a/manager/integration/README.md
+++ b/manager/integration/README.md
@@ -5,14 +5,14 @@
 
 Requirement:
 1. A Kubernetes cluster with at least 3 worker nodes.
-   1.1 And control node(s) with following taints:
+   - And control node(s) with following taints:
       - `node-role.kubernetes.io/master=true:NoExecute`
-      - `node-role.kubernetes.io/master=true:NoSchedule`
+      - `node-role.kubernetes.io/master=true:NoSchedule` 
 2. Longhorn system has already been successfully deployed in the cluster.
 3. No volume exists in the Longhorn system.
 4. Need kubernetes 1.10 or higher.
 5. Make sure MountPropagation feature gate is enabled
-   5.1 For RKE before v0.1.9, you would need the extra parameter feature-gates: `MountPropagation=true` for kube-api and kubelet to enable the feature gate.
+   - For RKE before v0.1.9, you would need the extra parameter feature-gates: `MountPropagation=true` for kube-api and kubelet to enable the feature gate.
 6. Make sure `nfs-common` or equivalent has been installed on the node to allow the NFS client to work.
 
 Run the test:


### PR DESCRIPTION
Turns out ordered list begin with `1.1` doesn't supported in the GitHub Flavored Markdown<sup>*</sup> , and there is a couple trouble<sup>**</sup> with the ordered nested list.

<sup>*</sup> https://github.github.com/gfm/#ordered-list-marker
<sup>**</sup> https://github.com/github/markup/issues/210#issuecomment-470705342