### PR TITLE
ci: ensure all testing resources have proper tag to be identified

### DIFF
--- a/secscan/terraform/aws/main.tf
+++ b/secscan/terraform/aws/main.tf
@@ -18,6 +18,7 @@ resource "aws_vpc" "lh-secscan_aws_vpc" {
 
   tags = {
     Name = "${var.lh-secscan_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -26,7 +27,8 @@ resource "aws_internet_gateway" "lh-secscan_aws_igw" {
   vpc_id = aws_vpc.lh-secscan_aws_vpc.id
 
   tags = {
-    Name = "lh-secscan_igw"
+    Name = "lh-secscan_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -53,6 +55,7 @@ resource "aws_security_group" "lh-secscan_aws_secgrp" {
 
   tags = {
     Name = "lh-secscan_aws_sec_grp_secscan-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -64,6 +67,7 @@ resource "aws_subnet" "lh-secscan_aws_public_subnet" {
 
   tags = {
     Name = "lh-secscan_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -82,6 +86,7 @@ resource "aws_route_table" "lh-secscan_aws_public_rt" {
 
   tags = {
     Name = "lh-secscan_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -100,6 +105,11 @@ resource "aws_route_table_association" "lh-secscan_aws_public_subnet_rt_associat
 resource "aws_key_pair" "lh-secscan_aws_pair_key" {
   key_name   = format("%s_%s", "lh-secscan_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh-secscan_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 # Create aws instance
@@ -135,6 +145,11 @@ resource "aws_instance" "lh-secscan_aws_instance" {
 
 resource "aws_eip" "lh-secscan_aws_eip_secscan" {
   vpc      = true
+
+  tags = {
+    Name = "lh-secscan_aws_eip-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 # Associate every EIP with secscan instance

--- a/test_framework/terraform/aws/centos/main.tf
+++ b/test_framework/terraform/aws/centos/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -108,6 +110,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -135,6 +138,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -147,6 +151,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -158,6 +163,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -167,6 +173,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -184,6 +191,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -203,6 +211,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -221,6 +230,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -250,9 +260,19 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }

--- a/test_framework/terraform/aws/oracle/main.tf
+++ b/test_framework/terraform/aws/oracle/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -108,6 +110,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -135,6 +138,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -147,6 +151,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -158,6 +163,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -167,6 +173,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -184,6 +191,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -203,6 +211,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -221,6 +230,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -250,9 +260,19 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }

--- a/test_framework/terraform/aws/rhel/main.tf
+++ b/test_framework/terraform/aws/rhel/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -108,6 +110,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -135,6 +138,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -147,6 +151,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -158,6 +163,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -167,6 +173,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -184,6 +191,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -203,6 +211,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -221,6 +230,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -250,9 +260,19 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }

--- a/test_framework/terraform/aws/rockylinux/main.tf
+++ b/test_framework/terraform/aws/rockylinux/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -109,6 +111,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -136,6 +139,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -148,6 +152,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -159,6 +164,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -168,6 +174,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -185,6 +192,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -204,6 +212,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -222,6 +231,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -251,9 +261,19 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }

--- a/test_framework/terraform/aws/sles/main.tf
+++ b/test_framework/terraform/aws/sles/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -108,6 +110,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -135,6 +138,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -147,6 +151,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -158,6 +163,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -167,6 +173,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -184,6 +191,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -203,6 +211,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -221,6 +230,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -250,9 +260,19 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }

--- a/test_framework/terraform/aws/ubuntu/main.tf
+++ b/test_framework/terraform/aws/ubuntu/main.tf
@@ -33,6 +33,7 @@ resource "aws_vpc" "lh_aws_vpc" {
 
   tags = {
     Name = "${var.lh_aws_vpc_name}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -41,7 +42,8 @@ resource "aws_internet_gateway" "lh_aws_igw" {
   vpc_id = aws_vpc.lh_aws_vpc.id
 
   tags = {
-    Name = "lh_igw"
+    Name = "lh_igw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -110,6 +112,7 @@ resource "aws_security_group" "lh_aws_secgrp_controlplane" {
 
   tags = {
     Name = "lh_aws_sec_grp_controlplane-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -137,6 +140,7 @@ resource "aws_security_group" "lh_aws_secgrp_worker" {
 
   tags = {
     Name = "lh_aws_sec_grp_worker-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -149,6 +153,7 @@ resource "aws_subnet" "lh_aws_public_subnet" {
 
   tags = {
     Name = "lh_public_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -160,6 +165,7 @@ resource "aws_subnet" "lh_aws_private_subnet" {
 
   tags = {
     Name = "lh_private_subnet-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -169,6 +175,7 @@ resource "aws_eip" "lh_aws_eip_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -186,6 +193,7 @@ resource "aws_nat_gateway" "lh_aws_nat_gw" {
 
   tags = {
     Name = "lh_eip_nat_gw-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -205,6 +213,7 @@ resource "aws_route_table" "lh_aws_public_rt" {
 
   tags = {
     Name = "lh_aws_public_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -223,6 +232,7 @@ resource "aws_route_table" "lh_aws_private_rt" {
 
   tags = {
     Name = "lh_aws_private_rt-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
   }
 }
 
@@ -252,9 +262,19 @@ resource "aws_route_table_association" "lh_aws_private_subnet_rt_association" {
 resource "aws_key_pair" "lh_aws_pair_key" {
   key_name   = format("%s_%s", "lh_aws_key_pair", "${random_string.random_suffix.id}")
   public_key = file(var.aws_ssh_public_key_file_path)
+
+  tags = {
+    Name = "lh_aws_key_pair-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
   vpc      = true
+
+  tags = {
+    Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"
+    Owner = "longhorn-infra"
+  }
 }


### PR DESCRIPTION
ci: ensure all testing resources have proper tag to be identified

(1) ensure aws ec2 instances have Owner="longhorn-infra" to be identified as longhorn testing instances. 
(2) ensure all aws resources have Name contains random suffix to be associated to aws ec2 instances, then if there is a long-running aws ec2 instance, the random suffix can be used to track and delete all the aws resources associated to this aws ec2 instance.
(3) add Owner="longhorn-infra" to all aws resources to reverse lookup orphaned resources with no aws ec2 instance.

For https://github.com/longhorn/longhorn/issues/4395

Signed-off-by: Yang Chiu <yang.chiu@suse.com>