### PR TITLE
[v1.1.x-backport] Fix test_allow_volume_creation_with_degraded_availability_restore

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3427,6 +3427,7 @@ def test_allow_volume_creation_with_degraded_availability_restore(
     common.wait_for_replica_scheduled(client, dst_vol_name,
                                       to_nodes=[node1.name],
                                       expect_success=1,
+                                      expect_fail=2,
                                       chk_vol_healthy=False,
                                       chk_replica_running=False)
 


### PR DESCRIPTION
- from longhorn/longhorn-tests#756