### PR TITLE
test: fix busybox version to 1.34.0  to avoid the CrashLoopBackOff issue in its latest version

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -99,7 +99,7 @@ spec:
     - name: test-report
       mountPath: /tmp/test-report
   - name: longhorn-test-report
-    image: busybox
+    image: busybox:1.34.0
     command: [ "tail", "-f", "/dev/null" ]
     volumeMounts:
     - name: test-report

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -946,7 +946,7 @@ def pod_make(request):
             },
             'spec': {
                 'containers': [{
-                    'image': 'busybox',
+                    'image': 'busybox:1.34.0',
                     'imagePullPolicy': 'IfNotPresent',
                     'name': 'sleep',
                     "args": [
@@ -1010,7 +1010,7 @@ def pod(request):
         },
         'spec': {
             'containers': [{
-                'image': 'busybox',
+                'image': 'busybox:1.34.0',
                 'imagePullPolicy': 'IfNotPresent',
                 'name': 'sleep',
                 "args": [
@@ -1250,7 +1250,7 @@ def statefulset(request):
                 'spec': {
                     'terminationGracePeriodSeconds': 10,
                     'containers': [{
-                        'image': 'busybox',
+                        'image': 'busybox:1.34.0',
                         'imagePullPolicy': 'IfNotPresent',
                         'name': 'sleep',
                         'args': [

--- a/manager/integration/tests/test_cloning.py
+++ b/manager/integration/tests/test_cloning.py
@@ -36,7 +36,7 @@ def clone_pod(request):
         },
         'spec': {
             'containers': [{
-                'image': 'busybox',
+                'image': 'busybox:1.34.0',
                 'imagePullPolicy': 'IfNotPresent',
                 'name': 'sleep',
                 "args": [

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -2202,7 +2202,7 @@ def test_auto_remount_with_subpath(client, core_api, storage_class, sts_name, st
     statefulset['spec']['replicas'] = 1
     statefulset['spec']['template']['spec']['containers'] = \
         [{
-            'image': 'busybox',
+            'image': 'busybox:1.34.0',
             'imagePullPolicy': 'IfNotPresent',
             'name': 'sleep',
             'args': [


### PR DESCRIPTION
test: fix busybox version to 1.34.0  to avoid the CrashLoopBackOff issue in its latest version

For https://github.com/longhorn/longhorn/issues/4685

Signed-off-by: Yang Chiu <yang.chiu@suse.com>
