### PR TITLE
Use longer timeout when running HDD regression test

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -234,7 +234,7 @@ NODE_UPDATE_RETRY_COUNT = 30
 disk_being_syncing = "being syncing and please retry later"
 
 # customize the timeout for HDD
-disktype = os.environ['LONGHORN_DISK_TYPE']
+disktype = os.environ.get('LONGHORN_DISK_TYPE')
 if disktype == "hdd":
     RETRY_COUNTS *= 32
     DEFAULT_DEPLOYMENT_TIMEOUT *= 32

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -339,6 +339,10 @@ run_longhorn_tests(){
       yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
     fi
 
+  if [[ "${TF_VAR_use_hdd}" == true ]]; then
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[3].value="hdd"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  fi
+
 	set +x
 	## inject aws cloudprovider and credentials env variables from created secret
 	yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "CLOUDPROVIDER", "value": "aws"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"


### PR DESCRIPTION
Use longer timeout when running HDD regression test

For https://github.com/longhorn/longhorn/issues/4228

Signed-off-by: Yang Chiu <yang.chiu@suse.com>