### PR TITLE
ci: fix manifest air gap installation pipeline failed in v1.2.x

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -114,6 +114,7 @@ wait_longhorn_status_running(){
 
 get_longhorn_manifest(){
   wget ${LONGHORN_MANIFEST_URL} -P ${TF_VAR_tf_workspace}
+  sed -i ':a;N;$!ba;s/---\n---/---/g' "${TF_VAR_tf_workspace}/longhorn.yaml"
 }
 
 
@@ -171,7 +172,9 @@ generate_longhorn_yaml_manifest() {
 
     for FILE in `find "${LONGHORN_MANAGER_REPO_DIR}/deploy/install" -type f -name "*\.yaml" | sort`; do
       cat ${FILE} >> "${MANIFEST_BASEDIR}/longhorn.yaml"
-      echo "---"  >> "${MANIFEST_BASEDIR}/longhorn.yaml"
+      if [[ `tail -1 "${MANIFEST_BASEDIR}/longhorn.yaml"` != "---" ]]; then
+        echo "---"  >> "${MANIFEST_BASEDIR}/longhorn.yaml"
+      fi
     done
 
 	# get longhorn default images from yaml manifest


### PR DESCRIPTION
ci: fix manifest air gap installation pipeline failed in v1.2.x by avoiding duplicated document separator in yaml file causing yq parsing error.

For https://github.com/longhorn/longhorn/issues/4479

Signed-off-by: Yang Chiu <yang.chiu@suse.com>