### PR TITLE
Modify common function write_volume_dev_random_mb_data

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -781,14 +781,15 @@ def copy_pod_volume_data(api, pod_name, src_path, dest_path):
         tty=False)
 
 
-def write_volume_dev_random_mb_data(path, offset_in_mb, length_in_mb):
+def write_volume_dev_random_mb_data(path, offset_in_mb, length_in_mb,
+                                    timeout_cnt=3):
     write_cmd = [
         '/bin/sh',
         '-c',
         'dd if=/dev/urandom of=%s bs=1M seek=%d count=%d' %
         (path, offset_in_mb, length_in_mb)
     ]
-    with timeout(seconds=STREAM_EXEC_TIMEOUT * 3,
+    with timeout(seconds=STREAM_EXEC_TIMEOUT * timeout_cnt,
                  error_message='Timeout on writing dev'):
         subprocess.check_call(write_cmd)
 

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -4453,7 +4453,7 @@ def test_space_usage_for_rebuilding_only_volume(client, volume_name, request):  
     snap_offset = 1
     volume_endpoint = get_volume_endpoint(volume)
     write_volume_dev_random_mb_data(volume_endpoint,
-                                    snap_offset, 3000)
+                                    snap_offset, 3000, 5)
 
     snap2 = create_snapshot(client, volume_name)
     volume.snapshotDelete(name=snap2.name)
@@ -4461,7 +4461,7 @@ def test_space_usage_for_rebuilding_only_volume(client, volume_name, request):  
     wait_for_snapshot_purge(client, volume_name, snap2.name)
 
     write_volume_dev_random_mb_data(volume_endpoint,
-                                    snap_offset, 3000)
+                                    snap_offset, 3000, 5)
 
     for r in volume.replicas:
         if r.hostId != lht_hostId:


### PR DESCRIPTION
Make wait time become variable in `write_volume_dev_random_mb_data`

Avoid some test case get timeout error when writing big size data into volume


Failed test [case](https://ci.longhorn.io/job/public/job/master/job/sles/job/amd64/job/longhorn-upgrade-tests-sles-amd64/307/testReport/tests/test_basic/test_space_usage_for_rebuilding_only_volume/) 

Signed-off-by: Chris Chien <chris.chien@suse.com>
