### PR TITLE
Update the case test_backuptarget_available_during_engine_image_not_ready

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1500,6 +1500,7 @@ def cleanup_client():
     reset_node(client)
     reset_settings(client)
     reset_disks_for_all_nodes(client)
+    scale_up_engine_image_daemonset(client)
     reset_engine_image(client)
     wait_for_all_instance_manager_running(client)
 
@@ -3123,6 +3124,26 @@ def reset_engine_image(client):
         time.sleep(RETRY_INTERVAL)
 
     assert ready
+
+
+# ensure that the engine image daemonset scale up for longhorn
+# after scaling down daemonset
+def scale_up_engine_image_daemonset(client):
+    apps_api = get_apps_api_client()
+    default_img = get_default_engine_image(client)
+    ds_name = "engine-image-" + default_img.name
+    body = [{
+        "op": "replace",
+        "path": "/spec/template/spec/nodeSelector",
+        "value": None
+    }]
+    try:
+        apps_api.patch_namespaced_daemon_set(
+            name=ds_name, namespace='longhorn-system', body=body)
+    except ApiException as e:
+        # for scaling up a running daemond set,
+        # the status_code is 422 server error.
+        assert e.status == 422
 
 
 def wait_for_all_instance_manager_running(client):

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3769,8 +3769,7 @@ def test_workload_with_fsgroup(core_api, statefulset):  # NOQA
 # After introducing the gRPC proxy, the backup target controller is relying on
 # the gRPC server availability instead of the engine binary availability.
 # https://github.com/longhorn/longhorn/issues/4033
-@pytest.mark.skip(reason="TODO")  # NOQA
-def test_backuptarget_available_during_engine_image_not_ready(client, apps_api, request):  # NOQA
+def test_backuptarget_available_during_engine_image_not_ready(client, apps_api):  # NOQA
     """
     Test backup target available during engine image not ready
 
@@ -3785,18 +3784,6 @@ def test_backuptarget_available_during_engine_image_not_ready(client, apps_api, 
     9. Reset backup target setting
     10. Check backup target status.available=false
     """
-    def finalizer():
-        default_img = common.get_default_engine_image(client)
-        ds_name = "engine-image-" + default_img.name
-        body = [{
-            "op": "remove",
-            "path": "/spec/template/spec/nodeSelector/foo"
-        }]
-        apps_api.patch_namespaced_daemon_set(
-            name=ds_name, namespace='longhorn-system', body=body)
-
-    request.addfinalizer(finalizer)
-
     backupstores = common.get_backupstore_url()
     for backupstore in backupstores:
         url = ""

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3766,9 +3766,7 @@ def test_workload_with_fsgroup(core_api, statefulset):  # NOQA
                                  DATA_SIZE_IN_MB_1)
     get_pod_data_md5sum(core_api, pod_name, "/data/test")
 
-# After introducing the gRPC proxy, the backup target controller is relying on
-# the gRPC server availability instead of the engine binary availability.
-# https://github.com/longhorn/longhorn/issues/4033
+
 def test_backuptarget_available_during_engine_image_not_ready(client, apps_api):  # NOQA
     """
     Test backup target available during engine image not ready


### PR DESCRIPTION
Update the case test_backuptarget_available_during_engine_image_not_ready

issue https://github.com/longhorn/longhorn/issues/4750

Signed-off-by: Roger Yao <roger.yao@suse.com>