### PR TITLE
Unscheduled replica clean-up

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3395,8 +3395,7 @@ def test_allow_volume_creation_with_degraded_availability_restore(set_random_bac
                          numberOfReplicas=3, fromBackup=backup.url)
     common.wait_for_volume_replica_count(client, dst_vol_name, 3)
     common.wait_for_volume_restoration_start(client, dst_vol_name, backup.name)
-    wait_for_volume_condition_scheduled(client, dst_vol_name,
-                                        "status", "True")
+    common.wait_for_volume_degraded(client, dst_vol_name)
 
     # check only 1 replica scheduled successfully
     common.wait_for_replica_scheduled(client, dst_vol_name,

--- a/manager/integration/tests/test_migration.py
+++ b/manager/integration/tests/test_migration.py
@@ -159,13 +159,15 @@ def test_migration_with_unscheduled_replica(clients, volume_name):  # NOQA
     data = common.write_volume_random_data(volume)
     common.check_volume_data(volume, data)
 
-    volume.detach(hostId="")
-    volume = common.wait_for_volume_detached(client, volume_name)
+    # collect replicas name before detaching,
+    # unscheduled replica would be deleted.
     old_replicas = []
     v = client.by_id_volume(volume_name)
     replicas = v.replicas
     for r in replicas:
         old_replicas.append(r.name)
+    volume.detach(hostId="")
+    volume = common.wait_for_volume_detached(client, volume_name)
 
     # Step 6
     volume.attach(hostId=hosts[0])


### PR DESCRIPTION
Unscheduled replica would be deleted when volume was detached, so there would not be failed replicas when degraded volume was detached.

Merged after PR https://github.com/longhorn/longhorn-manager/pull/1534

longhorn/longhorn#4791