### PR TITLE
Retry node/disk update if "too many retries error" happened.

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -226,6 +226,10 @@ JOB_LABEL = "recurring-job.longhorn.io"
 
 MAX_SUPPORT_BINDLE_NUMBER = 20
 
+NODE_UPDATE_RETRY_INTERVAL = 6
+NODE_UPDATE_RETRY_COUNT = 30
+retry_error = "cannot finish API request due to too many error retries"
+
 
 def load_k8s_config():
     c = Configuration()
@@ -839,23 +843,85 @@ def check_volume_replicas(volume, spec, tag_mapping):
 # Default argument is mutable on this function, but it's fine since we're only
 # using it as an empty tag list to pass to the server and will never actually
 # modify it.
-def set_node_tags(client, node, tags=[]):  # NOQA
+def set_node_tags(client, node, tags=[], retry=False):  # NOQA
     """
     Set the tags on a node without modifying its scheduling status.
+    Retry if "too many retries error" happened.
     :param client: The Longhorn client to use in the request.
     :param node: The Node to update.
     :param tags: The tags to set on the node.
     :return: The updated Node.
     """
-    return client.update(node, allowScheduling=node.allowScheduling,
-                         tags=tags)
+    if not retry:
+        return client.update(node, allowScheduling=node.allowScheduling,
+                             tags=tags)
+
+    for _ in range(NODE_UPDATE_RETRY_COUNT):
+        try:
+            node = client.update(node,
+                                 allowScheduling=node.allowScheduling,
+                                 tags=tags)
+        except Exception as e:
+            if retry_error in str(e.error.message):
+                time.sleep(NODE_UPDATE_RETRY_INTERVAL)
+                continue
+            print(e)
+            raise
+        else:
+            break
+
+    return node
 
 
-def set_node_scheduling(client, node, allowScheduling):
+def set_node_scheduling(client, node, allowScheduling, retry=False):
     if node.tags is None:
         node.tags = []
-    return client.update(node, allowScheduling=allowScheduling,
-                         tags=node.tags)
+
+    if not retry:
+        return client.update(node, allowScheduling=allowScheduling,
+                             tags=node.tags)
+
+    # Retry if "too many retries error" happened.
+    for _ in range(NODE_UPDATE_RETRY_COUNT):
+        try:
+            node = client.update(node, allowScheduling=allowScheduling,
+                                 tags=node.tags)
+        except Exception as e:
+            if retry_error in str(e.error.message):
+                time.sleep(NODE_UPDATE_RETRY_INTERVAL)
+                continue
+            print(e)
+            raise
+        else:
+            break
+
+    return node
+
+def set_node_scheduling_eviction(client, node, allowScheduling, evictionRequested, retry=False):  # NOQA
+    if node.tags is None:
+        node.tags = []
+
+    if not retry:
+        node = client.update(node,
+                             allowScheduling=allowScheduling,
+                             evictionRequested=evictionRequested)
+
+    # Retry if "too many retries error" happened.
+    for _ in range(NODE_UPDATE_RETRY_COUNT):
+        try:
+            node = client.update(node,
+                                 allowScheduling=allowScheduling,
+                                 evictionRequested=evictionRequested)
+        except Exception as e:
+            if retry_error in str(e.error.message):
+                time.sleep(NODE_UPDATE_RETRY_INTERVAL)
+                continue
+            print(e)
+            raise
+        else:
+            break
+
+    return node
 
 
 @pytest.fixture
@@ -1300,7 +1366,8 @@ def node_default_tags():
 
         update_disks = get_update_disks(node.disks)
         update_disks[list(update_disks)[0]].tags = tags["disk"]
-        new_node = node.diskUpdate(disks=update_disks)
+        new_node = update_node_disks(client, node.name, disks=update_disks,
+                                     retry=True)
         disks = get_update_disks(new_node.disks)
         assert disks[list(new_node.disks)[0]].tags == tags["disk"]
 
@@ -1315,7 +1382,8 @@ def node_default_tags():
     for node in nodes:
         update_disks = get_update_disks(node.disks)
         update_disks[list(update_disks)[0]].tags = []
-        new_node = node.diskUpdate(disks=update_disks)
+        new_node = update_node_disks(client, node.name, disks=update_disks,
+                                     retry=True)
         disks = get_update_disks(new_node.disks)
         assert len(disks[list(new_node.disks)[0]].tags) == 0, \
             f" disk = {disks}"
@@ -2484,8 +2552,37 @@ def cleanup_node_disks(client, node_name):
         disk.allowScheduling = False
     update_disks = get_update_disks(disks)
     node = client.by_id_node(node_name)
-    node.diskUpdate(disks=update_disks)
-    node.diskUpdate(disks={})
+
+    # Retry if "too many retries error" happened.
+    for _ in range(NODE_UPDATE_RETRY_COUNT):
+        try:
+            node.diskUpdate(disks=update_disks)
+        except Exception as e:
+            if retry_error in str(e.error.message):
+                time.sleep(NODE_UPDATE_RETRY_INTERVAL)
+                continue
+            print(e)
+            raise
+        else:
+            break
+
+    for name, disk in iter(disks.items()):
+        wait_for_disk_status(client, node_name,
+                             name, "allowScheduling", False)
+
+    # Retry if "too many retries error" happened.
+    for _ in range(NODE_UPDATE_RETRY_COUNT):
+        try:
+            node.diskUpdate(disks={})
+        except Exception as e:
+            if retry_error in str(e.error.message):
+                time.sleep(NODE_UPDATE_RETRY_INTERVAL)
+                continue
+            print(e)
+            raise
+        else:
+            break
+
     return wait_for_disk_update(client, node_name, 0)
 
 
@@ -2668,13 +2765,13 @@ def reset_node(client):
     nodes = client.list_node()
     for node in nodes:
         try:
-            node = client.update(node, tags=[])
+            node = set_node_tags(client, node, tags=[])
             node = wait_for_node_tag_update(client, node.id, [])
-            node = client.update(node, allowScheduling=True)
+            node = set_node_scheduling(client, node, allowScheduling=True)
             wait_for_node_update(client, node.id,
                                  "allowScheduling", True)
         except Exception as e:
-            print("\nException when reset node schedulding and tags", node)
+            print("\nException when reset node scheduling and tags", node)
             print(e)
 
     reset_longhorn_node_zone(client)
@@ -2745,19 +2842,27 @@ def cleanup_test_disks(client):
             if dir_path == disk.path:
                 disk.allowScheduling = False
     update_disks = get_update_disks(disks)
-    try:
-        node = node.diskUpdate(disks=update_disks)
-        disks = node.disks
-        for name, disk in iter(disks.items()):
-            for del_dir in del_dirs:
-                dir_path = os.path.join(DIRECTORY_PATH, del_dir)
-                if dir_path == disk.path:
-                    wait_for_disk_status(client, host_id, name,
-                                         "allowScheduling", False)
-    except Exception as e:
-        print("\nException when update node disks", node)
-        print(e)
-        pass
+
+    # Retry if "too many retries error" happened.
+    for _ in range(NODE_UPDATE_RETRY_COUNT):
+        try:
+            node = node.diskUpdate(disks=update_disks)
+            disks = node.disks
+            for name, disk in iter(disks.items()):
+                for del_dir in del_dirs:
+                    dir_path = os.path.join(DIRECTORY_PATH, del_dir)
+                    if dir_path == disk.path:
+                        wait_for_disk_status(client, host_id, name,
+                                             "allowScheduling", False)
+        except Exception as e:
+            if retry_error in str(e.error.message):
+                time.sleep(NODE_UPDATE_RETRY_INTERVAL)
+                continue
+            print("\nException when update node disks", node)
+            print(e)
+            raise
+        else:
+            break
 
     # delete test disks
     disks = node.disks
@@ -2765,13 +2870,20 @@ def cleanup_test_disks(client):
     for name, disk in iter(disks.items()):
         if disk.allowScheduling:
             update_disks[name] = disk
-    try:
-        node.diskUpdate(disks=update_disks)
-        wait_for_disk_update(client, host_id, len(update_disks))
-    except Exception as e:
-        print("\nException when delete node test disks", node)
-        print(e)
-        pass
+    # Retry if "too many retries error" happened.
+    for _ in range(NODE_UPDATE_RETRY_COUNT):
+        try:
+            node.diskUpdate(disks=update_disks)
+            wait_for_disk_update(client, host_id, len(update_disks))
+        except Exception as e:
+            if retry_error in str(e.error.message):
+                time.sleep(NODE_UPDATE_RETRY_INTERVAL)
+                continue
+            print("\nException when delete node test disks", node)
+            print(e)
+            raise
+        else:
+            break
     # cleanup host disks
     for del_dir in del_dirs:
         try:
@@ -2799,15 +2911,18 @@ def reset_disks_for_all_nodes(client):  # NOQA
             for disk_name, disk in iter(update_disks.items()):
                 disk.allowScheduling = False
                 update_disks[disk_name] = disk
-                node = node.diskUpdate(disks=update_disks)
+                node = update_node_disks(client, node.name, disks=update_disks,
+                                         retry=True)
             update_disks = {}
-            node = node.diskUpdate(disks=update_disks)
+            node = update_node_disks(client, node.name, disks=update_disks,
+                                     retry=True)
             node = wait_for_disk_update(client, node.name, 0)
         if len(node.disks) == 0:
             default_disk = {"default-disk":
                             {"path": DEFAULT_DISK_PATH,
                              "allowScheduling": True}}
-            node = node.diskUpdate(disks=default_disk)
+            node = update_node_disks(client, node.name, disks=default_disk,
+                                     retry=True)
             node = wait_for_disk_update(client, node.name, 1)
             assert len(node.disks) == 1
         # wait for node controller to update disk status
@@ -2820,7 +2935,8 @@ def reset_disks_for_all_nodes(client):  # NOQA
                 int(update_disk.storageMaximum * 30 / 100)
             update_disk.tags = []
             update_disks[name] = update_disk
-        node = node.diskUpdate(disks=update_disks)
+        node = update_node_disks(client, node.name, disks=update_disks,
+                                 retry=True)
         for name, disk in iter(node.disks.items()):
             # wait for node controller update disk status
             wait_for_disk_status(client, node.name, name,
@@ -4726,3 +4842,79 @@ def get_volume_running_replica_cnt(client, volume_name):  # NOQA
             client, volume_name, node.name, chk_running=True)
 
     return cnt
+
+
+def create_volume(client, vol_name, size, node_id, r_num):
+    volume = client.create_volume(name=vol_name, size=size,
+                                  numberOfReplicas=r_num)
+    assert volume.numberOfReplicas == r_num
+    assert volume.frontend == VOLUME_FRONTEND_BLOCKDEV
+
+    volume = wait_for_volume_detached(client, vol_name)
+    assert len(volume.replicas) == r_num
+
+    assert volume.state == "detached"
+    assert volume.created != ""
+
+    volumeByName = client.by_id_volume(vol_name)
+    assert volumeByName.name == volume.name
+    assert volumeByName.size == volume.size
+    assert volumeByName.numberOfReplicas == volume.numberOfReplicas
+    assert volumeByName.state == volume.state
+    assert volumeByName.created == volume.created
+
+    volume.attach(hostId=node_id)
+    volume = wait_for_volume_healthy(client, vol_name)
+
+    return volume
+
+
+def cleanup_volume_by_name(client, vol_name):
+    volume = client.by_id_volume(vol_name)
+    volume.detach(hostId="")
+    client.delete(volume)
+    wait_for_volume_delete(client, vol_name)
+
+
+def create_host_disk(client, vol_name, size, node_id):
+    # create a single replica volume and attach it to node
+    volume = create_volume(client, vol_name, size, node_id, 1)
+
+    mkfs_ext4_settings = client.by_id_setting(SETTING_MKFS_EXT4_PARAMS)
+    mkfs_ext4_options = mkfs_ext4_settings.value
+
+    # prepare the disk in the host filesystem
+    disk_path = prepare_host_disk(get_volume_endpoint(volume),
+                                  volume.name,
+                                  mkfs_ext4_options)
+    return disk_path
+
+
+def cleanup_host_disks(client, *args):
+    # clean disk
+    for vol_name in args:
+        # umount disk
+        cleanup_host_disk(vol_name)
+        # clean volume
+        cleanup_volume_by_name(client, vol_name)
+
+
+def update_node_disks(client, node_name, disks, retry=False):
+    node = client.by_id_node(node_name)
+
+    if not retry:
+        return node.diskUpdate(disks=disks)
+
+    # Retry if "too many retries error" happened.
+    for _ in range(NODE_UPDATE_RETRY_COUNT):
+        try:
+            node = node.diskUpdate(disks=disks)
+        except Exception as e:
+            if retry_error in str(e.error.message):
+                time.sleep(NODE_UPDATE_RETRY_INTERVAL)
+                continue
+            print(e)
+            raise
+        else:
+            break
+    return node

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -78,6 +78,7 @@ from common import create_backup_from_volume_attached_to_pod
 from common import restore_backup_and_get_data_checksum
 from common import write_volume_dev_random_mb_data
 from common import VOLUME_HEAD_NAME
+from common import set_node_scheduling
 
 from backupstore import backupstore_delete_volume_cfg_file
 from backupstore import backupstore_cleanup
@@ -563,7 +564,7 @@ def backup_status_for_unavailable_replicas_test(client, volume_name,  # NOQA
     for r in volume.replicas:
         if r.name == replica_name:
             node = client.by_id_node(r.hostId)
-            node = client.update(node, allowScheduling=False)
+            node = set_node_scheduling(client, node, allowScheduling=False)
             common.wait_for_node_update(client, node.id,
                                         "allowScheduling", False)
     assert node
@@ -580,7 +581,7 @@ def backup_status_for_unavailable_replicas_test(client, volume_name,  # NOQA
 
     # re enable scheduling on the previously disabled node
     node = client.by_id_node(node.id)
-    node = client.update(node, allowScheduling=True)
+    node = set_node_scheduling(client, node, allowScheduling=True)
     common.wait_for_node_update(client, node.id,
                                 "allowScheduling", True)
 
@@ -1774,7 +1775,7 @@ def test_volume_scheduling_failure(client, volume_name):  # NOQA
     assert len(nodes) > 0
 
     for node in nodes:
-        node = client.update(node, allowScheduling=False)
+        node = set_node_scheduling(client, node, allowScheduling=False)
         node = common.wait_for_node_update(client, node.id,
                                            "allowScheduling", False)
 
@@ -1792,7 +1793,7 @@ def test_volume_scheduling_failure(client, volume_name):  # NOQA
     assert "unable to attach volume" in str(e.value)
 
     for node in nodes:
-        node = client.update(node, allowScheduling=True)
+        node = set_node_scheduling(client, node, allowScheduling=True)
         node = common.wait_for_node_update(client, node.id,
                                            "allowScheduling", True)
 
@@ -2586,7 +2587,7 @@ def test_running_volume_with_scheduling_failure(
     for r in volume.replicas:
         existing_replicas[r.name] = r
     node = client.by_id_node(volume.replicas[0].hostId)
-    node = client.update(node, allowScheduling=False)
+    node = set_node_scheduling(client, node, allowScheduling=False)
     common.wait_for_node_update(client, node.id,
                                 "allowScheduling", False)
 
@@ -2722,7 +2723,7 @@ def test_expansion_with_scheduling_failure(
         old_replicas[r.name] = r
     failed_replica = volume.replicas[0]
     node = client.by_id_node(failed_replica.hostId)
-    node = client.update(node, allowScheduling=False)
+    node = set_node_scheduling(client, node, allowScheduling=False)
     common.wait_for_node_update(client, node.id,
                                 "allowScheduling", False)
 
@@ -2794,7 +2795,7 @@ def test_expansion_with_scheduling_failure(
     original_md5sum3 = get_pod_data_md5sum(core_api, test_pod_name, data_path3)
 
     node = client.by_id_node(failed_replica.hostId)
-    client.update(node, allowScheduling=True)
+    set_node_scheduling(client, node, allowScheduling=True)
     wait_for_volume_healthy(client, volume_name)
 
     md5sum3 = get_pod_data_md5sum(core_api, test_pod_name, data_path3)

--- a/manager/integration/tests/test_tagging.py
+++ b/manager/integration/tests/test_tagging.py
@@ -7,6 +7,7 @@ from common import check_volume_replicas, cleanup_volume, \
     generate_volume_name, get_self_host_id, get_update_disks, set_node_tags, \
     wait_for_volume_delete, wait_for_volume_detached, \
     wait_for_volume_healthy, wait_scheduling_failure
+from common import update_node_disks
 
 from time import sleep
 
@@ -50,7 +51,7 @@ def test_tag_basic(client):  # NOQA
     unsorted_node, sorted_node = generate_unordered_tag_names()
     update_disks = get_update_disks(node.disks)
     update_disks[list(update_disks)[0]].tags = unsorted_disk
-    node = node.diskUpdate(disks=update_disks)
+    node = update_node_disks(client, node.name, disks=update_disks)
     disks = get_update_disks(node.disks)
     assert disks[list(disks)[0]].tags == sorted_disk
 
@@ -71,13 +72,13 @@ def test_tag_basic(client):  # NOQA
         with pytest.raises(Exception) as e:
             update_disks = get_update_disks(node.disks)
             update_disks[list(update_disks)[0]].tags = tags
-            node.diskUpdate(disks=update_disks)
+            update_node_disks(client, node.name, disks=update_disks)
         assert "at least one error encountered while validating tags" in \
                str(e.value)
 
     update_disks = get_update_disks(node.disks)
     update_disks[list(update_disks)[0]].tags = []
-    node = node.diskUpdate(disks=update_disks)
+    node = update_node_disks(client, node.name, disks=update_disks)
     disks = get_update_disks(node.disks)
     assert len(node.disks[list(node.disks)[0]].tags) == 0, f"disks = {disks}"
 
@@ -248,7 +249,7 @@ def test_tag_scheduling_on_update(client, node_default_tags, volume_name):  # NO
     node = client.by_id_node(host_id)
     update_disks = get_update_disks(node.disks)
     update_disks[list(update_disks)[0]].tags = tag_spec["disk"]
-    node = node.diskUpdate(disks=update_disks)
+    node = update_node_disks(client, node.name, disks=update_disks)
     set_node_tags(client, node, tag_spec["node"])
     scheduled = False
     for i in range(RETRY_COUNTS):


### PR DESCRIPTION
There are some errors in the e2e test after introducing the node monitor, like
```
...cannot finish API request due to too many error retries
```

Currently, the tests are not waiting long enough for the disks to be reconciled by the node controller.
The subsequent actions might encounter unexpected errors due to the non-ready disks.

The fix is retrying node/disk update if "too many retries error" happened.

[Longhorn 3939](https://github.com/longhorn/longhorn/issues/3939)

Signed-off-by: Derek Su <derek.su@suse.com>