### PR TITLE
Fix the flaky issue in test_allow_volume_creation_with_degraded_ability

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3175,7 +3175,7 @@ def test_allow_volume_creation_with_degraded_availability(client, volume_name): 
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=self_host)
-    volume = common.wait_for_volume_degraded(client, volume_name)
+    volume = common.wait_for_volume_healthy(client, volume_name)
     check_volume_data(volume, data)
 
 


### PR DESCRIPTION
After all nodes are enabled and replicas are scheduled, the replicas might
be rebuilt before wait_for_volume_healthy(), the volume becomes healthy.

Thus, we wait for the volume healthy rather than degraded, and then check the data.

[Longhorn 3220](https://github.com/longhorn/longhorn/issues/3220)

Signed-off-by: Derek Su <derek.su@suse.com>