### PR TITLE
integration: Use a longer timeout for test_exporting_backing_image_from_volume

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -56,8 +56,8 @@ BACKING_IMAGE_EXT4_SIZE = 32 * Mi
 PORT = ":9500"
 
 RETRY_COMMAND_COUNT = 3
-RETRY_COUNTS = 300
-RETRY_INTERVAL = 0.5
+RETRY_COUNTS = 150
+RETRY_INTERVAL = 1
 RETRY_INTERVAL_LONG = 2
 RETRY_BACKUP_COUNTS = 300
 RETRY_BACKUP_INTERVAL = 1
@@ -1656,13 +1656,13 @@ def wait_for_volume_detached_unknown(client, name):
     return wait_for_volume_detached(client, name)
 
 
-def wait_for_volume_healthy(client, name):
+def wait_for_volume_healthy(client, name, retry_count=RETRY_COUNTS):
     wait_for_volume_status(client, name,
                            VOLUME_FIELD_STATE,
-                           VOLUME_STATE_ATTACHED)
+                           VOLUME_STATE_ATTACHED, retry_count)
     wait_for_volume_status(client, name,
                            VOLUME_FIELD_ROBUSTNESS,
-                           VOLUME_ROBUSTNESS_HEALTHY)
+                           VOLUME_ROBUSTNESS_HEALTHY, retry_count)
     return wait_for_volume_endpoint(client, name)
 
 
@@ -1693,9 +1693,10 @@ def wait_for_volume_faulted(client, name):
                                   VOLUME_ROBUSTNESS_FAULTED)
 
 
-def wait_for_volume_status(client, name, key, value):
+def wait_for_volume_status(client, name, key, value,
+                           retry_count=RETRY_COUNTS):
     wait_for_volume_creation(client, name)
-    for i in range(RETRY_COUNTS):
+    for i in range(retry_count):
         volume = client.by_id_volume(name)
         if volume[key] == value:
             break

--- a/manager/integration/tests/test_backing_image.py
+++ b/manager/integration/tests/test_backing_image.py
@@ -471,7 +471,7 @@ def test_exporting_backing_image_from_volume(client, volume_name):  # NOQA
         client, volume_name=volume2_name, size=str(1 * Gi),
         backing_image=backing_img1["name"])
     volume2 = volume2.attach(hostId=hostId)
-    volume2 = wait_for_volume_healthy(client, volume2_name)
+    volume2 = wait_for_volume_healthy(client, volume2_name, 300)
 
     # Step5, 6
     data2 = write_volume_random_data(volume2)
@@ -493,7 +493,7 @@ def test_exporting_backing_image_from_volume(client, volume_name):  # NOQA
         client, volume_name=volume3_name, size=str(1 * Gi),
         backing_image=backing_img2["name"])
     volume3 = volume3.attach(hostId=hostId)
-    volume3 = wait_for_volume_healthy(client, volume3_name)
+    volume3 = wait_for_volume_healthy(client, volume3_name, 300)
 
     # Step10
     check_volume_data(volume3, data2)


### PR DESCRIPTION
Creating a backing image from a volume then copying it to other nodes during volume attachment would take a longer time. Hence we need to use a longer timeout.