### PR TITLE
ci: update sles default version to 15.4, rocky/rhel/oracle default version to 8.6

### DIFF
--- a/test_framework/terraform/aws/oracle/variables.tf
+++ b/test_framework/terraform/aws/oracle/variables.tf
@@ -30,7 +30,7 @@ variable "arch" {
 
 variable "distro_version" {
   type        = string
-  default     = "8.5"
+  default     = "8.6"
 }
 
 variable "aws_ami_oraclelinux_account_number" {

--- a/test_framework/terraform/aws/rhel/variables.tf
+++ b/test_framework/terraform/aws/rhel/variables.tf
@@ -30,7 +30,7 @@ variable "arch" {
 
 variable "os_distro_version" {
   type        = string
-  default     = "8.3"
+  default     = "8.6.0"
 }
 
 variable "aws_ami_rhel_account_number" {

--- a/test_framework/terraform/aws/rockylinux/variables.tf
+++ b/test_framework/terraform/aws/rockylinux/variables.tf
@@ -30,7 +30,7 @@ variable "arch" {
 
 variable "os_distro_version" {
   type        = string
-  default     = "8.5"
+  default     = "8.6"
 }
 
 variable "aws_ami_rockylinux_account_number" {

--- a/test_framework/terraform/aws/sles/variables.tf
+++ b/test_framework/terraform/aws/sles/variables.tf
@@ -30,7 +30,7 @@ variable "arch" {
 
 variable "os_distro_version" {
   type        = string
-  default     = "15-sp3-v20210622"
+  default     = "15-sp4-v20220621"
 }
 
 variable "aws_ami_sles_account_number" {


### PR DESCRIPTION
ci: update sles default version to 15.4, rocky/rhel/oracle default version to 8.6

For https://github.com/longhorn/longhorn/issues/4620, https://github.com/longhorn/longhorn/issues/4618

Signed-off-by: Yang Chiu <yang.chiu@suse.com>