### PR TITLE
Fix no cleanup_volume_by_name() in v1.2.x

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -297,6 +297,13 @@ def cleanup_volume(client, volume):
     assert len(volumes) == 0
 
 
+def cleanup_volume_by_name(client, vol_name):
+    volume = client.by_id_volume(vol_name)
+    volume.detach(hostId="")
+    client.delete(volume)
+    wait_for_volume_delete(client, vol_name)
+
+
 def cleanup_all_volumes(client):
     """
     Clean up all volumes


### PR DESCRIPTION
Fix no cleanup_volume_by_name() in v1.2.x

For https://github.com/longhorn/longhorn/issues/4304

Signed-off-by: Yang Chiu <yang.chiu@suse.com>