### PR TITLE
 Build test engine/version image for both amd64/arm64

### DIFF
--- a/build_engine_test_images/Dockerfile.setup
+++ b/build_engine_test_images/Dockerfile.setup
@@ -1,0 +1,21 @@
+From alpine:latest
+
+ARG TERRAFORM_VERSION=1.0.11
+
+ARG YQ_VERSION=v4.9.8
+
+ENV WORKSPACE /src/longhorn-tests
+
+WORKDIR $WORKSPACE
+
+RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    mv terraform /usr/bin/terraform && \
+    chmod +x /usr/bin/terraform && \
+    wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" && \
+    mv yq_linux_amd64 /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && \
+    apk add openssh-client ca-certificates git rsync bash curl jq && \
+    ssh-keygen -t rsa -b 4096 -N "" -f ~/.ssh/id_rsa
+
+COPY [".", "$WORKSPACE"]

--- a/build_engine_test_images/Jenkinsfile
+++ b/build_engine_test_images/Jenkinsfile
@@ -1,0 +1,62 @@
+def imageName = "${JOB_BASE_NAME}-${env.BUILD_NUMBER}"
+def summary
+def BUILD_TRIGGER_BY = "\n${currentBuild.getBuildCauses()[0].shortDescription}"
+def TF_VAR_tf_workspace="/src/longhorn-tests/build_engine_test_images"
+
+node {
+
+	if(params.SEND_SLACK_NOTIFICATION){
+		notifyBuild('STARTED', BUILD_TRIGGER_BY, params.NOTIFY_SLACK_CHANNEL)
+	}
+
+  checkout scm
+
+  withCredentials([
+    usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME'),
+    usernamePassword(credentialsId: 'AWS_CREDS', passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY')
+  ]) {
+        stage('build') {      
+            
+            sh "build_engine_test_images/scripts/build.sh"
+
+            sh """ docker run -itd --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
+                                   --env TF_VAR_build_engine_aws_access_key=${AWS_ACCESS_KEY} \
+                                   --env TF_VAR_build_engine_aws_secret_key=${AWS_SECRET_KEY} \
+                                   --env TF_VAR_docker_id=${DOCKER_USERNAME} \
+                                   --env TF_VAR_docker_password=${DOCKER_PASSWORD} \
+                                   --env TF_VAR_docker_repo=${DOCKER_REPO} \
+                                   --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} \
+                                   ${imageName}
+            """
+
+            sh "docker exec -w ${TF_VAR_tf_workspace} ${JOB_BASE_NAME}-${BUILD_NUMBER} ./run.sh"
+            }
+        }
+    }
+
+
+def notifyBuild(String buildStatus = 'STARTED', String summary_msg, String slack_channel) {
+  // build status of null means successful
+  buildStatus =  buildStatus ?: 'SUCCESSFUL'
+
+  // Default values
+  def colorName = 'RED'
+  def colorCode = '#FF0000'
+  def subject = "${buildStatus}: Job '${env.JOB_BASE_NAME} [${env.BUILD_NUMBER}]'"
+  def summary = "${subject} (${env.BUILD_URL})" + summary_msg
+
+  // Override default values based on build status
+  if (buildStatus == 'STARTED') {
+    color = 'YELLOW'
+    colorCode = '#FFFF00'
+  } else if (buildStatus == 'SUCCESSFUL') {
+    color = 'GREEN'
+    colorCode = '#00FF00'
+  } else {
+    color = 'RED'
+    colorCode = '#FF0000'
+  }
+
+  // Send notifications
+  slackSend (color: colorCode, message: summary, channel: slack_channel,  tokenCredentialId: 'longhorn-tests-slack-token')
+}

--- a/build_engine_test_images/run.sh
+++ b/build_engine_test_images/run.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+if [[ -z "$TF_VAR_build_engine_aws_access_key" ]]; then
+    echo "Must provide TF_VAR_build_engine_aws_access_key in environment" 1>&2
+    exit 1
+fi
+
+if [[ -z "$TF_VAR_build_engine_aws_secret_key" ]]; then
+    echo "Must provide TF_VAR_build_engine_aws_secret_key in environment" 1>&2
+    exit 1
+fi
+
+if [[ -z "$TF_VAR_docker_id" ]]; then
+    echo "Must provide TF_VAR_docker_id in environment" 1>&2
+    exit 1
+fi
+
+if [[ -z "$TF_VAR_docker_password" ]]; then
+    echo "Must provide TF_VAR_docker_password in environment" 1>&2
+    exit 1
+fi
+
+if [[ -z "$TF_VAR_docker_repo" ]]; then
+    echo "Must provide TF_VAR_docker_repo in environment" 1>&2
+    exit 1
+fi
+
+trap ./scripts/cleanup.sh EXIT
+
+# Build amd64 images
+export TF_VAR_build_engine_arch="amd64"
+export TF_VAR_build_engine_aws_instance_type="t2.micro"
+terraform -chdir=${TF_VAR_tf_workspace}/terraform/aws/ubuntu init
+terraform -chdir=${TF_VAR_tf_workspace}/terraform/aws/ubuntu apply -auto-approve -no-color
+./scripts/cleanup.sh
+
+# Build arm64 images
+export TF_VAR_build_engine_arch="arm64"
+export TF_VAR_build_engine_aws_instance_type="a1.medium"
+terraform -chdir=${TF_VAR_tf_workspace}/terraform/aws/ubuntu init
+terraform -chdir=${TF_VAR_tf_workspace}/terraform/aws/ubuntu apply -auto-approve -no-color
+
+echo "Done"

--- a/build_engine_test_images/scripts/build.sh
+++ b/build_engine_test_images/scripts/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --no-cache -f ./build_engine_test_images/Dockerfile.setup -t "${JOB_BASE_NAME}-${BUILD_NUMBER}" .

--- a/build_engine_test_images/scripts/cleanup.sh
+++ b/build_engine_test_images/scripts/cleanup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# terminate any terraform processes
+TERRAFORM_PIDS=( `ps aux | grep -i terraform | grep -v grep | awk '{printf("%s ",$1)}'` )
+if [[ -n ${TERRAFORM_PIDS[@]} ]] ; then
+	for PID in "${TERRAFORM_PIDS[@]}"; do
+		kill "${TERRAFORM_PIDS}"
+	done
+fi
+
+# wait 30 seconds for graceful terraform termination
+sleep 30
+
+terraform -chdir=${TF_VAR_tf_workspace}/terraform/aws/ubuntu destroy -auto-approve -no-color

--- a/build_engine_test_images/scripts/generate_images.sh
+++ b/build_engine_test_images/scripts/generate_images.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+arch=$1
+docker_id=$2
+docker_password=$3
+docker_repo=$4
+
+function build_version_test_images() {
+  # 1~6 API number
+  # 7 arch
+  version_image=`./generate_version_image.sh \$1 \$2 \$3 \$4 \$5 \$6 | tail -n 1`
+  docker push ${version_image}-${7}
+  
+  if [ ${7} == 'arm64' ]
+  then
+    docker manifest create ${version_image} ${version_image}-amd64 ${version_image}-arm64
+    docker manifest push ${version_image}
+  fi
+}
+
+# Get API information
+docker pull longhornio/longhorn-engine:master-head
+IMAGE="longhornio/longhorn-engine:master-head"
+
+version=`docker run $IMAGE longhorn version --client-only`
+
+export CLIAPIVersion=`echo $version|jq -r ".clientVersion.cliAPIVersion"`
+export CLIAPIMinVersion=`echo $version|jq -r ".clientVersion.cliAPIMinVersion"`
+export ControllerAPIVersion=`echo $version|jq -r ".clientVersion.controllerAPIVersion"`
+export ControllerAPIMinVersion=`echo $version|jq -r ".clientVersion.controllerAPIMinVersion"`
+export DataFormatVersion=`echo $version|jq -r ".clientVersion.dataFormatVersion"`
+export DataFormatMinVersion=`echo $version|jq -r ".clientVersion.dataFormatMinVersion"`
+
+# Build upgrade images
+upgrade_image="${docker_repo}:upgrade-test.$CLIAPIVersion-$CLIAPIMinVersion"\
+".$ControllerAPIVersion-$ControllerAPIMinVersion"\
+".$DataFormatVersion-$DataFormatMinVersion"
+
+git clone https://github.com/longhorn/longhorn-engine.git
+sed -i "s/.*ARG DAPPER_HOST_ARCH=.*/ARG DAPPER_HOST_ARCH=${arch}/" longhorn-engine/Dockerfile.dapper
+cd longhorn-engine
+echo -en test >> README.md
+git config --global user.email mock@gmail.com
+git config --global user.name mock
+git commit -a -m "make commit number diff"
+sudo make build
+sudo make package
+
+docker login -u=${docker_id} -p=${docker_password}
+image_info=($(docker images | grep "longhornio/longhorn-engine"))
+image_id=${image_info[2]}
+docker tag ${image_id} ${upgrade_image}-${arch}
+docker push ${upgrade_image}-${arch}
+
+if [ ${arch} == 'arm64' ]
+then
+  docker manifest create ${upgrade_image} ${upgrade_image}-amd64 ${upgrade_image}-arm64
+  docker manifest push ${upgrade_image}
+fi
+
+# Build version images
+git clone https://github.com/longhorn/longhorn-tests.git
+cd longhorn-tests/manager/test_containers/compatibility
+
+docker_repo=(${docker_repo////\\/})
+sed -i "s/.*docker build -t longhornio\\/longhorn-test:\${version_tag} package*/docker build -t ${docker_repo}:\${version_tag}-${arch} package/" generate_version_image.sh
+sed -i "s/.*echo longhornio\\/longhorn-test:\${version_tag}*/echo ${docker_repo}:\${version_tag}/" generate_version_image.sh
+build_version_test_images $((CLIAPIVersion-1)) $((CLIAPIMinVersion-1)) $ControllerAPIVersion $ControllerAPIMinVersion $DataFormatVersion $DataFormatMinVersion $arch
+build_version_test_images $((CLIAPIVersion+1)) $((CLIAPIMinVersion+1)) $ControllerAPIVersion $ControllerAPIMinVersion $DataFormatVersion $DataFormatMinVersion $arch
+build_version_test_images $((CLIAPIMinVersion-1)) $((CLIAPIMinVersion-1)) $ControllerAPIVersion $ControllerAPIMinVersion $DataFormatVersion $DataFormatMinVersion $arch
+build_version_test_images $CLIAPIVersion $CLIAPIMinVersion $ControllerAPIVersion $ControllerAPIMinVersion $DataFormatVersion $DataFormatMinVersion $arch
+build_version_test_images $((CLIAPIVersion+1)) $((CLIAPIVersion+1)) $ControllerAPIVersion $ControllerAPIMinVersion $DataFormatVersion $DataFormatMinVersion $arch

--- a/build_engine_test_images/terraform/aws/ubuntu/data.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/data.tf
@@ -1,0 +1,10 @@
+# Query AWS for Ubuntu AMI
+data "aws_ami" "aws_ami_ubuntu" {
+  most_recent      = true
+  owners           = [var.aws_ami_ubuntu_account_number]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu*${var.distro_version}-${var.build_engine_arch}-server-*"]
+  }
+}

--- a/build_engine_test_images/terraform/aws/ubuntu/main.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/main.tf
@@ -1,0 +1,221 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  access_key = var.build_engine_aws_access_key
+  secret_key = var.build_engine_aws_secret_key
+}
+
+# Create a random string suffix for instance names
+resource "random_string" "random_suffix" {
+  length           = 8
+  special          = false
+  lower            = true
+  upper            = false
+}
+
+# Create a VPC
+resource "aws_vpc" "build_engine_aws_vpc" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "${var.build_engine_aws_vpc_name}-${random_string.random_suffix.id}"
+  }
+}
+
+# Create internet gateway
+resource "aws_internet_gateway" "build_engine_aws_igw" {
+  vpc_id = aws_vpc.build_engine_aws_vpc.id
+
+  tags = {
+    Name = "build_engine_igw"
+  }
+}
+
+# Create build_node security group
+resource "aws_security_group" "build_engine_aws_secgrp" {
+  name        = "build_engine_aws_secgrp"
+  description = "Allow all inbound traffic"
+  vpc_id      = aws_vpc.build_engine_aws_vpc.id
+
+  ingress {
+    description = "Allow SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "build_engine_aws_sec_grp_build_node-${random_string.random_suffix.id}"
+  }
+}
+
+# Create Public subnet
+resource "aws_subnet" "build_engine_aws_public_subnet" {
+  vpc_id     = aws_vpc.build_engine_aws_vpc.id
+  availability_zone = var.aws_availability_zone
+  cidr_block = "10.0.1.0/24"
+
+  tags = {
+    Name = "build_engine_public_subnet-${random_string.random_suffix.id}"
+  }
+}
+
+# Create route table for public subnets
+resource "aws_route_table" "build_engine_aws_public_rt" {
+  depends_on = [
+    aws_internet_gateway.build_engine_aws_igw,
+  ]
+
+  vpc_id = aws_vpc.build_engine_aws_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.build_engine_aws_igw.id
+  }
+
+  tags = {
+    Name = "build_engine_aws_public_rt-${random_string.random_suffix.id}"
+  }
+}
+
+# Assciate public subnet to public route table
+resource "aws_route_table_association" "build_engine_aws_public_subnet_rt_association" {
+  depends_on = [
+    aws_subnet.build_engine_aws_public_subnet,
+    aws_route_table.build_engine_aws_public_rt
+  ]
+
+  subnet_id      = aws_subnet.build_engine_aws_public_subnet.id
+  route_table_id = aws_route_table.build_engine_aws_public_rt.id
+}
+
+# Create AWS key pair
+resource "aws_key_pair" "build_engine_aws_pair_key" {
+  key_name   = format("%s_%s", "build_engine_aws_key_pair", "${random_string.random_suffix.id}")
+  public_key = file(var.aws_ssh_public_key_file_path)
+}
+
+# Create build_node instances
+resource "aws_instance" "build_engine_aws_instance" {
+ depends_on = [
+    aws_subnet.build_engine_aws_public_subnet,
+  ]
+
+  count = var.build_engine_aws_instance_count
+
+  availability_zone = var.aws_availability_zone
+
+  ami           = data.aws_ami.aws_ami_ubuntu.id
+  instance_type = var.build_engine_aws_instance_type
+
+  subnet_id = aws_subnet.build_engine_aws_public_subnet.id
+  vpc_security_group_ids = [
+    aws_security_group.build_engine_aws_secgrp.id
+  ]
+
+  root_block_device {
+    delete_on_termination = true
+    volume_size = var.build_engine_aws_instance_root_block_device_size
+  }
+
+  key_name = aws_key_pair.build_engine_aws_pair_key.key_name
+  user_data = file("${path.module}/user-data-scripts/provision.sh")
+  
+  tags = {
+    Name = "${var.build_engine_aws_instance_name}-${count.index}-${random_string.random_suffix.id}"
+    DoNotDelete	= "true"
+    Owner = "longhorn-infra"
+  }
+}
+
+resource "aws_eip" "build_engine_aws_eip_build_node" {
+  count    = var.build_engine_aws_instance_count
+  vpc      = true
+}
+
+# Associate every EIP with build_node instance
+resource "aws_eip_association" "build_engine_aws_eip_assoc" {
+  depends_on = [
+    aws_instance.build_engine_aws_instance,
+    aws_eip.build_engine_aws_eip_build_node
+  ]
+
+  count    = var.build_engine_aws_instance_count
+
+  instance_id   = element(aws_instance.build_engine_aws_instance, count.index).id
+  allocation_id = element(aws_eip.build_engine_aws_eip_build_node, count.index).id
+}
+
+# wait for docker to start on instances (for rke on amd64 only)
+resource "null_resource" "wait_for_docker_start" {
+  depends_on = [
+    aws_instance.build_engine_aws_instance,
+    aws_eip.build_engine_aws_eip_build_node,
+    aws_eip_association.build_engine_aws_eip_assoc
+  ]
+
+  count = var.build_engine_aws_instance_count
+
+  provisioner "remote-exec" {
+    inline = ["until( systemctl is-active docker.service ); do echo \"waiting for docker to start \"; sleep 2; done"]
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      host     = element(aws_eip.build_engine_aws_eip_build_node, count.index).public_ip
+      private_key = file(var.aws_ssh_private_key_file_path)
+    }
+  }
+}
+
+# build engine base image with different commit ID
+resource "null_resource" "build_images" {
+  depends_on = [
+    null_resource.wait_for_docker_start,
+    aws_eip.build_engine_aws_eip_build_node,
+  ]
+
+  count = var.build_engine_aws_instance_count
+
+  provisioner "file" {
+    source      = "${var.tf_workspace}/scripts/generate_images.sh"
+    destination = "/tmp/generate_images.sh"
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      host     = element(aws_eip.build_engine_aws_eip_build_node, count.index).public_ip
+      private_key = file(var.aws_ssh_private_key_file_path)
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+        "sudo chmod +x /tmp/generate_images.sh",
+        "sudo /tmp/generate_images.sh ${var.build_engine_arch} ${var.docker_id} ${var.docker_password} ${var.docker_repo}"
+    ]
+
+    connection {
+      type     = "ssh"
+      user     = "ubuntu"
+      host     = element(aws_eip.build_engine_aws_eip_build_node, count.index).public_ip
+      private_key = file(var.aws_ssh_private_key_file_path)
+    }
+  }
+}

--- a/build_engine_test_images/terraform/aws/ubuntu/user-data-scripts/provision.sh
+++ b/build_engine_test_images/terraform/aws/ubuntu/user-data-scripts/provision.sh
@@ -1,0 +1,8 @@
+#!/bin/bash 
+
+DOCKER_VERSION=20.10
+
+sudo apt-get update 
+sudo apt-get install -y build-essential git nfs-common jq docker.io
+
+sudo usermod -aG docker ubuntu

--- a/build_engine_test_images/terraform/aws/ubuntu/variables.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/variables.tf
@@ -1,0 +1,96 @@
+variable "build_engine_aws_access_key" {
+  type        = string
+  description = "AWS ACCESS_KEY"
+  #sensitive   = true
+}
+
+variable "build_engine_aws_secret_key" {
+  type        = string
+  description = "AWS SECRET_KEY"
+  #sensitive   = true
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "tf_workspace" {
+  type        = string
+}
+
+variable "aws_availability_zone" {
+  type        = string
+  default     = "us-east-1a"
+}
+
+variable "build_engine_aws_vpc_name" {
+  type        = string
+  default     = "vpc-build-test-engine"
+}
+
+variable "build_engine_arch" {
+  type        = string
+  description = "available values (amd64, arm64)"
+}
+
+variable "distro_version" {
+  type        = string
+  default     = "20.04"
+}
+
+variable "aws_ami_ubuntu_account_number" {
+  type        = string
+  default     = "099720109477"
+}
+
+variable "build_engine_aws_instance_count" {
+  type        = number
+  default     = 1
+}
+
+variable "build_engine_aws_instance_name" {
+  type        = string
+  default     = "build_test_engine_node"
+}
+
+variable "build_engine_aws_instance_type" {
+  type        = string
+  description = "Recommended instance types t2.xlarge for amd64 & a1.xlarge  for arm64"
+  default     = ""
+}
+
+variable "build_engine_aws_instance_root_block_device_size" {
+  type        = number
+  default     = 40
+}
+
+variable "aws_ssh_public_key_file_path" {
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+variable "aws_ssh_private_key_file_path" {
+  type        = string
+  default     = "~/.ssh/id_rsa"
+}
+
+variable "docker_id" {
+  type        = string
+  description = "read form TF_VAR_docker_id"
+  default     = ""
+  #sensitive   = true
+}
+
+variable "docker_password" {
+  type        = string
+  description = "read from TF_VAR_docker_password"
+  default     = ""
+  #sensitive   = true
+}
+
+variable "docker_repo" {
+  type        = string
+  description = "read from TF_VAR_docker_repo"
+  default     = ""
+}


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

From https://github.com/longhorn/longhorn/issues/1961, https://github.com/longhorn/longhorn/issues/4206


Will build amd64/arm64 test engine image by API version for longhorn-test use and push to specific docker hub repo
```
chanow/longhorn-engine:upgrade-test.5-3.3-3.1-1
chanow/longhorn-engine:version-test.5-3.3-3.1-1
chanow/longhorn-engine:version-test.6-4.3-3.1-1
chanow/longhorn-engine:version-test.6-6.3-3.1-1
chanow/longhorn-engine:version-test.4-2.3-3.1-1
chanow/longhorn-engine:version-test.2-2.3-3.1-1
```

Test reault : [amd64](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/1602/), [arm64](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/1601/parameters/)

Environment
- Have docker installed
- Have local private ssh key
- Have jq installed

Environment Variable
- `TF_VAR_build_engine_aws_access_key`
- `TF_VAR_build_engine_aws_secret_key`
- `TF_VAR_docker_repo` (should be set to **longhornio/longhorn-test**)
- `TF_VAR_docker_id` (docker id for longhornio/longhorn-test)
- `TF_VAR_docker_password` (docker password for longhornio/longhorn-test)

Run

- Switch to `build_engine_test_images` folder
- run `./run.sh`
- Result as below when set `TF_VAR_docker_repo` to `chanow/longhron-engine`
![Screenshot from 2022-07-11 11-38-42](https://user-images.githubusercontent.com/73337386/178184948-c3056570-31a9-479a-8ccc-56befb6b67ff.png)

