### PR TITLE
Fix asserting message in test_recurring_jobs_maximum_retain

### DIFF
--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -599,10 +599,13 @@ def test_recurring_jobs_maximum_retain(client, core_api, volume_name): # NOQA
             LABELS: {},
         },
     }
+
+    validator_error = \
+        "retain" + " in body should be less than or equal to " + "50"
+
     with pytest.raises(Exception) as e:
         create_recurring_jobs(client, recurring_jobs)
-    assert "spec.retain in body should be less than or equal to 50".upper()\
-        in str(e.value).upper()
+    assert validator_error.upper() in str(e.value).upper()
 
     recurring_jobs[RECURRING_JOB_NAME][RETAIN] = 50
     create_recurring_jobs(client, recurring_jobs)
@@ -612,8 +615,7 @@ def test_recurring_jobs_maximum_retain(client, core_api, volume_name): # NOQA
     with pytest.raises(Exception) as e:
         update_recurring_job(client, RECURRING_JOB_NAME,
                              groups=[], labels={}, retain=51)
-    assert "spec.retain in body should be less than or equal to 50".upper()\
-        in str(e.value).upper()
+    assert validator_error.upper() in str(e.value).upper()
 
 
 @pytest.mark.recurring_job  # NOQA

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -600,8 +600,7 @@ def test_recurring_jobs_maximum_retain(client, core_api, volume_name): # NOQA
         },
     }
 
-    validator_error = \
-        "retain" + " in body should be less than or equal to " + "50"
+    validator_error = "retain in body should be less than or equal to 50"
 
     with pytest.raises(Exception) as e:
         create_recurring_jobs(client, recurring_jobs)


### PR DESCRIPTION
The current case will fail with longhorn-manager v1.3.0-dev(master branch), due to the introduction of webhook.
Adjusting the assertion string to make it recognize the error message.

---
pytest output for the reference:
```
_______________________________________________________________________ test_recurring_jobs_maximum_retain ________________________________________________________________________

client = <longhorn.Client object at 0x7f7de8274d90>, core_api = <kubernetes.client.api.core_v1_api.CoreV1Api object at 0x7f7de8475a00>, volume_name = 'longhorn-testvol-25ptih'

    def test_recurring_jobs_maximum_retain(client, core_api, volume_name): # NOQA
        """
        Scenario: test recurring jobs' maximum retain

        Given set a recurring job retain to 51.

        When create recurring job.
        Then should fail.

        When set recurring job retain to 50.
        And create recurring job.
        Then recurring job created with retain equals to 50.

        When update recurring job retain to 51.
        Then should fail.
        """
        # set max total number of retain to exceed 50
        recurring_jobs = {
            RECURRING_JOB_NAME: {
                TASK: BACKUP,
                GROUPS: [],
                CRON: SCHEDULE_1MIN,
                RETAIN: 51,
                CONCURRENCY: 1,
                LABELS: {},
            },
        }
        with pytest.raises(Exception) as e:
            create_recurring_jobs(client, recurring_jobs)
>       assert "spec.retain in body should be less than or equal to 50".upper()\
            in str(e.value).upper()
E       assert 'SPEC.RETAIN IN BODY SHOULD BE LESS THAN OR EQUAL TO 50' in '(APIERROR(...), \'500 : UNABLE TO CREATE RECURRING JOB RECURRING-TEST: ADMISSION WEBHOOK "VALIDATOR.LONGHORN.IO" DENI...IDATOR.LONGHORN.IO" DENIED THE REQUEST: RETAIN IN BODY SHOULD BE LESS THAN OR EQUAL TO 50\\\', \\\'STATUS\\\': 500}\')'
E        +  where 'SPEC.RETAIN IN BODY SHOULD BE LESS THAN OR EQUAL TO 50' = <built-in method upper of str object at 0x7f7de8592b90>()
E        +    where <built-in method upper of str object at 0x7f7de8592b90> = 'spec.retain in body should be less than or equal to 50'.upper
E        +  and   '(APIERROR(...), \'500 : UNABLE TO CREATE RECURRING JOB RECURRING-TEST: ADMISSION WEBHOOK "VALIDATOR.LONGHORN.IO" DENI...IDATOR.LONGHORN.IO" DENIED THE REQUEST: RETAIN IN BODY SHOULD BE LESS THAN OR EQUAL TO 50\\\', \\\'STATUS\\\': 500}\')' = <built-in method upper of str object at 0x55c94cae5440>()
E        +    where <built-in method upper of str object at 0x55c94cae5440> = '(ApiError(...), \'500 : unable to create recurring job recurring-test: admission webhook "validator.longhorn.io" deni...idator.longhorn.io" denied the request: retain in body should be less than or equal to 50\\\', \\\'status\\\': 500}\')'.upper
E        +      where '(ApiError(...), \'500 : unable to create recurring job recurring-test: admission webhook "validator.longhorn.io" deni...idator.longhorn.io" denied the request: retain in body should be less than or equal to 50\\\', \\\'status\\\': 500}\')' = str(ApiError(ApiError(...), '500 : unable to create recurring job recurring-test: admission webhook "validator.longhorn.io...ook "validator.longhorn.io" denied the request: retain in body should be less than or equal to 50\', \'status\': 500}'))
E        +        where ApiError(ApiError(...), '500 : unable to create recurring job recurring-test: admission webhook "validator.longhorn.io...ook "validator.longhorn.io" denied the request: retain in body should be less than or equal to 50\', \'status\': 500}') = <ExceptionInfo ApiError(ApiError(...), '500 : unable to create recurring job recurring-test: admission webhook "valida...dator.longhorn.io" denied the request: retain in body should be less than or equal to 50\', \'status\': 500}') tblen=7>.value

test_recurring_job.py:604: AssertionError
```