### PR TITLE
grpc-proxy: skip test_backuptarget_available_during_engine_image_not_ready

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3760,7 +3760,10 @@ def test_workload_with_fsgroup(core_api, statefulset):  # NOQA
                                  DATA_SIZE_IN_MB_1)
     get_pod_data_md5sum(core_api, pod_name, "/data/test")
 
-
+# After introducing the gRPC proxy, the backup target controller is relying on
+# the gRPC server availability instead of the engine binary availability.
+# https://github.com/longhorn/longhorn/issues/4033
+@pytest.mark.skip(reason="TODO")  # NOQA
 def test_backuptarget_available_during_engine_image_not_ready(client, apps_api, request):  # NOQA
     """
     Test backup target available during engine image not ready


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/3546
https://github.com/longhorn/longhorn/issues/4033