### PR TITLE
ci: update default k8s version to v1.25 on master branch

### DIFF
--- a/test_framework/terraform/aws/centos/variables.tf
+++ b/test_framework/terraform/aws/centos/variables.tf
@@ -96,12 +96,12 @@ variable "k8s_distro_name" {
 
 variable "k8s_distro_version" {
   type        = string
-  default     = "v1.23.1+k3s2"
+  default     = "v1.25.3+k3s1"
   description = <<-EOT
     kubernetes version that will be deployed
     rke: (default: v1.22.5-rancher1-1)
-    k3s: (default: v1.23.1+k3s2)
-    rke2: (default: v1.23.3+rke2r1)
+    k3s: (default: v1.25.3+k3s1)
+    rke2: (default: v1.25.3+rke2r1)
   EOT
 }
 

--- a/test_framework/terraform/aws/oracle/variables.tf
+++ b/test_framework/terraform/aws/oracle/variables.tf
@@ -96,12 +96,12 @@ variable "k8s_distro_name" {
 
 variable "k8s_distro_version" {
   type        = string
-  default     = "v1.23.1+k3s2"
+  default     = "v1.25.3+k3s1"
   description = <<-EOT
     kubernetes version that will be deployed
     rke: (default: v1.22.5-rancher1-1)
-    k3s: (default: v1.23.1+k3s2)
-    rke2: (default: v1.23.3+rke2r1)
+    k3s: (default: v1.25.3+k3s1)
+    rke2: (default: v1.25.3+rke2r1)
   EOT
 }
 

--- a/test_framework/terraform/aws/rhel/variables.tf
+++ b/test_framework/terraform/aws/rhel/variables.tf
@@ -96,12 +96,12 @@ variable "k8s_distro_name" {
 
 variable "k8s_distro_version" {
   type        = string
-  default     = "v1.23.1+k3s2"
+  default     = "v1.25.3+k3s1"
   description = <<-EOT
     kubernetes version that will be deployed
     rke: (default: v1.22.5-rancher1-1)
-    k3s: (default: v1.23.1+k3s2)
-    rke2: (default: v1.23.3+rke2r1)
+    k3s: (default: v1.25.3+k3s1)
+    rke2: (default: v1.25.3+rke2r1)
   EOT
 }
 

--- a/test_framework/terraform/aws/rockylinux/variables.tf
+++ b/test_framework/terraform/aws/rockylinux/variables.tf
@@ -96,12 +96,12 @@ variable "k8s_distro_name" {
 
 variable "k8s_distro_version" {
   type        = string
-  default     = "v1.23.1+k3s2"
+  default     = "v1.25.3+k3s1"
   description = <<-EOT
     kubernetes version that will be deployed
     rke: (default: v1.22.5-rancher1-1)
-    k3s: (default: v1.23.1+k3s2)
-    rke2: (default: v1.23.3+rke2r1)
+    k3s: (default: v1.25.3+k3s1)
+    rke2: (default: v1.25.3+rke2r1)
   EOT
 }
 

--- a/test_framework/terraform/aws/sles/variables.tf
+++ b/test_framework/terraform/aws/sles/variables.tf
@@ -97,12 +97,12 @@ variable "k8s_distro_name" {
 
 variable "k8s_distro_version" {
   type        = string
-  default     = "v1.23.1+k3s2"
+  default     = "v1.25.3+k3s1"
   description = <<-EOT
     kubernetes version that will be deployed
     rke: (default: v1.22.5-rancher1-1)
-    k3s: (default: v1.23.1+k3s2)
-    rke2: (default: v1.23.3+rke2r1)
+    k3s: (default: v1.25.3+k3s1)
+    rke2: (default: v1.25.3+rke2r1)
   EOT
 }
 

--- a/test_framework/terraform/aws/ubuntu/variables.tf
+++ b/test_framework/terraform/aws/ubuntu/variables.tf
@@ -97,12 +97,12 @@ variable "k8s_distro_name" {
 
 variable "k8s_distro_version" {
   type        = string
-  default     = "v1.23.1+k3s2"
+  default     = "v1.25.3+k3s1"
   description = <<-EOT
     kubernetes version that will be deployed
     rke: (default: v1.22.5-rancher1-1)
-    k3s: (default: v1.23.1+k3s2)
-    rke2: (default: v1.23.3+rke2r1)
+    k3s: (default: v1.25.3+k3s1)
+    rke2: (default: v1.25.3+rke2r1)
   EOT
 }
 


### PR DESCRIPTION
ci: update default k8s version to v1.25 on master branch

for k3s, update to v1.25.3+k3s1
for rke2, update to v1.25.3+rke2r1
for rke, it doesn't support k8s v1.25 yet

For https://github.com/longhorn/longhorn/issues/4239

Signed-off-by: Yang Chiu <yang.chiu@suse.com>