### PR TITLE
fix(rwx backup): fix failed to backup for RWX volume occasionally

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -82,8 +82,6 @@ from common import VOLUME_HEAD_NAME
 from common import set_node_scheduling
 from common import SETTING_FAILED_BACKUP_TTL
 from common import wait_for_volume_creation
-from common import get_apps_api_client, create_and_wait_deployment
-from common import make_deployment_with_pvc # NOQA
 
 from backupstore import backupstore_delete_volume_cfg_file
 from backupstore import backupstore_cleanup
@@ -4578,8 +4576,7 @@ def test_backup_volume_restore_with_access_mode(core_api, # NOQA
                                                 set_random_backupstore, # NOQA
                                                 client, # NOQA
                                                 access_mode, # NOQA
-                                       overridden_restored_access_mode, # NOQA
-                                       make_deployment_with_pvc): # NOQA
+                                       overridden_restored_access_mode): # NOQA
 
     """
     Test the backup w/ the volume access mode, then restore a volume w/ the
@@ -4597,29 +4594,12 @@ def test_backup_volume_restore_with_access_mode(core_api, # NOQA
     client.create_volume(name=test_volume_name,
                          size=str(DEFAULT_VOLUME_SIZE * Gi),
                          numberOfReplicas=2,
-                         accessMode=access_mode)
+                         accessMode=access_mode,
+                         migratable=True if access_mode == "rwx" else False)
     wait_for_volume_creation(client, test_volume_name)
     volume = wait_for_volume_detached(client, test_volume_name)
-
-    # Since RWX volumes can only be manually attached in maintenance mode,
-    # the volume should be created by PVC and PV instead
-    # to ensure the volume attach/deattach successfully.
-    if access_mode == "rwx":
-        test_pv_name = test_volume_name + "-pv"
-        test_pvc_name = test_volume_name + "-pvc"
-
-        create_pv_for_volume(client, core_api, volume, test_pv_name)
-        create_pvc_for_volume(client, core_api, volume, test_pvc_name)
-
-        test_deployment_name = test_volume_name + "-dep"
-        deployment = make_deployment_with_pvc(
-            test_deployment_name, test_pvc_name, replicas=2)
-
-        apps_api = get_apps_api_client() # NOQA
-        create_and_wait_deployment(apps_api, deployment)
-    else:
-        volume.attach(hostId=common.get_self_host_id())
-        volume = common.wait_for_volume_healthy(client, test_volume_name)
+    volume.attach(hostId=common.get_self_host_id())
+    volume = common.wait_for_volume_healthy(client, test_volume_name)
 
     # Step 2
     _, b, _, _ = create_backup(client, test_volume_name)


### PR DESCRIPTION
[Longhorn 4653](https://github.com/longhorn/longhorn/issues/4653)

Signed-off-by: Ray Chang <ray.chang@suse.com>

### Purpose
Fix e2e test case: test_backup_volume_restore_with_access_mode, failed to backup for RWX volume occasionally.
```
test_basic.py:4625: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
common.py:345: in create_backup
    data = write_volume_random_data(volume)
common.py:2256: in write_volume_random_data
    return write_device_random_data(dev, position=position)
common.py:2270: in write_device_random_data
    data_len = dev_write(dev, data_pos, data)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

dev = '/dev/longhorn/longhorn-testvol-e2290o', start = 88601
data = b'xb1xyet6uz8a1aowdbkpniwg5zvhgk44au6avvyt2dbop4f4v5f7mi0sun04aop2kdtukv9m8gyrc1f861nyzdaf1yj7pvcathhqoeccy52kqk2ypyvx...vdh9uhoeiepkhym31igjo2uryfuvhsmfj0jq5yni3uxeve9e630q4tu7xevjpifqnuqhevb4qjqpdlpq89ynxel2i8kqfng7figui4kz4ystvccqckqqpc'

    def dev_write(dev, start, data):
        data = bytes(data, encoding='utf-8')
        w_length = 0
>       fdev = open(dev, 'rb+')
E       FileNotFoundError: [Errno 2] No such file or directory: '/dev/longhorn/longhorn-testvol-e2290o'
```

### Reason 
   - the node of volume device (`/dev/longhorn/<vol-name>`) is not locate same as client (pod `longhorn-test`).

### plan to do
 - After reference [other functions](https://github.com/longhorn/longhorn-tests/blob/5673f228c4e6b306f1baa9b1c4a36808c1fc0986/manager/integration/tests/test_migration.py#L471-L491),  [docs](https://github.com/longhorn/longhorn/blob/master/enhancements/20210216-volume-live-migration.md#attach-changes) and [code](https://github.com/longhorn/longhorn-manager/blob/76468fa5013b70c5715977e6ba2dc35c3f024974/manager/volume.go#L266-L270), I think make the RWX volume as `migratable` could attach to specified node.
 - self test result:
<img width="1090" alt="截圖 2022-10-26 下午11 55 48" src="https://user-images.githubusercontent.com/17548901/198075533-98a0a5bd-3ede-41e7-81fc-d0069bcb4a59.png">

