### PR TITLE
Update test_rwx_delete_share_manager_pod

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -85,6 +85,7 @@ from common import wait_for_volume_creation
 from common import create_host_disk, get_update_disks, update_node_disks
 from common import wait_for_disk_status, wait_for_rebuild_start, wait_for_rebuild_complete # NOQA
 from common import RETRY_BACKUP_COUNTS
+from common import LONGHORN_NAMESPACE
 
 from backupstore import backupstore_delete_volume_cfg_file
 from backupstore import backupstore_cleanup
@@ -4037,12 +4038,12 @@ def test_default_storage_class_syncup(core_api, request):  # NOQA
         """
         config_map = core_api.read_namespaced_config_map(
                                                 "longhorn-storageclass",
-                                                "longhorn-system")
+                                                LONGHORN_NAMESPACE)
         config_map_data = yaml.safe_load(config_map.data["storageclass.yaml"])
         config_map_data["allowVolumeExpansion"] = allow_exp
         config_map.data["storageclass.yaml"] = yaml.dump(config_map_data)
         core_api.patch_namespaced_config_map("longhorn-storageclass",
-                                             "longhorn-system",
+                                             LONGHORN_NAMESPACE,
                                              config_map)
 
         for i in range(RETRY_COMMAND_COUNT):
@@ -4067,7 +4068,7 @@ def test_default_storage_class_syncup(core_api, request):  # NOQA
     # step 1
     storage_api = common.get_storage_api_client()
     config_map = core_api.read_namespaced_config_map("longhorn-storageclass",
-                                                     "longhorn-system")
+                                                     LONGHORN_NAMESPACE)
     config_map_data = yaml.safe_load(config_map.data["storageclass.yaml"])
 
     # step 2

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -64,6 +64,7 @@ from common import wait_pod, exec_command_in_pod
 from common import RETRY_EXEC_COUNTS, RETRY_EXEC_INTERVAL
 from common import get_volume_running_replica_cnt
 from common import update_node_disks
+from common import LONGHORN_NAMESPACE
 
 from backupstore import set_random_backupstore # NOQA
 from backupstore import backupstore_cleanup
@@ -2775,7 +2776,7 @@ def test_autosalvage_with_data_locality_enabled(client, core_api, make_deploymen
             .format(node_1["name"])
 
     ret = core_api.list_namespaced_pod(
-            namespace="longhorn-system", label_selector=labels)
+            namespace=LONGHORN_NAMESPACE, label_selector=labels)
     imr_name = ret.items[0].metadata.name
 
     delete_and_wait_pod(core_api, pod_name=imr_name,
@@ -2798,7 +2799,7 @@ def test_autosalvage_with_data_locality_enabled(client, core_api, make_deploymen
     labels = "app=longhorn-manager"
     selector = "spec.nodeName=={}".format(node_2["name"])
     ret = core_api.list_namespaced_pod(
-                namespace="longhorn-system", field_selector=selector,
+                namespace=LONGHORN_NAMESPACE, field_selector=selector,
                 label_selector=labels)
 
     mgr_name = ret.items[0].metadata.name
@@ -2866,7 +2867,7 @@ def test_recovery_from_im_deletion(client, core_api, volume_name, make_deploymen
     # Step5, 6
     volume = client.by_id_volume(volume_name)
     im_name = volume["controllers"][0]["instanceManagerName"]
-    exec_cmd = ["kubectl", "delete", "pod",  im_name, "-n", "longhorn-system"]
+    exec_cmd = ["kubectl", "delete", "pod",  im_name, "-n", LONGHORN_NAMESPACE]
     subprocess.check_output(exec_cmd)
 
     target_pod = \

--- a/manager/integration/tests/test_rwx.py
+++ b/manager/integration/tests/test_rwx.py
@@ -12,9 +12,9 @@ from common import find_backup, Gi, volume_name, csi_pv, pod_make  # NOQA
 from common import wait_for_volume_creation, DATA_SIZE_IN_MB_3
 from common import create_pv_for_volume, create_pvc_for_volume
 from common import DEFAULT_STATEFULSET_TIMEOUT, DEFAULT_STATEFULSET_INTERVAL
-from common import wait_delete_pod, wait_for_pod_remount
 from common import get_core_api_client, write_pod_volume_random_data
 from common import create_pvc_spec, make_deployment_with_pvc  # NOQA
+from common import wait_for_pod_phase
 from common import core_api, statefulset, pvc, pod, client  # NOQA
 from common import RETRY_COUNTS, RETRY_INTERVAL
 from backupstore import set_random_backupstore # NOQA
@@ -340,10 +340,9 @@ def test_rwx_delete_share_manager_pod(core_api, statefulset):  # NOQA
     2. Wait for StatefulSet to come up healthy.
     3. Write data and compute md5sum.
     4. Delete the share manager pod.
-    5. Wait for a new pod to be created and volume getting attached.
-    6. Check the data md5sum in statefulSet.
-    7. Write more data to it and compute md5sum.
-    8. Check the data md5sum in share manager volume.
+    5. Check the data md5sum in statefulSet.
+    6. Write more data to it and compute md5sum.
+    7. Check the data md5sum in share manager volume.
     """
 
     statefulset_name = 'statefulset-delete-share-manager-pods-test'
@@ -374,10 +373,8 @@ def test_rwx_delete_share_manager_pod(core_api, statefulset):  # NOQA
     delete_and_wait_pod(core_api, share_manager_name,
                         namespace=LONGHORN_NAMESPACE)
 
-    target_pod = core_api.read_namespaced_pod(name=pod_name,
-                                              namespace='default')
-    wait_delete_pod(core_api, target_pod.metadata.uid)
-    wait_for_pod_remount(core_api, pod_name)
+    wait_for_pod_phase(core_api, share_manager_name,
+                       namespace=LONGHORN_NAMESPACE, pod_phase="Running")
 
     test_data_2 = generate_random_data(VOLUME_RWTEST_SIZE)
     write_pod_volume_data(core_api, pod_name, test_data_2, filename='test2')


### PR DESCRIPTION
The workload pod using a RWX volume won't be deleted if the volume is detached after introducing https://github.com/longhorn/longhorn-manager/pull/1589.

Longhorn/longhorn#5017

Signed-off-by: Derek Su <derek.su@suse.com>