### PR TITLE
[Backport 1.2.x] Use external snapshotter release branch

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -32,7 +32,7 @@ set_kubeconfig_envvar(){
 
 install_csi_snapshotter_crds(){
     CSI_SNAPSHOTTER_REPO_URL="https://github.com/kubernetes-csi/external-snapshotter.git"
-    CSI_SNAPSHOTTER_REPO_BRANCH="master"
+    CSI_SNAPSHOTTER_REPO_BRANCH="release-4.0"
     CSI_SNAPSHOTTER_REPO_DIR="${TMPDIR}/k8s-csi-external-snapshotter"
 
     git clone --single-branch \


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

backport https://github.com/longhorn/longhorn-tests/pull/970