### PR TITLE
Fix(1.2.x) set_node_scheduling

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -859,12 +859,29 @@ def set_node_tags(client, node, tags=[]):  # NOQA
                          tags=tags)
 
 
-def set_node_scheduling(client, node, allowScheduling):
+def set_node_scheduling(client, node, allowScheduling, retry=False):
     if node.tags is None:
         node.tags = []
-    return client.update(node, allowScheduling=allowScheduling,
-                         tags=node.tags)
 
+    if not retry:
+        return client.update(node, allowScheduling=allowScheduling,
+                             tags=node.tags)
+
+    # Retry if "too many retries error" happened.
+    for _ in range(NODE_UPDATE_RETRY_COUNT):
+        try:
+            node = client.update(node, allowScheduling=allowScheduling,
+                                 tags=node.tags)
+        except Exception as e:
+            if retry_error in str(e.error.message):
+                time.sleep(NODE_UPDATE_RETRY_INTERVAL)
+                continue
+            print(e)
+            raise
+        else:
+            break
+
+    return node
 
 @pytest.fixture
 def pod_make(request):

--- a/manager/integration/tests/test_engine_upgrade.py
+++ b/manager/integration/tests/test_engine_upgrade.py
@@ -858,7 +858,13 @@ def test_engine_live_upgrade_while_replica_concurrent_rebuild(client, # NOQA
 
     default_img = common.get_default_engine_image(client)
     default_img_name = default_img.name
-    default_img = wait_for_engine_image_ref_count(client, default_img_name, 2)
+
+    # Total ei.refCount of the two volumes is
+    # 2 volumes + 2 engines + all replicas
+    expected_ref_count = 4 + len(volume1.replicas) + len(volume2.replicas)
+    default_img = wait_for_engine_image_ref_count(client,
+                                                  default_img_name,
+                                                  expected_ref_count)
     cli_v = default_img.cliAPIVersion
     cli_minv = default_img.cliAPIMinVersion
     ctl_v = default_img.controllerAPIVersion
@@ -937,8 +943,16 @@ def test_engine_live_upgrade_while_replica_concurrent_rebuild(client, # NOQA
     assert engine.engineImage == engine_upgrade_image
     wait_for_rebuild_complete(client, volume1_name)
 
-    wait_for_engine_image_ref_count(client, default_img_name, 1)
-    wait_for_engine_image_ref_count(client, new_img_name, 1)
+    # Total ei.refCount of one volumes is equal to
+    # 1 volumes + 1 engine + all replicas
+    expected_ref_count = 2 + len(volume1.replicas)
+    wait_for_engine_image_ref_count(client,
+                                    default_img_name,
+                                    expected_ref_count)
+    expected_ref_count = 2 + len(volume2.replicas)
+    wait_for_engine_image_ref_count(client,
+                                    new_img_name,
+                                    expected_ref_count)
 
     for replica in volume2.replicas:
         assert replica.engineImage == engine_upgrade_image


### PR DESCRIPTION
After https://github.com/longhorn/longhorn-tests/commit/30cc2cb merged
Test_migration_with_unscheduled_replica always failed.
Master-head could test case
We need to fix the 1.2.x-head script.

issue #4585

Refs. https://github.com/longhorn/longhorn-tests/commit/fa175e3172e43e9d0a13cebddadc1ee78ac34ea4

Signed-off-by: Roger Yao roger.yao@suse.com