### PR TITLE
test: update kubernetes client version to 25.3 and replace batch/v1beta1 with batch/v1

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1087,17 +1087,17 @@ def apps_api(request):
 
 
 @pytest.fixture
-def batch_v1_beta_api(request):
+def batch_v1_api(request):
     """
-    Create a new BatchV1beta1Api instance.
+    Create a new BatchV1Api instance.
     Returns:
-        A new BatchV1beta1Api Instance.
+        A new BatchV1Api Instance.
     """
     c = Configuration()
     c.assert_hostname = False
     Configuration.set_default(c)
     k8sconfig.load_incluster_config()
-    api = k8sclient.BatchV1beta1Api()
+    api = k8sclient.BatchV1Api()
 
     return api
 
@@ -4737,12 +4737,12 @@ def wait_for_volume_recurring_job_update(volume, jobs=[], groups=[]):
     assert ok
 
 
-def wait_for_cron_job_create(batch_v1_beta_api, label="",
+def wait_for_cron_job_create(batch_v1_api, label="",
                              retry_counts=RETRY_COUNTS):
     exist = False
     for _ in range(retry_counts):
-        job = batch_v1_beta_api.list_namespaced_cron_job('longhorn-system',
-                                                         label_selector=label)
+        job = batch_v1_api.list_namespaced_cron_job('longhorn-system',
+                                                    label_selector=label)
         if len(job.items) != 0:
             exist = True
             break
@@ -4751,12 +4751,12 @@ def wait_for_cron_job_create(batch_v1_beta_api, label="",
     assert exist
 
 
-def wait_for_cron_job_delete(batch_v1_beta_api, label="",
+def wait_for_cron_job_delete(batch_v1_api, label="",
                              retry_counts=RETRY_COUNTS):
     exist = True
     for _ in range(retry_counts):
-        job = batch_v1_beta_api.list_namespaced_cron_job('longhorn-system',
-                                                         label_selector=label)
+        job = batch_v1_api.list_namespaced_cron_job('longhorn-system',
+                                                    label_selector=label)
         if len(job.items) == 0:
             exist = False
             break
@@ -4765,12 +4765,12 @@ def wait_for_cron_job_delete(batch_v1_beta_api, label="",
     assert not exist
 
 
-def wait_for_cron_job_count(batch_v1_beta_api, number, label="",
+def wait_for_cron_job_count(batch_v1_api, number, label="",
                             retry_counts=RETRY_COUNTS):
     ok = False
     for _ in range(retry_counts):
-        jobs = batch_v1_beta_api.list_namespaced_cron_job('longhorn-system',
-                                                          label_selector=label)
+        jobs = batch_v1_api.list_namespaced_cron_job('longhorn-system',
+                                                     label_selector=label)
         if len(jobs.items) == number:
             ok = True
             break

--- a/manager/integration/tests/requirements.txt
+++ b/manager/integration/tests/requirements.txt
@@ -1,7 +1,7 @@
 argcomplete==1.10.0
 directio==1.2
 flake8
-kubernetes==11.0.0
+kubernetes==25.3.0
 pytest==5.3.1
 pytest-repeat==0.9.1
 pytest-order==1.0.1

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -10,7 +10,7 @@ import backupstore
 from backupstore import set_random_backupstore  # NOQA
 
 import common
-from common import client, core_api, apps_api, batch_v1_beta_api  # NOQA
+from common import client, core_api, apps_api, batch_v1_api  # NOQA
 from common import random_labels, volume_name  # NOQA
 from common import storage_class, statefulset, pvc  # NOQA
 from common import make_deployment_with_pvc  # NOQA
@@ -622,7 +622,7 @@ def test_recurring_jobs_maximum_retain(client, core_api, volume_name): # NOQA
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_detached_volume(client, batch_v1_beta_api, volume_name):  # NOQA
+def test_recurring_job_detached_volume(client, batch_v1_api, volume_name):  # NOQA
     """
     Scenario: test recurring job while volume is detached
 
@@ -663,7 +663,7 @@ def test_recurring_job_detached_volume(client, batch_v1_beta_api, volume_name): 
     }
     create_recurring_jobs(client, recurring_jobs)
     check_recurring_jobs(client, recurring_jobs)
-    wait_for_cron_job_count(batch_v1_beta_api, 1)
+    wait_for_cron_job_count(batch_v1_api, 1)
 
     time.sleep(60 * 2)
     volume.attach(hostId=self_host)
@@ -955,7 +955,7 @@ def test_recurring_jobs_on_nodes_with_taints():  # NOQA
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_groups(set_random_backupstore, client, batch_v1_beta_api):  # NOQA
+def test_recurring_job_groups(set_random_backupstore, client, batch_v1_api):  # NOQA
     """
     Scenario: test recurring job groups (S3/NFS)
 
@@ -1021,7 +1021,7 @@ def test_recurring_job_groups(set_random_backupstore, client, batch_v1_beta_api)
     volume1.recurringJobAdd(name=group1, isGroup=True)
     volume2.recurringJobAdd(name=group2, isGroup=True)
 
-    wait_for_cron_job_count(batch_v1_beta_api, 2)
+    wait_for_cron_job_count(batch_v1_api, 2)
 
     write_volume_random_data(volume1)
     write_volume_random_data(volume2)
@@ -1043,7 +1043,7 @@ def test_recurring_job_groups(set_random_backupstore, client, batch_v1_beta_api)
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_default(client, batch_v1_beta_api, volume_name):  # NOQA
+def test_recurring_job_default(client, batch_v1_api, volume_name):  # NOQA
     """
     Scenario: test recurring job set with default in groups
 
@@ -1086,7 +1086,7 @@ def test_recurring_job_default(client, batch_v1_beta_api, volume_name):  # NOQA
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_delete(client, batch_v1_beta_api, volume_name):  # NOQA
+def test_recurring_job_delete(client, batch_v1_api, volume_name):  # NOQA
     """
     Scenario: test delete recurring job
 
@@ -1189,29 +1189,29 @@ def test_recurring_job_delete(client, batch_v1_beta_api, volume_name):  # NOQA
     }
     create_recurring_jobs(client, recurring_jobs)
     check_recurring_jobs(client, recurring_jobs)
-    wait_for_cron_job_count(batch_v1_beta_api, 6)
+    wait_for_cron_job_count(batch_v1_api, 6)
 
     # snapshot
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+snap1)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+snap2)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+snap3)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+snap1)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+snap2)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+snap3)
     # backup
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+back1)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+back2)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+back3)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+back1)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+back2)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+back3)
 
     # Delete `snapshot2` recurring job should delete the cron job
     snap2_recurring_job = client.by_id_recurring_job(snap2)
     client.delete(snap2_recurring_job)
-    wait_for_cron_job_count(batch_v1_beta_api, 5)
+    wait_for_cron_job_count(batch_v1_api, 5)
     # snapshot
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+snap1)
-    wait_for_cron_job_delete(batch_v1_beta_api, JOB_LABEL+"="+snap2)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+snap3)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+snap1)
+    wait_for_cron_job_delete(batch_v1_api, JOB_LABEL+"="+snap2)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+snap3)
     # backup
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+back1)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+back2)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+back3)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+back1)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+back2)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+back3)
 
     # Delete multiple recurring jobs should reflect on the cron jobs.
     back1_recurring_job = client.by_id_recurring_job(back1)
@@ -1220,19 +1220,19 @@ def test_recurring_job_delete(client, batch_v1_beta_api, volume_name):  # NOQA
     client.delete(back1_recurring_job)
     client.delete(back2_recurring_job)
     client.delete(back3_recurring_job)
-    wait_for_cron_job_count(batch_v1_beta_api, 2)
+    wait_for_cron_job_count(batch_v1_api, 2)
     # snapshot
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+snap1)
-    wait_for_cron_job_delete(batch_v1_beta_api, JOB_LABEL+"="+snap2)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+snap3)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+snap1)
+    wait_for_cron_job_delete(batch_v1_api, JOB_LABEL+"="+snap2)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+snap3)
     # backup
-    wait_for_cron_job_delete(batch_v1_beta_api, JOB_LABEL+"="+back1)
-    wait_for_cron_job_delete(batch_v1_beta_api, JOB_LABEL+"="+back2)
-    wait_for_cron_job_delete(batch_v1_beta_api, JOB_LABEL+"="+back3)
+    wait_for_cron_job_delete(batch_v1_api, JOB_LABEL+"="+back1)
+    wait_for_cron_job_delete(batch_v1_api, JOB_LABEL+"="+back2)
+    wait_for_cron_job_delete(batch_v1_api, JOB_LABEL+"="+back3)
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_delete_should_remove_volume_label(client, batch_v1_beta_api, volume_name):  # NOQA
+def test_recurring_job_delete_should_remove_volume_label(client, batch_v1_api, volume_name):  # NOQA
     """
     Scenario: test delete recurring job should remove volume labels
 
@@ -1459,7 +1459,7 @@ def test_recurring_job_volume_label_when_job_and_group_use_same_name(client, vol
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1_beta_api):  # NOQA
+def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1_api):  # NOQA
     """
     Scenario: test recurring job with multiple volumes
 
@@ -1519,9 +1519,9 @@ def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1
     create_recurring_jobs(client, recurring_jobs)
     check_recurring_jobs(client, recurring_jobs)
     wait_for_volume_recurring_job_update(volume1, jobs=[], groups=[DEFAULT])
-    wait_for_cron_job_count(batch_v1_beta_api, 2)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+back1)
-    wait_for_cron_job_create(batch_v1_beta_api, JOB_LABEL+"="+back2)
+    wait_for_cron_job_count(batch_v1_api, 2)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+back1)
+    wait_for_cron_job_create(batch_v1_api, JOB_LABEL+"="+back2)
 
     write_volume_random_data(volume1)
     wait_for_snapshot_count(volume1, 2)
@@ -1552,7 +1552,7 @@ def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_snapshot(client, batch_v1_beta_api):  # NOQA
+def test_recurring_job_snapshot(client, batch_v1_api):  # NOQA
     """
     Scenario: test recurring job snapshot
 
@@ -1602,7 +1602,7 @@ def test_recurring_job_snapshot(client, batch_v1_beta_api):  # NOQA
     }
     create_recurring_jobs(client, recurring_jobs)
     check_recurring_jobs(client, recurring_jobs)
-    wait_for_cron_job_count(batch_v1_beta_api, 1)
+    wait_for_cron_job_count(batch_v1_api, 1)
 
     # volume-head
     wait_for_snapshot_count(volume1, 1)
@@ -1625,7 +1625,7 @@ def test_recurring_job_snapshot(client, batch_v1_beta_api):  # NOQA
 
 
 @pytest.mark.recurring_job  # NOQA
-def test_recurring_job_backup(set_random_backupstore, client, batch_v1_beta_api):  # NOQA
+def test_recurring_job_backup(set_random_backupstore, client, batch_v1_api):  # NOQA
     """
     Scenario: test recurring job backup (S3/NFS)
 
@@ -1672,7 +1672,7 @@ def test_recurring_job_backup(set_random_backupstore, client, batch_v1_beta_api)
     }
     create_recurring_jobs(client, recurring_jobs)
     check_recurring_jobs(client, recurring_jobs)
-    wait_for_cron_job_count(batch_v1_beta_api, 1)
+    wait_for_cron_job_count(batch_v1_api, 1)
 
     # 1st job
     write_volume_random_data(volume1)


### PR DESCRIPTION
test: update kubernetes client version to 25.3 and replace batch/v1beta1 with batch/v1 to fix recurring job test cases failed on master pipeline

For https://github.com/longhorn/longhorn/issues/4830

Signed-off-by: Yang Chiu <yang.chiu@suse.com>