### PR TITLE
ci: get rid of longhorn-manger repo in test setup

### DIFF
--- a/manager/integration/scripts/upgrade-longhorn.sh
+++ b/manager/integration/scripts/upgrade-longhorn.sh
@@ -1,14 +1,14 @@
 #!/bin/bash 
 
-LONGHORN_MANAGER_REPO_URI="${1}"
-LONGHORN_MANAGER_BRANCH="${2}"
+LONGHORN_REPO_URI="${1}"
+LONGHORN_REPO_BRANCH="${2}"
 CUSTOM_LONGHORN_MANAGER_IMAGE="${3}"
 CUSTOM_LONGHORN_ENGINE_IMAGE="${4}"
 CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE="${5}"
 CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE="${6}"
 CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE="${7}"
 
-LONGHORN_MANAGER_REPO_DIR="/tmp/longhorn-manager"
+LONGHORN_REPO_DIR="/tmp/longhorn"
 LONGHORN_MANIFEST="/tmp/longhorn.yml"
 
 LONGHORN_NAMESPACE="longhorn-system"
@@ -32,20 +32,18 @@ wait_longhorn_status_running(){
 }
 
 git clone --single-branch \
-          --branch ${LONGHORN_MANAGER_BRANCH} \
-          ${LONGHORN_MANAGER_REPO_URI} \
-          ${LONGHORN_MANAGER_REPO_DIR}
+          --branch ${LONGHORN_REPO_BRANCH} \
+          ${LONGHORN_REPO_URI} \
+          ${LONGHORN_REPO_DIR}
 
-for FILE in `find "${LONGHORN_MANAGER_REPO_DIR}/deploy/install" -type f -name "*\.yaml" | sort`; do
-  cat ${FILE} >> "${LONGHORN_MANIFEST}"
-  echo "---"  >> "${LONGHORN_MANIFEST}"
-done
+cat "${LONGHORN_REPO_DIR}/deploy/longhorn.yaml" > "${LONGHORN_MANIFEST}"
+sed -i ':a;N;$!ba;s/---\n---/---/g' "${LONGHORN_MANIFEST}"
 
-LONGHORN_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-manager:.*$" "${LONGHORN_MANIFEST}"| head -1`
-LONGHORN_ENGINE_IMAGE=`grep -io "longhornio\/longhorn-engine:.*$" "${LONGHORN_MANIFEST}"| head -1`
-LONGHORN_INSTANCE_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-instance-manager:.*$" "${LONGHORN_MANIFEST}"| head -1`
-LONGHORN_SHARE_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-share-manager:.*$" "${LONGHORN_MANIFEST}"| head -1`
-LONGHORN_BACKING_IMAGE_MANAGER_IMAGE=`grep -io "longhornio\/backing-image-manager:.*$" "${LONGHORN_MANIFEST}"| head -1`
+LONGHORN_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-manager:.*$" "${LONGHORN_MANIFEST}"| head -1 | sed -e 's/^"//' -e 's/"$//'`
+LONGHORN_ENGINE_IMAGE=`grep -io "longhornio\/longhorn-engine:.*$" "${LONGHORN_MANIFEST}"| head -1 | sed -e 's/^"//' -e 's/"$//'`
+LONGHORN_INSTANCE_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-instance-manager:.*$" "${LONGHORN_MANIFEST}"| head -1 | sed -e 's/^"//' -e 's/"$//'`
+LONGHORN_SHARE_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-share-manager:.*$" "${LONGHORN_MANIFEST}"| head -1 | sed -e 's/^"//' -e 's/"$//'`
+LONGHORN_BACKING_IMAGE_MANAGER_IMAGE=`grep -io "longhornio\/backing-image-manager:.*$" "${LONGHORN_MANIFEST}"| head -1 | sed -e 's/^"//' -e 's/"$//'`
 
 # replace longhorn images with custom images
 sed -i 's#'${LONGHORN_MANAGER_IMAGE}'#'${CUSTOM_LONGHORN_MANAGER_IMAGE}'#' "${LONGHORN_MANIFEST}"

--- a/manager/integration/tests/conftest.py
+++ b/manager/integration/tests/conftest.py
@@ -15,8 +15,8 @@ SKIP_INFRA_OPT = "--skip-infra-test"
 INCLUDE_STRESS_OPT = "--include-stress-test"
 INCLUDE_UPGRADE_OPT = "--include-upgrade-test"
 
-UPGRADE_LH_MANAGER_REPO_URL = "--upgrade-lh-manager-repo-url"
-UPGRADE_LH_MANAGER_REPO_BRANCH = "--upgrade-lh-manager-repo-branch"
+UPGRADE_LH_REPO_URL = "--upgrade-lh-repo-url"
+UPGRADE_LH_REPO_BRANCH = "--upgrade-lh-repo-branch"
 UPGRADE_LH_MANAGER_IMAGE = "--upgrade-lh-manager-image"
 UPGRADE_LH_ENGINE_IMAGE = "--upgrade-lh-engine-image"
 UPGRADE_LH_INSTANCE_MANAGER_IMAGE = "--upgrade-lh-instance-manager-image"
@@ -45,18 +45,18 @@ def pytest_addoption(parser):
                      default=False,
                      help="include upgrade tests (default: False)")
 
-    longhorn_manager_repo_url =\
-        "https://github.com/longhorn/longhorn-manager.git"
-    parser.addoption(UPGRADE_LH_MANAGER_REPO_URL, action="store",
-                     default=longhorn_manager_repo_url,
-                     help='''set longhorn-manger repo url, this will be used
+    longhorn_repo_url =\
+        "https://github.com/longhorn/longhorn.git"
+    parser.addoption(UPGRADE_LH_REPO_URL, action="store",
+                     default=longhorn_repo_url,
+                     help='''set longhorn repo url, this will be used
                      to generate longhorn yaml manifest for test_upgrade
                      (default:
-                     https://github.com/longhorn/longhorn-manager.git)''')
+                     https://github.com/longhorn/longhorn.git)''')
 
-    parser.addoption(UPGRADE_LH_MANAGER_REPO_BRANCH, action="store",
+    parser.addoption(UPGRADE_LH_REPO_BRANCH, action="store",
                      default="master",
-                     help='''set longhorn-manger repo branch, this will be used
+                     help='''set longhorn repo branch, this will be used
                      to generate longhorn yaml manifest for test_upgrade
                      (default: master)''')
 

--- a/manager/integration/tests/test_upgrade.py
+++ b/manager/integration/tests/test_upgrade.py
@@ -36,13 +36,13 @@ from common import client, core_api # NOQA
 
 
 @pytest.fixture
-def upgrade_longhorn_manager_repo_url(request):
-    return request.config.getoption("--upgrade-lh-manager-repo-url")
+def upgrade_longhorn_repo_url(request):
+    return request.config.getoption("--upgrade-lh-repo-url")
 
 
 @pytest.fixture
-def upgrade_longhorn_manager_repo_branch(request):
-    return request.config.getoption("--upgrade-lh-manager-repo-branch")
+def upgrade_longhorn_repo_branch(request):
+    return request.config.getoption("--upgrade-lh-repo-branch")
 
 
 @pytest.fixture
@@ -70,8 +70,8 @@ def upgrade_longhorn_backing_image_manager_image(request):
     return request.config.getoption("--upgrade-lh-backing-image-manager-image")
 
 
-def longhorn_upgrade(longhorn_manager_repo,
-                     longhorn_manager_branch,
+def longhorn_upgrade(longhorn_repo_url,
+                     longhorn_repo_branch,
                      longhorn_manager_image,
                      longhorn_engine_image,
                      longhorn_instance_manager_image,
@@ -80,8 +80,8 @@ def longhorn_upgrade(longhorn_manager_repo,
 
     command = "../scripts/upgrade-longhorn.sh"
     process = subprocess.Popen([command,
-                                longhorn_manager_repo,
-                                longhorn_manager_branch,
+                                longhorn_repo_url,
+                                longhorn_repo_branch,
                                 longhorn_manager_image,
                                 longhorn_engine_image,
                                 longhorn_instance_manager_image,
@@ -99,8 +99,8 @@ def longhorn_upgrade(longhorn_manager_repo,
 
 
 @pytest.mark.upgrade  # NOQA
-def test_upgrade(upgrade_longhorn_manager_repo_url,
-                 upgrade_longhorn_manager_repo_branch,
+def test_upgrade(upgrade_longhorn_repo_url,
+                 upgrade_longhorn_repo_branch,
                  upgrade_longhorn_manager_image,
                  upgrade_longhorn_engine_image,
                  upgrade_longhorn_instance_manager_image,
@@ -137,8 +137,8 @@ def test_upgrade(upgrade_longhorn_manager_repo_url,
     13. Attach the volume, and recreate Pod, and StatefulSet
     14. Check All volumes data
     """
-    longhorn_manager_repo = upgrade_longhorn_manager_repo_url
-    longhorn_manager_branch = upgrade_longhorn_manager_repo_branch
+    longhorn_repo_url = upgrade_longhorn_repo_url
+    longhorn_repo_branch = upgrade_longhorn_repo_branch
     longhorn_manager_image = upgrade_longhorn_manager_image
     longhorn_engine_image = upgrade_longhorn_engine_image
     longhorn_instance_manager_image = upgrade_longhorn_instance_manager_image
@@ -188,8 +188,8 @@ def test_upgrade(upgrade_longhorn_manager_repo_url,
                               sspod_info['data'])
 
     # upgrade Longhorn
-    assert longhorn_upgrade(longhorn_manager_repo,
-                            longhorn_manager_branch,
+    assert longhorn_upgrade(longhorn_repo_url,
+                            longhorn_repo_branch,
                             longhorn_manager_image,
                             longhorn_engine_image,
                             longhorn_instance_manager_image,

--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -25,8 +25,8 @@ node {
                                    --env CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE=${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE} \
                                    --env LONGHORN_TESTS_CUSTOM_IMAGE=${LONGHORN_TESTS_CUSTOM_IMAGE} \
                                    --env DISTRO=${DISTRO} \
-                                   --env LONGHORN_MANAGER_REPO_URI=${LONGHORN_MANAGER_REPO_URI} \
-                                   --env LONGHORN_MANAGER_BRANCH=${LONGHORN_MANAGER_BRANCH} \
+                                   --env LONGHORN_REPO_URI=${LONGHORN_REPO_URI} \
+                                   --env LONGHORN_REPO_BRANCH=${LONGHORN_REPO_BRANCH} \
                                    --env LONGHORN_STABLE_VERSION=${LONGHORN_STABLE_VERSION} \
                                    --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} \
                                    --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} \


### PR DESCRIPTION
ci: get rid of longhorn-manger repo in test setup

For https://github.com/longhorn/longhorn/issues/4476

Signed-off-by: Yang Chiu <yang.chiu@suse.com>