### PR TITLE
bug: fix to create rwx volume with PV & PVC deployment

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -82,6 +82,8 @@ from common import VOLUME_HEAD_NAME
 from common import set_node_scheduling
 from common import SETTING_FAILED_BACKUP_TTL
 from common import wait_for_volume_creation
+from common import get_apps_api_client, create_and_wait_deployment
+from common import make_deployment_with_pvc # NOQA
 
 from backupstore import backupstore_delete_volume_cfg_file
 from backupstore import backupstore_cleanup
@@ -4572,10 +4574,13 @@ def test_backup_failed_disable_auto_cleanup(set_random_backupstore,  # NOQA
         pytest.param("rwo", "rwx")
     ],
 )
-def test_backup_volume_restore_with_access_mode(set_random_backupstore, # NOQA
+def test_backup_volume_restore_with_access_mode(core_api, # NOQA
+                                                set_random_backupstore, # NOQA
                                                 client, # NOQA
                                                 access_mode, # NOQA
-                                       overridden_restored_access_mode): # NOQA
+                                       overridden_restored_access_mode, # NOQA
+                                       make_deployment_with_pvc): # NOQA
+
     """
     Test the backup w/ the volume access mode, then restore a volume w/ the
      original access mode or being overridden.
@@ -4595,14 +4600,32 @@ def test_backup_volume_restore_with_access_mode(set_random_backupstore, # NOQA
                          accessMode=access_mode)
     wait_for_volume_creation(client, test_volume_name)
     volume = wait_for_volume_detached(client, test_volume_name)
-    volume.attach(hostId=common.get_self_host_id())
-    volume = common.wait_for_volume_healthy(client, test_volume_name)
+
+    # Since RWX volumes can only be manually attached in maintenance mode,
+    # the volume should be created by PVC and PV instead
+    # to ensure the volume attach/deattach successfully.
+    if access_mode == "rwx":
+        test_pv_name = test_volume_name + "-pv"
+        test_pvc_name = test_volume_name + "-pvc"
+
+        create_pv_for_volume(client, core_api, volume, test_pv_name)
+        create_pvc_for_volume(client, core_api, volume, test_pvc_name)
+
+        test_deployment_name = test_volume_name + "-dep"
+        deployment = make_deployment_with_pvc(
+            test_deployment_name, test_pvc_name, replicas=2)
+
+        apps_api = get_apps_api_client() # NOQA
+        create_and_wait_deployment(apps_api, deployment)
+    else:
+        volume.attach(hostId=common.get_self_host_id())
+        volume = common.wait_for_volume_healthy(client, test_volume_name)
 
     # Step 2
     _, b, _, _ = create_backup(client, test_volume_name)
 
     # Step 3
-    volume_name_ori_access_mode = test_volume_name + '-default-access-mode'
+    volume_name_ori_access_mode = test_volume_name + '-default-access'
     client.create_volume(name=volume_name_ori_access_mode,
                          size=str(DEFAULT_VOLUME_SIZE * Gi),
                          numberOfReplicas=2,
@@ -4611,7 +4634,7 @@ def test_backup_volume_restore_with_access_mode(set_random_backupstore, # NOQA
     assert volume_ori_access_mode.accessMode == access_mode
 
     # Step 4
-    volume_name_sp_access_mode = test_volume_name + '-specified-access-mode'
+    volume_name_sp_access_mode = test_volume_name + '-specified-access'
     client.create_volume(name=volume_name_sp_access_mode,
                          size=str(DEFAULT_VOLUME_SIZE * Gi),
                          numberOfReplicas=2,


### PR DESCRIPTION
[Longhorn 4653](https://github.com/longhorn/longhorn/issues/4653)

Signed-off-by: Ray Chang <ray.chang@suse.com>

Description:  As RWX volumes can only be attached in maintenance mode and cannot be attached using the API. Therefore, volumes require additional deployment PVs and PVCs.

Self test: Pass with parameter matrix with 4 condition
![image](https://user-images.githubusercontent.com/17548901/195608883-5647987a-e2b9-49ab-a1e9-12067d26b222.png)
