### PR TITLE
Chanoge aws_availability_zone from us-east-1b to 1c

### DIFF
--- a/build_engine_test_images/terraform/aws/ubuntu/variables.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/variables.tf
@@ -21,7 +21,7 @@ variable "tf_workspace" {
 
 variable "aws_availability_zone" {
   type        = string
-  default     = "us-east-1b"
+  default     = "us-east-1c"
 }
 
 variable "build_engine_aws_vpc_name" {


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

When create ARM64 instances encountered
```
Error: Error launching source instance: Unsupported: Your requested instance type (a1.medium) is not supported in your requested Availability Zone (us-east-1b). Please retry your request by not specifying an Availability Zone or choosing us-east-1a, us-east-1c, us-east-1d.
	status code: 400, request id: ef12f50f-30ed-4265-9d81-9d6912e685a9
```
change the aws_availability_zone from us-east-1b to 1c