### PR TITLE
ci: support running secscan test on specified longhorn branch/version

### DIFF
--- a/secscan/Jenkinsfile
+++ b/secscan/Jenkinsfile
@@ -12,6 +12,7 @@ node {
                              --name ${JOB_BASE_NAME}${BUILD_NUMBER} \
                              --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} \
                              --env TF_VAR_severity=${TF_VAR_SEVERITY} \
+                             --env TF_VAR_longhorn_version=${TF_VAR_LONGHORN_VERSION} \
                              --env TF_VAR_lh_aws_access_key=${AWS_ACCESS_KEY} \
                              --env TF_VAR_lh_aws_secret_key=${AWS_SECRET_KEY} \
                              ${imageName}

--- a/secscan/scripts/secscan.sh
+++ b/secscan/scripts/secscan.sh
@@ -3,10 +3,11 @@
 set -x
 
 SEVERITY=${1}
+LONGHORN_VERSION=${2}
 
 mkdir -p /junit-reports /templates
 
-wget https://raw.githubusercontent.com/longhorn/longhorn-manager/master/deploy/longhorn-images.txt
+wget "https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn-images.txt"
 IMAGES=($(< longhorn-images.txt))
 
 wget -O /templates/junit.tpl https://raw.githubusercontent.com/longhorn/longhorn-tests/master/secscan/templates/junit.tpl

--- a/secscan/terraform/aws/main.tf
+++ b/secscan/terraform/aws/main.tf
@@ -198,7 +198,7 @@ resource "null_resource" "secscan" {
 
     inline = [
       "chmod +x /home/ubuntu/secscan.sh",
-      "sudo /home/ubuntu/secscan.sh \"${var.severity}\"",
+      "sudo /home/ubuntu/secscan.sh \"${var.severity}\" \"${var.longhorn_version}\"",
     ]
   }
 

--- a/secscan/terraform/aws/variables.tf
+++ b/secscan/terraform/aws/variables.tf
@@ -73,3 +73,8 @@ variable "aws_ssh_private_key_file_path" {
 variable "severity" {
   type        = string
 }
+
+variable "longhorn_version" {
+  type        = string
+  default     = "master"
+}


### PR DESCRIPTION
ci: support running secscan test on specified longhorn branch/version

For https://github.com/longhorn/longhorn/issues/4357

Signed-off-by: Yang Chiu <yang.chiu@suse.com>