### PR TITLE
Fix the flaky issue in test_allow_volume_creation_with_degraded_avail…

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3172,7 +3172,7 @@ def test_allow_volume_creation_with_degraded_availability(client, volume_name): 
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=self_host)
-    volume = common.wait_for_volume_degraded(client, volume_name)
+    volume = common.wait_for_volume_healthy(client, volume_name)
     check_volume_data(volume, data)
 
 


### PR DESCRIPTION
…ability

After all nodes are enabled and replicas are scheduled, the replicas might be rebuilt before wait_for_volume_healthy(), the volume becomes healthy.

Thus, we wait for the volume healthy rather than degraded, and then check the data.

Longhorn 3220

Signed-off-by: Derek Su <derek.su@suse.com>
(cherry picked from commit f3b65c6d5585910ef07a4f09e913f2f7e34b70b7)

issue https://github.com/longhorn/longhorn/issues/4787

Signed-off-by: Roger Yao <roger.yao@suse.com>