### PR TITLE
ci: fix rhel >= 8.4 nm-cloud-setup related error when setup k3s cluster.

### DIFF
--- a/test_framework/terraform/aws/rhel/k3s_instances.tf
+++ b/test_framework/terraform/aws/rhel/k3s_instances.tf
@@ -115,8 +115,8 @@ resource "null_resource" "rsync_kubeconfig_file" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait",
-      "if [ \"`cloud-init status | grep error`\" ]; then cat /var/log/cloud-init-output.log; fi",
+      "sudo cloud-init status --wait",
+      "if [ \"`sudo cloud-init status | grep error`\" ]; then sudo cat /var/log/cloud-init-output.log; fi",
       "until([ -f /etc/rancher/k3s/k3s.yaml ] && [ `sudo /usr/local/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for k3s cluster nodes to be running\"; sleep 2; done"
     ]
 

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 sudo yum update -y
@@ -13,11 +13,12 @@ sudo yum group install -y "Development Tools"
 sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 if [ -b "/dev/xvdh" ]; then
-  mkfs.ext4 -E nodiscard /dev/xvdh
-  mkdir /var/lib/longhorn
-  mount /dev/xvdh /var/lib/longhorn
+  sudo mkfs.ext4 -E nodiscard /dev/xvdh
+  sudo mkdir /var/lib/longhorn
+  sudo mount /dev/xvdh /var/lib/longhorn
 fi
 
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_server.sh.tpl
@@ -15,13 +15,14 @@ sudo yum group install -y "Development Tools"
 sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq
 sudo systemctl -q enable iscsid                                                 
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
-until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do
+until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do
   echo 'k3s server did not install correctly'
   sleep 2
 done
 
-until (kubectl get pods -A | grep 'Running'); do
+until (sudo /usr/local/bin/kubectl get pods -A | grep 'Running'); do
   echo 'Waiting for k3s startup'
   sleep 5
 done

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke.sh.tpl
@@ -2,12 +2,12 @@
 
 DOCKER_VERSION=20.10
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-	setenforce  1
+	sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-	setenforce  0
+	sudo setenforce  0
 fi
 
 sudo yum update -y
@@ -15,11 +15,12 @@ sudo yum group install -y "Development Tools"
 sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 if [ -b "/dev/xvdh" ]; then
-  mkfs.ext4 -E nodiscard /dev/xvdh
-  mkdir /var/lib/longhorn
-  mount /dev/xvdh /var/lib/longhorn
+  sudo mkfs.ext4 -E nodiscard /dev/xvdh
+  sudo mkdir /var/lib/longhorn
+  sudo mount /dev/xvdh /var/lib/longhorn
 fi
 
 until (curl https://releases.rancher.com/install-docker/$${DOCKER_VERSION}.sh | sudo sh); do
@@ -27,4 +28,4 @@ until (curl https://releases.rancher.com/install-docker/$${DOCKER_VERSION}.sh | 
   sleep 2
 done
 
-sudo usermod -aG docker centos
+sudo usermod -aG docker ec2-user

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 sudo yum update -y
@@ -13,11 +13,12 @@ sudo yum group install -y "Development Tools"
 sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools nc
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 if [ -b "/dev/xvdh" ]; then
-  mkfs.ext4 -E nodiscard /dev/xvdh
-  mkdir /var/lib/longhorn
-  mount /dev/xvdh /var/lib/longhorn
+  sudo mkfs.ext4 -E nodiscard /dev/xvdh
+  sudo mkdir /var/lib/longhorn
+  sudo mount /dev/xvdh /var/lib/longhorn
 fi
 
 RKE_SERVER_IP=`echo ${rke2_server_url} | sed 's#https://##' | awk -F ":" '{print $1}'`
@@ -29,13 +30,13 @@ done
 
 curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="agent" INSTALL_RKE2_VERSION="${rke2_version}" sh -
 
-mkdir -p /etc/rancher/rke2
+sudo mkdir -p /etc/rancher/rke2
 
-cat << EOF > /etc/rancher/rke2/config.yaml 
+sudo cat << EOF > /etc/rancher/rke2/config.yaml
 server: ${rke2_server_url}
 token: ${rke2_cluster_secret}
 EOF
 
-systemctl enable rke2-agent.service
-systemctl start rke2-agent.service
+sudo systemctl enable rke2-agent.service
+sudo systemctl start rke2-agent.service
 exit $?

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke2_server.sh.tpl
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 sudo yum update -y
@@ -13,22 +13,23 @@ sudo yum group install -y "Development Tools"
 sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="server" INSTALL_RKE2_VERSION="${rke2_version}" sh -
 
-mkdir -p /etc/rancher/rke2
+sudo mkdir -p /etc/rancher/rke2
 
-cat << EOF > /etc/rancher/rke2/config.yaml
+sudo cat << EOF > /etc/rancher/rke2/config.yaml
 write-kubeconfig-mode: "0644"
 token: ${rke2_cluster_secret}
 tls-san:
   - ${rke2_server_public_ip}
 EOF
 
-systemctl enable rke2-server.service
-systemctl start rke2-server.service
+sudo systemctl enable rke2-server.service
+sudo systemctl start rke2-server.service
 
-until (KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get pods -A | grep 'Running'); do
+until (KUBECONFIG=/etc/rancher/rke2/rke2.yaml sudo /var/lib/rancher/rke2/bin/kubectl get pods -A | grep 'Running'); do
   echo 'Waiting for rke2 startup'
   sleep 5
 done


### PR DESCRIPTION
ci: fix rhel >= 8.4 nm-cloud-setup related error when setup k3s cluster.

For https://github.com/longhorn/longhorn/issues/4333

Signed-off-by: Yang Chiu <yang.chiu@suse.com>