### PR TITLE
Update node-deletion.md: Fix the ordered list style and add example to crash replicas via cli

### DIFF
--- a/docs/content/manual/pre-release/node/node-deletion.md
+++ b/docs/content/manual/pre-release/node/node-deletion.md
@@ -18,12 +18,15 @@ title: Test node deletion
     2. Write some data to all volumes.
 3. Delete multiple nodes in the cluster simultaneously. Make sure the corresponding Kubernetes node object is deleted. --> The related Longhorn node objects will be cleaned up immediately, too.
 4. For each deleted node:
-    1.Verify the volume Health state  -->
+    1. Verify the volume Health state  -->
         1. The 1st volume should become `Faulted`.
         2. The 2nd volume should keep `Unknown`.
         3. The 3rd and the 4th volume should become `Degraded`.
     2. Delete the 1st volume. --> The volume can be deleted.
     3. Detach then reattach the 2nd volume. --> The volume works fine and the data is correct.
     4. Crash all replicas of the 3rd volume and trigger the auto salvage. --> The auto salvage should work. The volume works fine and the data is correct after the salvage.
+        * An example to crash every volume replica instance manager pods with kubectl:
+            - `kubectl delete pods -l longhorn.io/instance-manager-type=replica -n longhorn-system --wait`
     5. Disabled the auto salvage setting. Then crash all replicas of the 3rd volume again. --> The replica on the deleted node cannot be salvaged manually, too. The salvage feature still works fine.
     6. Deleted the replica on the deleted node for the 4th volume. --> The replica can be deleted.
+

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -6,6 +6,9 @@
       {{ .Site.Title }}
     {{ end }}</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.min.css">
+    <style>
+      ol > li { list-style-type: decimal; }
+    </style>
   </head>
   <body class="markdown-body" style="display: flex; padding: 1%;">
     {{ block "main" . }}


### PR DESCRIPTION
Fix the ordered list for sublists with css, adding to the html > header > style tag block.

It should like this, as tested from my local environment:
![image](https://user-images.githubusercontent.com/602540/169022085-62f4abf0-4149-4a3b-ae50-f5668cb4b00d.png)
