### PR TITLE
Add Edit button to the docs/ contents

### DIFF
--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -1,11 +1,12 @@
 {{ define "main" }}
 {{ partial "sidebar.html" . }}
+{{ $editUrl := printf "https://github.com/longhorn/longhorn-tests/edit/master/docs/content/%s" .File.Path }}
 <main style="padding: 1%; width: 70%;">
   <h1 id="title">{{ .Title | markdownify }}</h1>
   <div>
     <article id="content">
        {{ .Content }}
     </article>
+  <a href="{{ $editUrl }}" target="_blank" title="Edit on Github" style="font-size:smaller;float:right;padding-right:3%">[Edit]</a>
   </div>
-</main>
 {{ end }}


### PR DESCRIPTION
- Add edit link be populated under each content section.
- The link will open github web editor

Local preview:
<img width="1433" alt="Screen Shot 2022-05-23 at 6 03 52 PM - marked" src="https://user-images.githubusercontent.com/602540/169797258-f4384a87-97f4-4b7f-b216-53d8d12541a8.png">