### PR TITLE
Implement test csi snapshot with bak param

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4671,32 +4671,6 @@ def generate_support_bundle(case_name):
             The error was {}".format(case_name, e))
 
 
-@pytest.fixture
-def deploy_csi_snapshot_and_classes(request):
-
-    """
-    Deploy the CSI snapshot CRDs, Controller as instructed at
-    https://longhorn.io/docs/1.2.3/snapshots-and-backups/csi-snapshot-support
-    /enable-csi-snapshot-support/
-    """
-
-    # depoly CSI snapshot CRDs, Controller
-
-    # Deploy 3 VolumeSnapshotClass
-    #   longhorn-backup (type=bak)
-    #   longhorn-snapshot (type=snap)
-    #   invalid (type=invalid)
-
-    def finalizer():
-
-        # Delete 4 VolumeSnapshotClass
-        #   longhorn-backup (type=bak)
-        #   longhorn-snapshot (type=snap)
-        #   invalid (type=invalid)
-        pass
-
-    request.addfinalizer(finalizer)
-
 def get_volume_running_replica_cnt(client, volume_name):  # NOQA
     nodes = client.list_node()
     cnt = 0


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>
Implement `test_csi_snapshot_with_bak_param`

- Remove `deploy_csi_snapshot_and_classes` from common.py because  `volumesnapshotclass` in test_csi_snapshotter.py can deploy specific volumesnapshotclass and CSI snapshot CRDs already installed in `longhorn-setup.sh`
- Reuse `test_csi_volumesnapshot_basic`