### PR TITLE
Add test test_auto_upgrade_engine_to_default_version

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -178,6 +178,8 @@ SETTING_BACKING_IMAGE_CLEANUP_WAIT_INTERVAL = \
 SETTING_DISABLE_REVISION_COUNTER = "disable-revision-counter"
 SETTING_ORPHAN_AUTO_DELETION = "orphan-auto-deletion"
 SETTING_FAILED_BACKUP_TTL = "failed-backup-ttl"
+SETTING_CONCURRENT_AUTO_ENGINE_UPGRADE_NODE_LIMIT = \
+    "concurrent-automatic-engine-upgrade-per-node-limit"
 
 CSI_UNKNOWN = 0
 CSI_TRUE = 1


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

https://github.com/longhorn/longhorn/issues/4737
Add test case `test_auto_upgrade_engine_to_default_version`
Run PR code 10 time on both [AMD64](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2385/testReport/tests/test_engine_upgrade/) / [ARM64](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2386/testReport/tests/test_engine_upgrade/) were  all passed

For the removed test step in PR code
```
6. In a retry loop, verify that the number of volumes who
       is upgrading engine is always smaller or equal to 3
```
I tried to compare value `volume.currentImage` between `volume.engineImage`,  if they were different and `volume.engineImage` is target image, I can consider that the volume is upgrading engine image, and total volume in upgrade status can not greater than 3

However due to timing issue(upgrade too fast), some times this step will become flaky so I removed this test step, thank you