### PR TITLE
Fix the issue #4593 on 1.3.x, missed commit from master

### DIFF
--- a/manager/integration/tests/test_engine_upgrade.py
+++ b/manager/integration/tests/test_engine_upgrade.py
@@ -858,7 +858,13 @@ def test_engine_live_upgrade_while_replica_concurrent_rebuild(client, # NOQA
 
     default_img = common.get_default_engine_image(client)
     default_img_name = default_img.name
-    default_img = wait_for_engine_image_ref_count(client, default_img_name, 2)
+
+    # Total ei.refCount of the two volumes is
+    # 2 volumes + 2 engines + all replicas
+    expected_ref_count = 4 + len(volume1.replicas) + len(volume2.replicas)
+    default_img = wait_for_engine_image_ref_count(client,
+                                                  default_img_name,
+                                                  expected_ref_count)
     cli_v = default_img.cliAPIVersion
     cli_minv = default_img.cliAPIMinVersion
     ctl_v = default_img.controllerAPIVersion
@@ -937,8 +943,16 @@ def test_engine_live_upgrade_while_replica_concurrent_rebuild(client, # NOQA
     assert engine.engineImage == engine_upgrade_image
     wait_for_rebuild_complete(client, volume1_name)
 
-    wait_for_engine_image_ref_count(client, default_img_name, 1)
-    wait_for_engine_image_ref_count(client, new_img_name, 1)
+    # Total ei.refCount of one volumes is equal to
+    # 1 volumes + 1 engine + all replicas
+    expected_ref_count = 2 + len(volume1.replicas)
+    wait_for_engine_image_ref_count(client,
+                                    default_img_name,
+                                    expected_ref_count)
+    expected_ref_count = 2 + len(volume2.replicas)
+    wait_for_engine_image_ref_count(client,
+                                    new_img_name,
+                                    expected_ref_count)
 
     for replica in volume2.replicas:
         assert replica.engineImage == engine_upgrade_image


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/4593
The private longhorn image test v1.3.x report 
1. test_engine_live_upgrade_while_replica_concurrent_rebuild [test report](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2009/testReport/tests/test_engine_upgrade/test_engine_live_upgrade_while_replica_concurrent_rebuild)
2. v1.3.x CI test result : [report](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2012/#showFailuresLink)

Signed-off-by: Roger Yao <roger.yao@suse.com>
(cherry picked from commit b0f9658a00370be9cfb51498c86976b908ceb570)