### PR TITLE
[BACKPORT][v1.2.x] Fix flaky test_recurring_job_detached_volume

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3522,17 +3522,19 @@ def create_snapshot(longhorn_api_client, volume_name):
 
 
 def wait_for_snapshot_count(volume, number, retry_counts=120):
-    ok = False
     for _ in range(retry_counts):
         count = 0
         for snapshot in volume.snapshotList():
             if snapshot.removed is False:
                 count += 1
         if count == number:
-            ok = True
-            break
+            return
         time.sleep(RETRY_SNAPSHOT_INTERVAL)
-    assert ok
+
+    assert False, \
+        f"failed to wait for snapshot.\n" \
+        f"Expect count={number}\n" \
+        f"Got count={count}"
 
 
 def wait_and_get_pv_for_pvc(api, pvc_name):

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -634,7 +634,7 @@ def test_recurring_job_detached_volume(client, batch_v1_beta_api, volume_name): 
 
     Then the volume should have 1 snapshot
 
-    When wait for 1 minute.
+    When wait for 2 minute.
     Then then volume should have only 2 snapshots.
     """
     client.create_volume(name=volume_name, size=SIZE)
@@ -660,12 +660,13 @@ def test_recurring_job_detached_volume(client, batch_v1_beta_api, volume_name): 
     check_recurring_jobs(client, recurring_jobs)
     wait_for_cron_job_count(batch_v1_beta_api, 1)
 
-    time.sleep(60 * 2 - WRITE_DATA_INTERVAL)
+    time.sleep(60 * 2)
     volume.attach(hostId=self_host)
     volume = wait_for_volume_healthy(client, volume_name)
+
     wait_for_snapshot_count(volume, 1)
 
-    time.sleep(60)
+    time.sleep(60 * 2)
     wait_for_snapshot_count(volume, 2)
 
 


### PR DESCRIPTION
Backport https://github.com/longhorn/longhorn-tests/pull/955

Flaky test result - [#1155](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/1155/)