### PR TITLE
ci: ensure all testing resources have proper tag to be identified

### DIFF
--- a/airgap/terraform/main.tf
+++ b/airgap/terraform/main.tf
@@ -53,6 +53,7 @@ resource "aws_vpc" "lh_registry_aws_vpc" {
 
   tags = {
     Name = "lh-registry-vpc-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -62,6 +63,7 @@ resource "aws_internet_gateway" "lh_registry_aws_igw" {
 
   tags = {
     Name = "lh-registry-igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -120,6 +122,7 @@ resource "aws_security_group" "lh_registry_aws_secgrp" {
 
   tags = {
     Name = "lh-registry-secgrp-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -133,6 +136,7 @@ resource "aws_subnet" "lh_registry_aws_public_subnet" {
 
   tags = {
     Name = "lh-registry-public-subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -146,6 +150,7 @@ resource "aws_subnet" "lh_registry_aws_private_subnet" {
 
   tags = {
     Name = "lh-registry-private-subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -164,6 +169,7 @@ resource "aws_route_table" "lh_registry_aws_public_rt" {
 
   tags = {
     Name = "lh-registry-aws-public-rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -182,6 +188,7 @@ resource "aws_route_table" "lh_registry_aws_private_rt" {
 
   tags = {
     Name = "lh-registry-aws-private-rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -211,6 +218,11 @@ resource "aws_route_table_association" "lh_registry_aws_private_subnet_rt_associ
 resource "aws_key_pair" "lh_registry_aws_pair_key" {
   key_name   = format("%s_%s", "lh_registry_aws_key_pair", random_string.random_suffix.id)
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_registry_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 # Create instance for registry
@@ -240,6 +252,8 @@ resource "aws_instance" "lh_registry_aws_instance" {
 
   tags = {
     Name = "lh-registry-${random_string.random_suffix.id}"
+    DoNotDelete = "true"
+    Owner = "longhorn-infra"
   }
 }
 

--- a/build_engine_test_images/terraform/aws/ubuntu/main.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/main.tf
@@ -27,6 +27,7 @@ resource "aws_vpc" "build_engine_aws_vpc" {
 
   tags = {
     Name = "${var.build_engine_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -35,7 +36,8 @@ resource "aws_internet_gateway" "build_engine_aws_igw" {
   vpc_id = aws_vpc.build_engine_aws_vpc.id
 
   tags = {
-    Name = "build_engine_igw"
+    Name = "build_engine_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -62,6 +64,7 @@ resource "aws_security_group" "build_engine_aws_secgrp" {
 
   tags = {
     Name = "build_engine_aws_sec_grp_build_node-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -73,6 +76,7 @@ resource "aws_subnet" "build_engine_aws_public_subnet" {
 
   tags = {
     Name = "build_engine_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -91,6 +95,7 @@ resource "aws_route_table" "build_engine_aws_public_rt" {
 
   tags = {
     Name = "build_engine_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -109,6 +114,11 @@ resource "aws_route_table_association" "build_engine_aws_public_subnet_rt_associ
 resource "aws_key_pair" "build_engine_aws_pair_key" {
   key_name   = format("%s_%s", "build_engine_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "build_engine_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 # Create build_node instances
@@ -147,6 +157,11 @@ resource "aws_instance" "build_engine_aws_instance" {
 resource "aws_eip" "build_engine_aws_eip_build_node" {
   count    = var.build_engine_aws_instance_count
   vpc      = true
+
+  tags = {
+    Name = "build_engine_aws_eip_build_node-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 # Associate every EIP with build_node instance

--- a/secscan/terraform/aws/main.tf
+++ b/secscan/terraform/aws/main.tf
@@ -18,6 +18,7 @@ resource "aws_vpc" "lh-secscan_aws_vpc" {
 
   tags = {
     Name = "${var.lh-secscan_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -26,7 +27,8 @@ resource "aws_internet_gateway" "lh-secscan_aws_igw" {
   vpc_id = aws_vpc.lh-secscan_aws_vpc.id
 
   tags = {
-    Name = "lh-secscan_igw"
+    Name = "lh-secscan_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -53,6 +55,7 @@ resource "aws_security_group" "lh-secscan_aws_secgrp" {
 
   tags = {
     Name = "lh-secscan_aws_sec_grp_secscan-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -64,6 +67,7 @@ resource "aws_subnet" "lh-secscan_aws_public_subnet" {
 
   tags = {
     Name = "lh-secscan_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -82,6 +86,7 @@ resource "aws_route_table" "lh-secscan_aws_public_rt" {
 
   tags = {
     Name = "lh-secscan_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -100,6 +105,11 @@ resource "aws_route_table_association" "lh-secscan_aws_public_subnet_rt_associat
 resource "aws_key_pair" "lh-secscan_aws_pair_key" {
   key_name   = format("%s_%s", "lh-secscan_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh-secscan_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 # Create aws instance
@@ -135,6 +145,11 @@ resource "aws_instance" "lh-secscan_aws_instance" {
 
 resource "aws_eip" "lh-secscan_aws_eip_secscan" {
   vpc      = true
+
+  tags = {
+    Name = "lh-secscan_aws_eip-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 # Associate every EIP with secscan instance

--- a/test_framework/terraform/aws/centos/main.tf
+++ b/test_framework/terraform/aws/centos/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -108,6 +110,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -151,6 +154,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -163,6 +167,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -174,6 +179,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -183,6 +189,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -200,6 +207,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -219,6 +227,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -237,6 +246,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -266,11 +276,21 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_ebs_volume" "lh_aws_hdd_volume" {
@@ -282,7 +302,8 @@ resource "aws_ebs_volume" "lh_aws_hdd_volume" {
   type              = "st1"
 
   tags = {
-    Name = "lh-aws-hdd-volume-${random_string.random_suffix.id}-${count.index}"
+    Name = "lh-aws-hdd-volume-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -305,6 +326,7 @@ resource "aws_lb_target_group" "lh_aws_lb_tg_443" {
 
   tags = {
     Name = "lh-aws-lb-tg-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -325,6 +347,7 @@ resource "aws_lb" "lh_aws_lb" {
 
   tags = {
     Name = "lh-aws-lb-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -348,6 +371,7 @@ resource "aws_lb_listener" "lh_aws_lb_listener_443" {
 
   tags = {
     Name = "lh-aws-lb-listener-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 
 }

--- a/test_framework/terraform/aws/oracle/main.tf
+++ b/test_framework/terraform/aws/oracle/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -108,6 +110,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -151,6 +154,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -163,6 +167,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -174,6 +179,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -183,6 +189,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -200,6 +207,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -219,6 +227,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -237,6 +246,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -266,11 +276,21 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_ebs_volume" "lh_aws_hdd_volume" {
@@ -282,7 +302,8 @@ resource "aws_ebs_volume" "lh_aws_hdd_volume" {
   type              = "st1"
 
   tags = {
-    Name = "lh-aws-hdd-volume-${random_string.random_suffix.id}-${count.index}"
+    Name = "lh-aws-hdd-volume-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -305,6 +326,7 @@ resource "aws_lb_target_group" "lh_aws_lb_tg_443" {
 
   tags = {
     Name = "lh-aws-lb-tg-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -325,6 +347,7 @@ resource "aws_lb" "lh_aws_lb" {
 
   tags = {
     Name = "lh-aws-lb-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -348,6 +371,7 @@ resource "aws_lb_listener" "lh_aws_lb_listener_443" {
 
   tags = {
     Name = "lh-aws-lb-listener-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 
 }

--- a/test_framework/terraform/aws/rhel/main.tf
+++ b/test_framework/terraform/aws/rhel/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -108,6 +110,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -151,6 +154,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -163,6 +167,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -174,6 +179,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -183,6 +189,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -200,6 +207,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -219,6 +227,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -237,6 +246,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -266,11 +276,21 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_ebs_volume" "lh_aws_hdd_volume" {
@@ -282,7 +302,8 @@ resource "aws_ebs_volume" "lh_aws_hdd_volume" {
   type              = "st1"
 
   tags = {
-    Name = "lh-aws-hdd-volume-${random_string.random_suffix.id}-${count.index}"
+    Name = "lh-aws-hdd-volume-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -305,6 +326,7 @@ resource "aws_lb_target_group" "lh_aws_lb_tg_443" {
 
   tags = {
     Name = "lh-aws-lb-tg-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -325,6 +347,7 @@ resource "aws_lb" "lh_aws_lb" {
 
   tags = {
     Name = "lh-aws-lb-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -348,6 +371,7 @@ resource "aws_lb_listener" "lh_aws_lb_listener_443" {
 
   tags = {
     Name = "lh-aws-lb-listener-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 
 }

--- a/test_framework/terraform/aws/rockylinux/main.tf
+++ b/test_framework/terraform/aws/rockylinux/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -109,6 +111,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -152,6 +155,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -164,6 +168,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -175,6 +180,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -184,6 +190,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -201,6 +208,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -220,6 +228,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -238,6 +247,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -267,11 +277,21 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_ebs_volume" "lh_aws_hdd_volume" {
@@ -283,7 +303,8 @@ resource "aws_ebs_volume" "lh_aws_hdd_volume" {
   type              = "st1"
 
   tags = {
-    Name = "lh-aws-hdd-volume-${random_string.random_suffix.id}-${count.index}"
+    Name = "lh-aws-hdd-volume-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -306,6 +327,7 @@ resource "aws_lb_target_group" "lh_aws_lb_tg_443" {
 
   tags = {
     Name = "lh-aws-lb-tg-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -326,6 +348,7 @@ resource "aws_lb" "lh_aws_lb" {
 
   tags = {
     Name = "lh-aws-lb-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -349,6 +372,7 @@ resource "aws_lb_listener" "lh_aws_lb_listener_443" {
 
   tags = {
     Name = "lh-aws-lb-listener-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 
 }

--- a/test_framework/terraform/aws/sles/main.tf
+++ b/test_framework/terraform/aws/sles/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -108,6 +110,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -151,6 +154,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -163,6 +167,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -174,6 +179,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -183,6 +189,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -200,6 +207,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -219,6 +227,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -237,6 +246,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -266,11 +276,21 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_ebs_volume" "lh_aws_hdd_volume" {
@@ -282,7 +302,8 @@ resource "aws_ebs_volume" "lh_aws_hdd_volume" {
   type              = "st1"
 
   tags = {
-    Name = "lh-aws-hdd-volume-${random_string.random_suffix.id}-${count.index}"
+    Name = "lh-aws-hdd-volume-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -305,6 +326,7 @@ resource "aws_lb_target_group" "lh_aws_lb_tg_443" {
 
   tags = {
     Name = "lh-aws-lb-tg-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -325,6 +347,7 @@ resource "aws_lb" "lh_aws_lb" {
 
   tags = {
     Name = "lh-aws-lb-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -348,6 +371,7 @@ resource "aws_lb_listener" "lh_aws_lb_listener_443" {
 
   tags = {
     Name = "lh-aws-lb-listener-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 
 }

--- a/test_framework/terraform/aws/ubuntu/main.tf
+++ b/test_framework/terraform/aws/ubuntu/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -110,6 +112,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -153,6 +156,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -165,6 +169,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -176,6 +181,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -185,6 +191,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -202,6 +209,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -221,6 +229,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -239,6 +248,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -268,11 +278,21 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_ebs_volume" "lh_aws_hdd_volume" {
@@ -284,7 +304,8 @@ resource "aws_ebs_volume" "lh_aws_hdd_volume" {
   type              = "st1"
 
   tags = {
-    Name = "lh-aws-hdd-volume-${random_string.random_suffix.id}-${count.index}"
+    Name = "lh-aws-hdd-volume-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -307,6 +328,7 @@ resource "aws_lb_target_group" "lh_aws_lb_tg_443" {
 
   tags = {
     Name = "lh-aws-lb-tg-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -327,6 +349,7 @@ resource "aws_lb" "lh_aws_lb" {
 
   tags = {
     Name = "lh-aws-lb-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -350,6 +373,7 @@ resource "aws_lb_listener" "lh_aws_lb_listener_443" {
 
   tags = {
     Name = "lh-aws-lb-listener-443-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 
 }


### PR DESCRIPTION
ci: ensure all testing resources have proper tag to be identified

(1) ensure aws ec2 instances have Owner="longhorn-infra" to be identified as longhorn testing instances.
(2) ensure all aws resources have Name contains random suffix to be associated to aws ec2 instances, then if there is a long-running aws ec2 instance, the random suffix can be used to track and delete all the aws resources associated to this aws ec2 instance.
(3) add Owner="longhorn-infra" to all aws resources to reverse lookup orphaned resources with no aws ec2 instance.

For https://github.com/longhorn/longhorn/issues/4395

Signed-off-by: Yang Chiu <yang.chiu@suse.com>