### PR TITLE
Add longhorn components recovery

### DIFF
--- a/docs/content/manual/pre-release/air-gap/_index.md
+++ b/docs/content/manual/pre-release/air-gap/_index.md
@@ -1,3 +1,0 @@
----
-title: Air Gap
----

--- a/docs/content/manual/pre-release/air-gap/air-gap-installation.md
+++ b/docs/content/manual/pre-release/air-gap/air-gap-installation.md
@@ -1,4 +1,0 @@
----
-title: Air gap installation
----
-Need to test air gap installation manually for now.

--- a/docs/content/manual/pre-release/air-gap/air-gap-instance-manager-name.md
+++ b/docs/content/manual/pre-release/air-gap/air-gap-instance-manager-name.md
@@ -1,8 +1,0 @@
----
-title: Air gap installation with an instance-manager-image name longer than 63 characters
----
-1. Host instance manager image under a name more than 63 characters in Docker hub
-2. Update longhorn-manager deployment flag --instance-manager-image to that value
-3. Try to create a new volume and attach it.
-
-Expected behavior:There should be no error.

--- a/docs/content/manual/pre-release/resiliency/test-longhorn-component-recovery.md
+++ b/docs/content/manual/pre-release/resiliency/test-longhorn-component-recovery.md
@@ -1,0 +1,21 @@
+---
+title: "Test Longhorn components recovery"
+---
+
+This is a simple test is check if all the components are recoverable.
+
+####Test data setup:
+1. Deploy Longhorn on a 3 nodes cluster.
+1. Create a volume `vol-1` using Longhorn UI.
+1. Create a volume `vol-2` using the Longhorn storage class.
+1. Create a volume `vol-3` with backing image.
+1. Create an RWX volume `vol-4`.
+1. Write some data in all the volumes created and compute the md5sum.
+1. Have all the volumes in attached state.
+
+####Test steps:
+1. Delete the IM-e from every volume and make sure every volume recovers. Check the data as well.
+1. Start replica rebuilding for the aforementioned volumes, and delete the IM-e while it is rebuilding. Verify the recovered volumes.
+1. Delete the Share-manager pod and verify the RWX volume `vol-4` is able recover. Verify the data too.
+1. Delete the backing image manager pod and verify the pod gets recreated.
+1. Delete one pod of all the Longhorn components like longhorn-manager, ui, csi components etc and verify they are able to recover. 


### PR DESCRIPTION
1. This is to include components recovery test in the release testing.
2. Removed air gap test from manual test as this is automated already.

Signed-off-by: Khushboo <fnu.khushboo@suse.com>