### PR TITLE
Fix flaky test_ha_salvage

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -334,6 +334,11 @@ def ha_salvage_test(client, core_api, # NOQA
     data = write_volume_random_data(volume)
 
     crash_replica_processes(client, core_api, volume_name)
+    # This is a workaround, since in some case it's hard to
+    # catch faulted volume status
+    common.wait_for_volume_status(client, volume_name,
+                                  common.VOLUME_FIELD_STATE,
+                                  'attaching')
 
     volume = common.wait_for_volume_healthy(client, volume_name)
     assert len(volume.replicas) == 3
@@ -373,6 +378,11 @@ def ha_salvage_test(client, core_api, # NOQA
     data = write_volume_random_data(volume)
 
     crash_replica_processes(client, core_api, volume_name)
+    # This is a workaround, since in some case it's hard to
+    # catch faulted volume status
+    common.wait_for_volume_status(client, volume_name,
+                                  common.VOLUME_FIELD_STATE,
+                                  'attaching')
 
     volume = common.wait_for_volume_healthy(client, volume_name)
     assert len(volume.replicas) == 3


### PR DESCRIPTION
Signed-off-by: Chris Chien [chris.chien@suse.com](mailto:chris.chien@suse.com)

Fix flaky test_ha_salvage https://github.com/longhorn/longhorn/issues/4381#issuecomment-1212704361

In case the volume faulted status was not easily to catch by script. modify script to detect volume `attaching` state is more stable
 Test PR code 20 times on pipeline were [passed](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/1873/)