### PR TITLE
Modify test_replica_schedule_to_disk_with_most_usable_storage

### DIFF
--- a/manager/integration/tests/test_scheduling.py
+++ b/manager/integration/tests/test_scheduling.py
@@ -1445,11 +1445,6 @@ def test_replica_schedule_to_disk_with_most_usable_storage(client, volume_name, 
     Then volume replica     on the current node scheduled to disk-1.
          volume replica not on the current node scheduled to default disk.
     """
-    # Remove volumes let no volume mounted to extra disk
-    def finalizer():
-        common.cleanup_all_volumes(client)
-    request.addfinalizer(finalizer)
-
     default_disk_available = 0
     self_host_id = get_self_host_id()
     cleanup_node_disks(client, self_host_id)
@@ -1472,7 +1467,7 @@ def test_replica_schedule_to_disk_with_most_usable_storage(client, volume_name, 
                              name, "storageReserved",
                              disk.storageMaximum-default_disk_available)
 
-    disk_path = create_host_disk(client, 'disk-1',
+    disk_path = create_host_disk(client, 'vol-disk-1',
                                  str(50 * Gi + default_disk_available),
                                  node.name)
     disk = {"path": disk_path, "allowScheduling": True}


### PR DESCRIPTION
To avoid volume not clean up clearly after longhorn-test [PR1193](https://github.com/longhorn/longhorn-tests/pull/1193) merged

Ref: [4957](https://github.com/longhorn/longhorn/issues/4957)

Signed-off-by: Chris Chien chris.chien@suse.com