### PR TITLE
fix test_reuse_failed_replica_with_scheduling_check

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -2264,7 +2264,7 @@ def test_reuse_failed_replica(client, core_api, volume_name): # NOQA
 
 def set_tags_for_node_and_its_disks(client, node, tags): # NOQA
     if len(tags) == 0:
-        expected_tags = None
+        expected_tags = []
     else:
         expected_tags = list(tags)
 


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

From [e2e](https://ci.longhorn.io/job/public/job/master/job/sles/job/amd64/job/longhorn-tests-sles-amd64/53/testReport/junit/tests/test_ha/test_reuse_failed_replica_with_scheduling_check/) 
Because recently CRD changes, using `[]` instead `None` when no expected tags in function `set_tags_for_node_and_its_disks`