### PR TITLE
Print pytest logs in jenkins console output

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -60,7 +60,7 @@ metadata:
     longhorn-test: test-job
 spec:
   containers:
-  - name: longhorn-test-pod
+  - name: longhorn-test
     image: longhornio/longhorn-manager-test:master-head
 #    args: [
 #           "-x", "-s",
@@ -74,7 +74,7 @@ spec:
       privileged: true
     env:
     - name: LONGHORN_JUNIT_REPORT_PATH
-      value: /integration/tests/longhorn-test-junit-report.xml
+      value: /tmp/test-report/longhorn-test-junit-report.xml
     - name: LONGHORN_BACKUPSTORES
       value: "s3://backupbucket@us-east-1/backupstore$minio-secret, nfs://longhorn-test-nfs-svc.default:/opt/backupstore"
     - name: LONGHORN_BACKUPSTORE_POLL_INTERVAL
@@ -94,6 +94,14 @@ spec:
     - name: longhorn
       mountPath: /var/lib/longhorn/
       mountPropagation: Bidirectional
+    - name: test-report
+      mountPath: /tmp/test-report
+  - name: longhorn-test-report
+    image: busybox
+    command: [ "tail", "-f", "/dev/null" ]
+    volumeMounts:
+    - name: test-report
+      mountPath: /tmp/test-report
   dnsConfig:
     nameservers:
       - 8.8.8.8
@@ -111,5 +119,8 @@ spec:
   - name: longhorn
     hostPath:
       path: /var/lib/longhorn/
+  - name: test-report
+    hostPath:
+      path: /tmp/test-report/
   restartPolicy: Never
   serviceAccountName: longhorn-test-service-account

--- a/manager/integration/tests/run.sh
+++ b/manager/integration/tests/run.sh
@@ -1,13 +1,3 @@
 #!/bin/bash
 
-if [[ $@ =~ "--junitxml=" ]] ; then 
-  pytest -v "$@" > /tmp/longhorn-pytest 2>&1
-  
-  cat ${LONGHORN_JUNIT_REPORT_PATH}
-else 
-  set -x 
-  
-  flake8
-
-  pytest -v "$@"
-fi 
+pytest -v "$@"


### PR DESCRIPTION
For task [#3740](https://github.com/longhorn/longhorn/issues/3740)

To fetch the test report, we have to "kubectl cp" the report, but there is no way to "kubectl cp" a completed pod, so another keepalive pod is created and we can get the test report from it.
    
After resolved the "kubectl cp" issue above, we don't have to use "kubectl logs" to print out the test report anymore. We can use "kubectl logs" to print pytest logs normally.