### PR TITLE
ci: fix rhel >= 8.4 nm-cloud-setup related error when setup k3s cluster.

### DIFF
--- a/test_framework/terraform/aws/rhel/main.tf
+++ b/test_framework/terraform/aws/rhel/main.tf
@@ -383,8 +383,8 @@ resource "null_resource" "rsync_kubeconfig_file" {
 
   provisioner "remote-exec" {
     inline = var.k8s_distro_name == "k3s" ? [
-      "cloud-init status --wait",
-      "if [ \"`cloud-init status | grep error`\" ]; then cat /var/log/cloud-init-output.log; fi",
+      "sudo cloud-init status --wait",
+      "if [ \"`sudo cloud-init status | grep error`\" ]; then sudo cat /var/log/cloud-init-output.log; fi",
       "until([ -f /etc/rancher/k3s/k3s.yaml ] && [ `sudo /usr/local/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq 4 ]); do echo \"waiting for k3s cluster nodes to be running\"; sleep 2; done"
     ] : null
 

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 sudo yum update -y
@@ -13,6 +13,7 @@ sudo yum group install -y "Development Tools"
 sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do
   echo 'k3s agent did not install correctly'

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_server.sh.tpl
@@ -15,13 +15,14 @@ sudo yum group install -y "Development Tools"
 sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq
 sudo systemctl -q enable iscsid                                                 
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
-until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do
+until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do
   echo 'k3s server did not install correctly'
   sleep 2
 done
 
-until (kubectl get pods -A | grep 'Running'); do
+until (sudo /usr/local/bin/kubectl get pods -A | grep 'Running'); do
   echo 'Waiting for k3s startup'
   sleep 5
 done

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke.sh.tpl
@@ -2,12 +2,12 @@
 
 DOCKER_VERSION=20.10
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-	setenforce  1
+	sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-	setenforce  0
+	sudo setenforce  0
 fi
 
 sudo yum update -y
@@ -15,6 +15,7 @@ sudo yum group install -y "Development Tools"
 sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 until (curl https://releases.rancher.com/install-docker/$${DOCKER_VERSION}.sh | sudo sh); do
   echo 'docker did not install correctly'


### PR DESCRIPTION
ci: fix rhel >= 8.4 nm-cloud-setup related error when setup k3s cluster.

For https://github.com/longhorn/longhorn/issues/4333

Signed-off-by: Yang Chiu <yang.chiu@suse.com>