### PR TITLE
Fix test case test_cloning_interrupted

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4767,9 +4767,14 @@ def wait_for_pod_annotation(core_api,
 def wait_for_volume_clone_status(client, name, key, value):
     for _ in range(RETRY_COUNTS):
         volume = client.by_id_volume(name)
-        if volume[VOLUME_FIELD_CLONE_STATUS][key] == value:
-            break
-        time.sleep(RETRY_INTERVAL)
+        try:
+            if volume[VOLUME_FIELD_CLONE_STATUS][key] == value:
+                break
+        except Exception as e:
+            print("\nVOLUME_FIELD_CLONE_STATUS is not ready")
+            print(e)
+        finally:
+            time.sleep(RETRY_INTERVAL)
     assert volume[VOLUME_FIELD_CLONE_STATUS][key] == value, \
         f" Expected value={value}\n. " \
         f" Got volume[{VOLUME_FIELD_CLONE_STATUS}][{key}]= " \

--- a/manager/integration/tests/test_cloning.py
+++ b/manager/integration/tests/test_cloning.py
@@ -15,6 +15,7 @@ from common import generate_random_suffix, wait_for_volume_endpoint
 from common import wait_for_snapshot_count, DATA_SIZE_IN_MB_3
 from common import get_clone_volume_name
 from common import create_storage_class, storage_class  # NOQA
+from common import wait_for_volume_degraded
 
 
 # Kept some fixtures specifically for volume cloning module to avoid cleaning
@@ -387,6 +388,7 @@ def test_cloning_interrupted(client, core_api, pvc, pod, clone_pvc, clone_pod): 
                                  'initiated')
 
     # Step-6
+    wait_for_volume_degraded(client, clone_volume_name)
     crash_replica_processes(client, core_api, source_volume_name)
 
     # Step-7


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

https://ci.longhorn.io/job/public/job/master/job/sles/job/amd64/job/longhorn-tests-sles-amd64/139/testReport/junit/tests/test_cloning/test_cloning_interrupted/
https://github.com/longhorn/longhorn/issues/4047

Fix test case test_cloning_interrupted

Add `wait_for_volume_degraded` for clone volume before crash source volume replica process.
Or the cloning won't interrupt in recent build.
