### PR TITLE
[Backport v1.2.x] Fix flaky test_ha_salvage

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -333,6 +333,11 @@ def ha_salvage_test(client, core_api, # NOQA
     data = write_volume_random_data(volume)
 
     crash_replica_processes(client, core_api, volume_name)
+    # This is a workaround, since in some case it's hard to
+    # catch faulted volume status
+    common.wait_for_volume_status(client, volume_name,
+                                  common.VOLUME_FIELD_STATE,
+                                  'attaching')
 
     volume = common.wait_for_volume_healthy(client, volume_name)
     assert len(volume.replicas) == 3
@@ -372,6 +377,11 @@ def ha_salvage_test(client, core_api, # NOQA
     data = write_volume_random_data(volume)
 
     crash_replica_processes(client, core_api, volume_name)
+    # This is a workaround, since in some case it's hard to
+    # catch faulted volume status
+    common.wait_for_volume_status(client, volume_name,
+                                  common.VOLUME_FIELD_STATE,
+                                  'attaching')
 
     volume = common.wait_for_volume_healthy(client, volume_name)
     assert len(volume.replicas) == 3


### PR DESCRIPTION
Backport https://github.com/longhorn/longhorn-tests/pull/1075 to v1.2.x