### PR TITLE
ci: update rockylinux ami filter to get 8.6 image and refine init script to disable nm-cloud-setup

### DIFF
--- a/test_framework/terraform/aws/rockylinux/data.tf
+++ b/test_framework/terraform/aws/rockylinux/data.tf
@@ -10,7 +10,7 @@ data "aws_ami" "aws_ami_rockylinux" {
 
   filter {
     name   = "name"
-    values = ["Rocky Linux ${var.os_distro_version}*"]
+    values = ["*RockyLinux-${var.os_distro_version}*"]
   }
 
   filter {

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -5,19 +5,20 @@ sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 if [ -b "/dev/xvdh" ]; then
-  mkfs.ext4 -E nodiscard /dev/xvdh
-  mkdir /var/lib/longhorn
-  mount /dev/xvdh /var/lib/longhorn
+  sudo mkfs.ext4 -E nodiscard /dev/xvdh
+  sudo mkdir /var/lib/longhorn
+  sudo mount /dev/xvdh /var/lib/longhorn
 fi
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
@@ -7,13 +7,14 @@ sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq
 sudo systemctl -q enable iscsid                                                 
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke.sh.tpl
@@ -2,18 +2,19 @@
 
 DOCKER_VERSION=20.10
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo dnf update -y
 sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools docker-ce docker-ce-cli containerd.io
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 sudo systemctl start iscsid
 sudo systemctl enable iscsid
@@ -24,7 +25,7 @@ sudo systemctl enable docker
 sudo usermod -aG docker rocky
 
 if [ -b "/dev/xvdh" ]; then
-  mkfs.ext4 -E nodiscard /dev/xvdh
-  mkdir /var/lib/longhorn
-  mount /dev/xvdh /var/lib/longhorn
+  sudo mkfs.ext4 -E nodiscard /dev/xvdh
+  sudo mkdir /var/lib/longhorn
+  sudo mount /dev/xvdh /var/lib/longhorn
 fi

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 sudo dnf update -y
@@ -13,11 +13,12 @@ sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq nmap-ncat
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 if [ -b "/dev/xvdh" ]; then
-  mkfs.ext4 -E nodiscard /dev/xvdh
-  mkdir /var/lib/longhorn
-  mount /dev/xvdh /var/lib/longhorn
+  sudo mkfs.ext4 -E nodiscard /dev/xvdh
+  sudo mkdir /var/lib/longhorn
+  sudo mount /dev/xvdh /var/lib/longhorn
 fi
 
 RKE_SERVER_IP=`echo ${rke2_server_url} | sed 's#https://##' | awk -F ":" '{print $1}'`
@@ -29,13 +30,13 @@ done
 
 curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="agent" INSTALL_RKE2_VERSION="${rke2_version}" sh -
 
-mkdir -p /etc/rancher/rke2
+sudo mkdir -p /etc/rancher/rke2
 
-cat << EOF > /etc/rancher/rke2/config.yaml 
+sudo cat << EOF > /etc/rancher/rke2/config.yaml
 server: ${rke2_server_url}
 token: ${rke2_cluster_secret}
 EOF
 
-systemctl enable rke2-agent.service
-systemctl start rke2-agent.service
+sudo systemctl enable rke2-agent.service
+sudo systemctl start rke2-agent.service
 exit $?

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_server.sh.tpl
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 sudo dnf update -y
@@ -13,22 +13,23 @@ sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="server" INSTALL_RKE2_VERSION="${rke2_version}" sh -
 
-mkdir -p /etc/rancher/rke2
+sudo mkdir -p /etc/rancher/rke2
 
-cat << EOF > /etc/rancher/rke2/config.yaml
+sudo cat << EOF > /etc/rancher/rke2/config.yaml
 write-kubeconfig-mode: "0644"
 token: ${rke2_cluster_secret}
 tls-san:
   - ${rke2_server_public_ip}
 EOF
 
-systemctl enable rke2-server.service
-systemctl start rke2-server.service
+sudo systemctl enable rke2-server.service
+sudo systemctl start rke2-server.service
 
-until (KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get pods -A | grep 'Running'); do
+until (KUBECONFIG=/etc/rancher/rke2/rke2.yaml sudo /var/lib/rancher/rke2/bin/kubectl get pods -A | grep 'Running'); do
   echo 'Waiting for rke2 startup'
   sleep 5
 done


### PR DESCRIPTION
ci: update rockylinux ami filter to get 8.6 image and refine init script to disable nm-cloud-setup

For https://github.com/longhorn/longhorn/issues/4620

Signed-off-by: Yang Chiu <yang.chiu@suse.com>