### PR TITLE
ci: prevent stuck in download support bundle forever if it cannot be downloaded

### DIFF
--- a/test_framework/scripts/download-support-bundle.sh
+++ b/test_framework/scripts/download-support-bundle.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 SUPPORT_BUNDLE_FILE_NAME=${1:-"lh-support-bundle.zip"}
 SUPPORT_BUNDLE_ISSUE_URL=${2:-""}
 SUPPORT_BUNDLE_ISSUE_DESC=${3:-"Auto-generated support buundle"}


### PR DESCRIPTION
ci: prevent stuck in download support bundle forever if it cannot be downloaded

For https://github.com/longhorn/longhorn/issues/4072

Signed-off-by: Yang Chiu <yang.chiu@suse.com>