### PR TITLE
Fix mkfs.ext4 notfound after migrating to bci

### DIFF
--- a/manager/integration/Dockerfile
+++ b/manager/integration/Dockerfile
@@ -4,7 +4,7 @@ ARG KUBECTL_VERSION=v1.17.0
 ARG ARCH=amd64
 
 RUN zypper ref -f
-RUN zypper in -y vim-small nfs-client xfsprogs util-linux-systemd gcc python39-devel && \
+RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python39-devel && \
     rm -rf /var/cache/zypp/*
 
 RUN curl -sO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/${ARCH}/kubectl && \


### PR DESCRIPTION
Signed-off-by: David Ko <dko@suse.com>