### PR TITLE
Fix integration tests fail to publish junit report

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -209,7 +209,9 @@ run_longhorn_upgrade_test(){
     done
 
     # wait upgrade test to complete
-    kubectl logs ${LONGHORN_UPGRADE_TEST_POD_NAME} -c longhorn-test -f
+  while [[ -n "`kubectl get pod longhorn-test-upgrade -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' | grep \"running\"`"  ]]; do
+    kubectl logs ${LONGHORN_UPGRADE_TEST_POD_NAME} -c longhorn-test -f --since=10s
+  done
 
 	# get upgrade test junit xml report
   kubectl cp ${LONGHORN_UPGRADE_TEST_POD_NAME}:${LONGHORN_JUNIT_REPORT_PATH} "${TF_VAR_tf_workspace}/longhorn-test-upgrade-junit-report.xml" -c longhorn-test-report
@@ -270,7 +272,9 @@ run_longhorn_tests(){
     done
 
     # wait longhorn tests to complete
-    kubectl logs ${LONGHORN_TEST_POD_NAME} -c longhorn-test -f
+  while [[ -n "`kubectl get pod longhorn-test -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' | grep \"running\"`"  ]]; do
+    kubectl logs ${LONGHORN_TEST_POD_NAME} -c longhorn-test -f --since=10s
+  done
 
   kubectl cp ${LONGHORN_TEST_POD_NAME}:${LONGHORN_JUNIT_REPORT_PATH} "${TF_VAR_tf_workspace}/longhorn-test-junit-report.xml" -c longhorn-test-report
 }


### PR DESCRIPTION
Deal with streaming-connection-idle-timeout to fix integration tests fail to publish junit report.

By default, streaming-connection-idle-timeout is set to 4 hours, so the "kubectl logs -f" would lost the connection after 4 hours even though the pod is still running. But it also isn't recommended to disable the streaming-connection-idle-timeout.

So keep tracking the status of the longhorn-tests pod and re-trigger "kubectl logs -f".

Signed-off-by: Yang Chiu <yang.chiu@suse.com>