### PR TITLE
change build test engine zone form us-east-1a to us-east-1b

### DIFF
--- a/build_engine_test_images/terraform/aws/ubuntu/variables.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/variables.tf
@@ -21,7 +21,7 @@ variable "tf_workspace" {
 
 variable "aws_availability_zone" {
   type        = string
-  default     = "us-east-1a"
+  default     = "us-east-1b"
 }
 
 variable "build_engine_aws_vpc_name" {


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

Got error `Your requested instance type (a1.medium) is not supported in your requested Availability Zone (us-east-1a)` when building arm64 test images, change zone from us-east-1a to us-east-1b