### PR TITLE
[Backport v1.3.x] Reorder cleanup_client

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -323,6 +323,7 @@ def cleanup_all_volumes(client):
         # ignore the error when clean up
         try:
             client.delete(v)
+            wait_for_volume_delete(client, v.name)
         except Exception as e:
             print("\nException when cleanup volume ", v)
             print(e)
@@ -1479,13 +1480,13 @@ def cleanup_client():
     client = get_longhorn_api_client()
     enable_default_disk(client)
 
+    cleanup_all_volumes(client)
+
     # cleanup test disks
     cleanup_test_disks(client)
 
     if recurring_job_feature_supported(client):
         cleanup_all_recurring_jobs(client)
-
-    cleanup_all_volumes(client)
 
     if backing_image_feature_supported(client):
         cleanup_all_backing_images(client)


### PR DESCRIPTION
Ref: longhorn-test PR 1181

Avoid teardown error when a volume attached to a volume disk

Signed-off-by: Chris Chien <chris.chien@suse.com>