### PR TITLE
[Backport 1.3.x] Modify backup_labels_test for new auto generated backup label

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -1304,7 +1304,11 @@ def backup_labels_test(client, random_labels, volume_name, size=SIZE, backing_im
     # If we're running the test with a BackingImage,
     # check field `volumeBackingImageName` is set properly.
     backup = bv.backupGet(name=b.name)
-    assert len(backup.labels) == len(random_labels)
+    # Longhorn will automatically add a label `longhorn.io/volume-access-mode`
+    # to a newly created backup
+    assert len(backup.labels) == len(random_labels) + 1
+    assert random_labels["key"] == backup.labels["key"]
+    assert "longhorn.io/volume-access-mode" in backup.labels.keys()
     wait_for_backup_volume(client, volume_name, backing_image)
 
 


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

Backport https://github.com/longhorn/longhorn-tests/pull/1098 to v1.3.x