### PR TITLE
Fix timing issue in test_backup_status_for_unavailable_replicas

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3002,6 +3002,20 @@ def find_backup(client, vol_name, snap_name):
                   " for volume " + vol_name
 
 
+def find_replica_for_backup(client, volume_name, backup_id):
+    replica_name = None
+    for _ in range(RETRY_EXEC_COUNTS):
+        volume = client.by_id_volume(volume_name)
+        for status in volume.backupStatus:
+            if status.id == backup_id:
+                replica_name = status.replica
+        if replica_name:
+            return replica_name
+        else:
+            time.sleep(RETRY_BACKUP_INTERVAL)
+    assert replica_name
+
+
 def check_longhorn(core_api):
     ready = False
     has_engine_image = False

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -33,7 +33,7 @@ from common import create_pvc_spec
 from common import generate_random_data, write_volume_data
 from common import VOLUME_RWTEST_SIZE
 from common import write_pod_volume_data
-from common import find_backup
+from common import find_backup, find_replica_for_backup
 from common import wait_for_backup_completion
 from common import create_storage_class
 from common import wait_for_backup_restore_completed
@@ -553,11 +553,7 @@ def backup_status_for_unavailable_replicas_test(client, volume_name,  # NOQA
     backup_id = b.id
 
     # find the replica for this backup
-    volume = client.by_id_volume(volume_name)
-    for status in volume.backupStatus:
-        if status.id == backup_id:
-            replica_name = status.replica
-    assert replica_name
+    replica_name = find_replica_for_backup(client, volume_name, backup_id)
 
     # disable scheduling on that node
     volume = client.by_id_volume(volume_name)


### PR DESCRIPTION
For [#3808](https://github.com/longhorn/longhorn/issues/3808)

when trying to find replica for a backup, the replica name is empty at first. 
Have to wait a few seconds (~5s) to get the correct value.

Signed-off-by: Yang Chiu <yang.chiu@suse.com>