### PR TITLE
Fix test_engine_crash_for_restore_volum

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4427,7 +4427,7 @@ def wait_for_instance_manager_desire_state(client, core_api, im_name,
                 continue
             # Report any other error
             else:
-                assert(not e)
+                assert (not e)
         if desire:
             if im.currentState == state.lower() and pod.status.phase == state:
                 break

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -1727,7 +1727,12 @@ def test_engine_crash_for_restore_volume(set_random_backupstore, client, core_ap
     # Check if the restore volume is auto reattached then continue
     # restoring data.
     crash_engine_process_with_sigkill(client, core_api, res_name)
-    wait_for_volume_detached(client, res_name)
+    # From https://github.com/longhorn/longhorn/issues/4309#issuecomment-1197897496 # NOQA
+    # The complete state transition would be like:
+    # detaching -> detached -> attaching -> attached -> restore -> detached .
+    # Now the state change too fast, script eventually caught final detach
+    # So temporaly comment out below line of code
+    # wait_for_volume_detached(client, res_name)
 
     res_volume = wait_for_volume_healthy_no_frontend(client, res_name)
     assert res_volume.ready is False


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

From https://github.com/longhorn/longhorn/issues/4309
Root cause : https://github.com/longhorn/longhorn/issues/4309#issuecomment-1197897496

Remove code for catch volume detach after `crash_engine_process_with_sigkill`
Without that line, test script still checked `RestoreInProgress` after engine crash and check restored volume's md5, which matched the test goal