### PR TITLE
test: update pyyaml version to 5.4.1 for kubernetes 25.3.0

### DIFF
--- a/manager/integration/tests/requirements.txt
+++ b/manager/integration/tests/requirements.txt
@@ -9,4 +9,4 @@ requests==2.25.1
 six==1.12.0
 minio==5.0.10
 boto3==1.17.91
-pyyaml==5.3.1
+pyyaml==5.4.1


### PR DESCRIPTION
test: update pyyaml version to 5.4.1 for kubernetes 25.3.0

since kubernetes 25.3.0 depends on pyyaml>=5.4.1

For https://github.com/longhorn/longhorn/issues/4830

Signed-off-by: Yang Chiu <yang.chiu@suse.com>