### PR TITLE
Fix missing write_volume_dev_random_mb_data method in v1.2.x

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -765,6 +765,30 @@ def copy_pod_volume_data(api, pod_name, src_path, dest_path):
         tty=False)
 
 
+def write_volume_dev_random_mb_data(path, offset_in_mb, length_in_mb):
+    write_cmd = [
+        '/bin/sh',
+        '-c',
+        'dd if=/dev/urandom of=%s bs=1M seek=%d count=%d' %
+        (path, offset_in_mb, length_in_mb)
+    ]
+    with timeout(seconds=STREAM_EXEC_TIMEOUT * 3,
+                 error_message='Timeout on writing dev'):
+        subprocess.check_call(write_cmd)
+
+
+def get_volume_dev_mb_data_md5sum(path, offset_in_mb, length_in_mb):
+    md5sum_command = [
+        '/bin/sh', '-c',
+        'dd if=%s bs=1M skip=%d count=%d | md5sum | awk \'{print $1}\'' %
+        (path, offset_in_mb, length_in_mb)
+    ]
+
+    with timeout(seconds=STREAM_EXEC_TIMEOUT * 5,
+                 error_message='Timeout on computing dev md5sum'):
+        return subprocess.check_output(md5sum_command).strip().decode('utf-8')
+
+
 def size_to_string(volume_size):
     # type: (int) -> str
     """


### PR DESCRIPTION
Fix missing write_volume_dev_random_mb_data method in v1.2.x

Signed-off-by: Yang Chiu <yang.chiu@suse.com>