### PR TITLE
Use external snapshotter release branch in e2e pipeline

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -34,7 +34,7 @@ set_kubeconfig_envvar(){
 
 install_csi_snapshotter_crds(){
     CSI_SNAPSHOTTER_REPO_URL="https://github.com/kubernetes-csi/external-snapshotter.git"
-    CSI_SNAPSHOTTER_REPO_BRANCH="master"
+    CSI_SNAPSHOTTER_REPO_BRANCH="release-4.0"
     CSI_SNAPSHOTTER_REPO_DIR="${TMPDIR}/k8s-csi-external-snapshotter"
 
     git clone --single-branch \


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

https://github.com/longhorn/longhorn/issues/4027

Use external snapshotter release branch instead of master branch to avoid unexpected error