### PR TITLE
Have option to build engine upgrade test images form specific commit

### DIFF
--- a/build_engine_test_images/Jenkinsfile
+++ b/build_engine_test_images/Jenkinsfile
@@ -26,6 +26,7 @@ node {
                                    --env TF_VAR_docker_password=${DOCKER_PASSWORD} \
                                    --env TF_VAR_docker_repo=${DOCKER_REPO} \
                                    --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} \
+                                   --env TF_VAR_commit_id=${COMMIT_ID} \
                                    ${imageName}
             """
 

--- a/build_engine_test_images/terraform/aws/ubuntu/main.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/main.tf
@@ -208,7 +208,7 @@ resource "null_resource" "build_images" {
   provisioner "remote-exec" {
     inline = [
         "sudo chmod +x /tmp/generate_images.sh",
-        "sudo /tmp/generate_images.sh ${var.build_engine_arch} ${var.docker_id} ${var.docker_password} ${var.docker_repo}"
+        "sudo /tmp/generate_images.sh ${var.build_engine_arch} ${var.docker_id} ${var.docker_password} ${var.docker_repo} ${var.commit_id}"
     ]
 
     connection {

--- a/build_engine_test_images/terraform/aws/ubuntu/variables.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/variables.tf
@@ -94,3 +94,9 @@ variable "docker_repo" {
   description = "read from TF_VAR_docker_repo"
   default     = ""
 }
+
+variable "commit_id" {
+  type        = string
+  description = "read from TF_VAR_commit_id"
+  default     = ""
+}


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>
https://github.com/longhorn/longhorn/issues/4615

With https://github.com/longhorn/infra/pull/100 to have option to build engine upgrade test images form specific commit

Longhorn v1.2.x engine upgrade test [result](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2067/) with [upgrade-test.5-3.3-3.1-1](https://hub.docker.com/layers/chanow/longhorn-manager-test/upgrade-test.5-3.3-3.1-1/images/sha256-14237c8bac6c32fc44552e37b76199b1e7b6683052e42c4f879e8b6ac5f1bf84?context=repo) 
Longhorn master-head engine upgrade test [result](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2068/) with [upgrade-test.6-3.3-3.1-1](https://hub.docker.com/layers/chanow/longhorn-test/upgrade-test.6-3.3-3.1-1/images/sha256-1d160111b798c0b06e29d91c327d15a0caa2f6ac06ed847ec5dd81a7880e5140?context=repo) 