### PR TITLE
Refine benchmark test to let volume and replicas on the same node

### DIFF
--- a/benchmark_test/Jenkinsfile
+++ b/benchmark_test/Jenkinsfile
@@ -14,7 +14,7 @@ node {
 
     checkout scm
 
-    withCredentials([usernamePassword(credentialsId: 'AWS_CREDS', passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY')]) {
+    withCredentials([usernamePassword(credentialsId: 'AWS_CREDS_RANCHER_QA', passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY')]) {
         stage('build') {
             sh "benchmark_test/scripts/build.sh"
 

--- a/benchmark_test/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/benchmark_test/user-data-scripts/provision_rke2_server.sh.tpl
@@ -15,6 +15,8 @@ write-kubeconfig-mode: "0644"
 token: ${rke2_cluster_secret}
 tls-san:
   - ${rke2_server_public_ip}
+node-taint:
+  - "node-role.kubernetes.io/control-plane=true:NoSchedule"
 EOF
 
 systemctl enable rke2-server.service


### PR DESCRIPTION
(1) Fix rke2 control plane schedulable
(2) Cordon redundant nodes when test replica count < cluster worker node count

For https://github.com/longhorn/longhorn/issues/4200

Signed-off-by: Yang Chiu <yang.chiu@suse.com>