### PR TITLE
Add user information to build name to easily identify which build is triggered by whom

### DIFF
--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -18,6 +18,10 @@ node {
     withCredentials([usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY')]) {
         stage('build') {
 
+           if(JOB_BASE_NAME == "longhorn-tests-regression") {
+               manager.addShortText(BUILD_TRIGGER_BY.replace("\nStarted by user ", ""), "grey", "white", "0px", "white")
+           }
+
             echo "Using credentials: $CREDS_ID"
 
             sh "test_framework/scripts/build.sh"


### PR DESCRIPTION
Add user information to build name to easily identify which build is triggered by whom

For https://github.com/longhorn/longhorn/issues/4034

Signed-off-by: Yang Chiu <yang.chiu@suse.com>