### PR TITLE
ci: update rockylinux ami filter to get 8.6 image and refine init script to disable nm-cloud-setup

### DIFF
--- a/test_framework/terraform/aws/rockylinux/data.tf
+++ b/test_framework/terraform/aws/rockylinux/data.tf
@@ -10,7 +10,7 @@ data "aws_ami" "aws_ami_rockylinux" {
 
   filter {
     name   = "name"
-    values = ["Rocky Linux ${var.os_distro_version}*"]
+    values = ["*RockyLinux-${var.os_distro_version}*"]
   }
 
   filter {

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -5,6 +5,7 @@ sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do
   echo 'k3s agent did not install correctly'

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
@@ -7,6 +7,7 @@ sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq
 sudo systemctl -q enable iscsid                                                 
 sudo systemctl start iscsid
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip}" INSTALL_K3S_VERSION="${k3s_version}" K3S_CLUSTER_SECRET="${k3s_cluster_secret}" sh -); do
   echo 'k3s server did not install correctly'

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke.sh.tpl
@@ -2,18 +2,19 @@
 
 DOCKER_VERSION=20.10
 
-sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    setenforce  1
+    sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    setenforce  0
+    sudo setenforce  0
 fi
 
 sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 sudo dnf update -y
 sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools docker-ce docker-ce-cli containerd.io
+sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
 sudo systemctl start iscsid
 sudo systemctl enable iscsid


### PR DESCRIPTION
ci: update rockylinux ami filter to get 8.6 image and refine init script to disable nm-cloud-setup

For https://github.com/longhorn/longhorn/issues/4620

Signed-off-by: Yang Chiu <yang.chiu@suse.com>