### PR TITLE
fix flaky test case test_auto_remount_with_subpath

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -2231,6 +2231,7 @@ def test_auto_remount_with_subpath(client, core_api, storage_class, sts_name, st
                             namespace='longhorn-system',
                             wait=True)
         wait_for_volume_healthy(client, vol_name)
+        common.wait_for_pod_phase(core_api, pod_name, pod_phase="Pending")
         common.wait_for_pod_remount(core_api, pod_name, chk_path=data_path)
         expect_md5sum = get_pod_data_md5sum(core_api, pod_name, data_path)
         assert expect_md5sum == md5sum


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

Test case was flaky because timing issue in below steps
```
  4. Delete the statefulset replica instance manager pod.
       This action simulates a network disconnection.
  5. Wait for volume `healthy`, then verify the file checksum.
```

After volume healthy, we should add `common.wait_for_pod_phase(core_api, pod_name, pod_phase="Pending")` make sure pod is in recreating status then check pod remount

Otherwise sometimes pod is still in running status (not restart yet)  and `wait_for_pod_remount` return true, then script started checking data in pod, if at that moment pod just starting remount, script will get IO error

Here is 20 times test [result](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2233/) on pipeline