### PR TITLE
[BACKPORT][v1.2.x] Add test case: failed backups cleanup

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -171,6 +171,7 @@ SETTING_TAINT_TOLERATION = "taint-toleration"
 SETTING_BACKING_IMAGE_CLEANUP_WAIT_INTERVAL = \
     "backing-image-cleanup-wait-interval"
 SETTING_DISABLE_REVISION_COUNTER = "disable-revision-counter"
+SETTING_FAILED_BACKUP_TTL = "failed-backup-ttl"
 
 CSI_UNKNOWN = 0
 CSI_TRUE = 1


### PR DESCRIPTION
Cover enabling and disabling auto failed backup cleanup.

longhorn/longhorn#4514

Signed-off-by: James Lu <james.lu@suse.com>