### PR TITLE
Update manual case Test timeout on loss of network connectivity

### DIFF
--- a/docs/content/manual/pre-release/resiliency/timeout.md
+++ b/docs/content/manual/pre-release/resiliency/timeout.md
@@ -2,7 +2,7 @@
 title: "Test timeout on loss of network connectivity"
 ---
 
-## Ping Timeout
+## R/W Timeout Block Device
 
 1. Create a docker network:
 
@@ -37,36 +37,28 @@ docker run --net longhorn-network --ip 192.168.22.4 --privileged \
          --frontend tgt-blockdev timeout-test
 ```
 
-5. In another terminal, find the name of the container running the replica with `docker ps`
-
-6. Disconnect the replica container from the network:
-
-```shell
-docker network disconnect longhorn-network <container id/name>
-```
-
-7. Note that the controller output displays "Backend tcp://192.168.22.2:9502 monitoring failed, mark as ERR: ping timeout" after eight seconds. 
-
-## R/W Timeout Block Device
-
-1. Perform steps 2-4 from the Ping Timeout Section.
-
-2. In another terminal, perform I/O:
+5. In another terminal, perform I/O:
 
 ```shell
 fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=16k \
            --direct=1 --size=1000m --numjobs=1 \
            --filename=/dev/longhorn/timeout-test --iodepth=1
 ```
-3. Stop the network on the replica with steps 5-6 in the Ping Timeout Section.
+6. In another terminal, find the name of the container running the replica with `docker ps`
 
-4. Note that the controller output displays "Setting replica tcp://192.168.22.2:9502 to ERR due to: r/w timeout" after eight seconds.
+7. Disconnect the replica container from the network:
+
+```shell
+docker network disconnect longhorn-network <container id/name>
+```
+
+8. Note that the controller output displays "Setting replica tcp://192.168.22.2:9502 to ERR due to: r/w timeout" after eight seconds.
 
 6. Check `dmesg` to verify that block device did not generate any kernel error messages.
 
 ## R/W Timeout Filesystem
 
-1. Perform steps 2-4 from the Ping Timeout Section.
+1. Perform steps 2-4 from the R/W Timeout Block Device section
 
 2. In another terminal, perform I/O:
 
@@ -78,7 +70,7 @@ fio --name=random-writers --ioengine=libaio --rw=randwrite --bs=16k \
            --direct=1 --size=1000m --numjobs=1 \
            --filename=/timeout-test/fio.dat --iodepth=1
 ```
-3. Stop the network on the replica with steps 5-6 in the Ping Timeout Section.
+3. Stop the network on the replica with steps 6-7 in the R/W Timeout Block Device section.
 
 4. Note that the controller output displays "Setting replica tcp://192.168.22.2:9502 to ERR due to: r/w timeout" after eight seconds.
 


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

Remove Ping Timeout scenario because test scenario outdated https://github.com/longhorn/longhorn/issues/4778#issuecomment-1292771137

