### PR TITLE
ci: shorten cleanup long-running instances threshold to 1 day

### DIFF
--- a/cleanup/scripts/cleanup.sh
+++ b/cleanup/scripts/cleanup.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 CURRENT_TIMESTAMP=$(date -u +%s)
 echo "Current Time: $(date -u)"
-THRESHOLD_IN_SEC=$((86400*3)) # if an instance exists more than 3 days, delete it.
+THRESHOLD_IN_SEC=$((86400)) # if an instance exists more than 1 day, delete it.
 SUFFIX_ARR=()
 
 echo "[Step 1] Get all instances:"


### PR DESCRIPTION
ci: shorten cleanup long-running instances threshold to 1 day

Signed-off-by: Yang Chiu <yang.chiu@suse.com>