### PR TITLE
Add replica removal retry for test_disk_eviction_with_node_level_soft_anti_affinity_disabled

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1829,6 +1829,11 @@ def wait_for_volume_replicas_running_on_hosts(client, volume_name, host_ids,
     return volume
 
 
+def is_replica_available(r):
+    return r is not None and r.running and not \
+        r.failedAt and r.mode == 'RW'
+
+
 def wait_for_volume_frontend_disabled(client, volume_name, state=True):
     for _ in range(RETRY_COUNTS):
         vol = client.by_id_volume(volume_name)

--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -36,6 +36,7 @@ from common import create_and_wait_pod
 from common import get_pod_data_md5sum
 from common import wait_for_volume_healthy
 from common import wait_for_volume_replica_count
+from common import is_replica_available
 from common import delete_and_wait_pod
 from common import wait_for_volume_detached
 from common import RETRY_COUNTS, RETRY_INTERVAL
@@ -2621,14 +2622,13 @@ def test_disk_eviction_with_node_level_soft_anti_affinity_disabled(client, # NOQ
 
     # Step 2
     nodes = client.list_node()
-    vol_name = common.generate_volume_name()
-    volume = client.create_volume(name=vol_name,
+    volume = client.create_volume(name=volume_name,
                                   size=SIZE, numberOfReplicas=len(nodes))
-    common.wait_for_volume_detached(client, vol_name)
+    common.wait_for_volume_detached(client, volume_name)
 
     lht_hostId = get_self_host_id()
     volume.attach(hostId=lht_hostId)
-    volume = common.wait_for_volume_healthy(client, vol_name)
+    volume = common.wait_for_volume_healthy(client, volume_name)
 
     # Step 3
     data = common.write_volume_random_data(volume)
@@ -2663,16 +2663,35 @@ def test_disk_eviction_with_node_level_soft_anti_affinity_disabled(client, # NOQ
             break
         time.sleep(common.RETRY_EXEC_INTERVAL)
     assert len(os.listdir(replica_path)) > 0
+    volume = wait_for_volume_healthy(client, volume_name)
 
     # Step 7
     replica_count = 1
-    volume = client.by_id_volume(vol_name)
-    volume = volume.updateReplicaCount(replicaCount=replica_count)
-    volume = common.wait_for_volume_healthy(client, vol_name)
+    volume.updateReplicaCount(replicaCount=replica_count)
+    volume = wait_for_volume_healthy(client, volume_name)
 
-    for r in volume.replicas:
-        if r.hostId != lht_hostId:
-            volume.replicaRemove(name=r.name)
+    done = False
+    for i in range(RETRY_COUNTS):
+        other_replicas_deleted = True
+        new_replica_available = False
+        volume = client.by_id_volume(volume_name)
+        for r in volume.replicas:
+            if r.hostId != lht_hostId:
+                try:
+                    volume.replicaRemove(name=r.name)
+                except Exception:
+                    other_replicas_deleted = False
+                    break
+            else:
+                if r.diskPath == test_disk_path and is_replica_available(r):
+                    new_replica_available = True
+
+        if other_replicas_deleted and \
+                len(volume.replicas) == 1 and new_replica_available:
+            done = True
+            break
+        time.sleep(RETRY_INTERVAL)
+    assert done
 
     common.check_volume_data(volume, data)
 


### PR DESCRIPTION
When deleting the replica at step 7 of the test, the new replica
rebuilding may be not done yet. Then the ReplicaRemove API would
be rejected until the new replica is healthy.

Here I prefer to use a retry rather than directly checking and
waiting for the new replica rebuilding. Since this retry operation
would help verify that the last replica won't disappear
accidentally.

Longhorn/longhorn#4238