### PR TITLE
test: update csi snapshotter to v5.0.1 for k8s v1.25

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -41,7 +41,7 @@ set_kubeconfig_envvar(){
 
 install_csi_snapshotter_crds(){
     CSI_SNAPSHOTTER_REPO_URL="https://github.com/kubernetes-csi/external-snapshotter.git"
-    CSI_SNAPSHOTTER_REPO_BRANCH="release-4.0"
+    CSI_SNAPSHOTTER_REPO_BRANCH="v5.0.1"
     CSI_SNAPSHOTTER_REPO_DIR="${TMPDIR}/k8s-csi-external-snapshotter"
 
     git clone --single-branch \


### PR DESCRIPTION
test: update csi snapshotter to v5.0.1 for k8s v1.25

For https://github.com/longhorn/longhorn/issues/4239

Signed-off-by: Yang Chiu <yang.chiu@suse.com>