### PR TITLE
Split case test_engine_image_missing_on_some_nodes skeleton

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -2619,108 +2619,163 @@ def test_replica_failure_during_attaching(settings_reset, client, core_api, volu
     common.wait_for_disk_update(client, node.name, 1)
 
 
-@pytest.mark.skip(reason="TODO") # NOQA
-def test_engine_image_missing_on_some_nodes():
+def prepare_engine_not_fully_deployed_evnironment():
     """
-    This e2e test follows the manual test steps at:
-    https://github.com/longhorn/longhorn/issues/2081#issuecomment-783747541
-
-    Steps:
-
-    Preparation:
-    1. Set up a backup store
-    2. Let's name the 3 nodes: node-1, node-2, node-3
-
-    Case 1: Test volume operations when engine image DaemonSet is miss
-    scheduled
-    1. Create a volume, vol-1, of 3 replicas
-    2. Create another volume, vol-2, of 3 replicas
-    3. Taint node-1 with the taint: key=value:NoSchedule
-    4. Verify that we can attach, take snapshot, take a backup,
-       expand, then detach vol-1
-
-    Case 2: Test volume operations when engine image DaemonSet is not fully
-    deployed
-    1. Continue from case #1
-    2. Attach vol-1 to node-1. Change the number of replicas of vol-1
-       to 2. Delete the replica on node-1
-    3. Delete the pod on node-1 of the engine image DaemonSet.
+    1. Taint node-1 with the taint: key=value:NoSchedule
+    2. Delete the pod on node-1 of the engine image DaemonSet.
        Or delete the engine image DaemonSet and wait for Longhorn
        to automatically recreates it.
-    4. Wait for the engine image CR state become deploying
-    5. Verify that functions (snapshot, backup, detach) are working ok
+    3. Wait for the engine image CR state become deploying
+    """
+
+
+def prepare_engine_not_fully_deployed_evnironment_with_volumes():
+    """
+    1. Create 2 volumes, vol-1 and vol-2 with 3 replicas
+    2. Taint node-1 with the taint: key=value:NoSchedule
+    3. Attach vol-1 to node-1. Change the number of replicas of vol-1
+       to 2. Delete the replica on node-1
+    4. Delete the pod on node-1 of the engine image DaemonSet.
+       Or delete the engine image DaemonSet and wait for Longhorn
+       to automatically recreates it.
+    5. Wait for the engine image CR state become deploying
+    """
+
+
+@pytest.mark.skip(reason="TODO") # NOQA
+def test_engine_image_miss_scheduled_perform_volume_operations():
+    """
+    Test volume operations when engine image DaemonSet is miss
+    scheduled
+
+    1. Create a volume, vol-1, of 3 replicas
+    2. Taint node-1 with the taint: key=value:NoSchedule
+    3. Verify that we can attach, take snapshot, take a backup,
+       expand, then detach vol-1
+    """
+    pass
+
+
+@pytest.mark.skip(reason="TODO") # NOQA
+def test_engine_image_not_fully_deployed_perform_volume_operations():
+    """
+    Test volume operations when engine image DaemonSet is not fully
+    deployed
+
+    Prerequisite:
+    Prepare system for the test by calling the method
+    prepare_engine_not_fully_deployed_evnironment_with_volumes to have
+    2 volumes, tainted node and not fully deployed engine.
+
+    1. Verify that functions (snapshot, backup, detach) are working ok
        for vol-1
-    6. Detach vol-1
-    7. Attach vol-1 to node-1. Verify that Longhorn cannot attach vol-1 to
+    2. Detach vol-1
+    3. Attach vol-1 to node-1. Verify that Longhorn cannot attach vol-1 to
        node-1 since there is no engine image on node-1. The attach API call
        returns error
-    8. Verify that we can attach to another node, take snapshot, take a backup,
+    4. Verify that we can attach to another node, take snapshot, take a backup,
        expand, then detach vol-1
-    9. Verify that vol-2 cannot be attached to any nodes because one of
+    5. Verify that vol-2 cannot be attached to any nodes because one of
        its replicas is sitting on the node-1 which doesn't have the
        engine image. The attach API call returns error
+    """
+    pass
 
-    Case 3: Test engine upgrade when engine image DaemonSet is not fully
+
+@pytest.mark.skip(reason="TODO") # NOQA
+def test_engine_image_not_fully_deployed_perform_engine_upgrade():
+    """
+    Test engine upgrade when engine image DaemonSet is not fully
     deployed
-    1. Continue from case #2
-    2. Deploy a new engine image, new-ei
-    3. Detach vol-1
-    4. Verify that you can upgrade vol-1 to new-ei
-    5. Attach vol-1 to node-2
-    6. Verify that you can live upgrade vol-1 to back to default engine image
-    7. Try to upgrade vol-2 to new-ei
-    8. Verify that the engineUpgrade API call returns error
 
-    Case 4: Test replicas scheduling when engine image DaemonSet is not fully
+    Prerequisite:
+    Prepare system for the test by calling the method
+    prepare_engine_not_fully_deployed_evnironment_with_volumes to have
+    2 volumes, tainted node and not fully deployed engine.
+
+    1. Deploy a new engine image, new-ei
+    2. Verify that you can upgrade vol-1 to new-ei
+    3. Detach then attach vol-1 to node-2
+    4. Verify that you can live upgrade vol-1 to back to default engine image
+    5. Try to upgrade vol-2 to new-ei
+    6. Verify that the engineUpgrade API call returns error
+    """
+    pass
+
+
+@pytest.mark.skip(reason="TODO") # NOQA
+def test_engine_image_not_fully_deployed_perform_replica_scheduling():
+    """
+    Test replicas scheduling when engine image DaemonSet is not fully
     deployed
-    1. Continue from case #3
-    2. Create a new volume, vol-3, with 2 replicas
-    3. disable the scheduling for node-2
-    4. Verify that there is one replica fail to be scheduled
-    5. enable the scheduling for node-2
-    6. Verify that replicas are scheduled onto node-2 and node-3
 
-    Case 5: Test auto upgrade engine feature when engine image DaemonSet is
+    Prerequisite:
+    Prepare system for the test by calling the method
+    prepare_engine_not_fully_deployed_evnironment to have
+    tainted node and not fully deployed engine.
+
+    1. Disable the scheduling for node-2
+    2. Create a volume, vol-1, with 2 replicas, attach to node-3
+    3. Verify that there is one replica fail to be scheduled
+    4. enable the scheduling for node-2
+    5. Verify that replicas are scheduled onto node-2 and node-3
+    """
+    pass
+
+
+@pytest.mark.skip(reason="TODO") # NOQA
+def test_engine_image_not_fully_deployed_perform_auto_upgrade_engine():
+    """
+    Test auto upgrade engine feature when engine image DaemonSet is
     not fully deployed
-    1. Continue from case #4
-    2. Detach vol-1 and vol-3
-    3. Upgrade vol-1 and vol-3 to the new-ei
-    4. Attach vol-3 to node node-2
+
+    Prerequisite:
+    Prepare system for the test by calling the method
+    prepare_engine_not_fully_deployed_evnironment to have
+    tainted node and not fully deployed engine.
+
+    1. Create 2 volumes vol-1 and vol-2 with 2 replicas
+    2. Deploy a new engine image, new-ei
+    3. Upgrade vol-1 and vol-2 to the new-ei
+    4. Attach vol-2 to node node-2
     5. Set `Concurrent Automatic Engine Upgrade Per Node Limit` setting to 3
     6. In a 2-min retry, verify that Longhorn upgrades the engine image of
-       vol-1 and vol-3 back to the default version and Longhorn doesn't
-       automatically upgrade vol-2's engine image since it has 1 replica
-       sitting on node-1 which doesn't have the engine image deployed
+       vol-1 and vol-2.
+    """
+    pass
 
-    Case 6: Test DR, restoring, expanding volumes when engine image DaemonSet
+
+@pytest.mark.skip(reason="TODO") # NOQA
+def test_engine_image_not_fully_deployed_perform_dr_restoring_expanding_volume(): # NOQA
+    """
+    Test DR, restoring, expanding volumes when engine image DaemonSet
     is not fully deployed
-    1. Continue from case #5
-    2. Create a DR volume (vol-dr) of 2 replicas.
-    3. Verify that 2 replicas are on node-2 and node-3 and the DR volume
+
+    Prerequisite:
+    Prepare system for the test by calling the method
+    prepare_engine_not_fully_deployed_evnironment to have
+    tainted node and not fully deployed engine.
+
+    1. Create volume vol-1 with 2 replicas
+    2. Attach vol-1 to node-2, write data and create backup
+    3. Create a DR volume (vol-dr) of 2 replicas.
+    4. Verify that 2 replicas are on node-2 and node-3 and the DR volume
        is attached to either node-2 or node-3.
        Let's say it is attached to node-x
-    4. Taint node-x with the taint `key=value:NoSchedule`
-    5. Delete the pod of engine image DeamonSet on node-x. Now, the engine
+    5. Taint node-x with the taint `key=value:NoSchedule`
+    6. Delete the pod of engine image DeamonSet on node-x. Now, the engine
        image is missing on node-1 and node-x
-    6. Verify that vol-dr is auto-attached node-y.
-    7. Restore a volume from backupstore with name vol-rs and replica count
+    7. Verify that vol-dr is auto-attached node-y.
+    8. Restore a volume from backupstore with name vol-rs and replica count
        is 1
-    8. Verify that replica is on node-y and the volume successfully restored.
-    9. Wait for vol-rs to finish restoring
-    10. Expand vol-rs.
-    11. Verify that the expansion is ok
-
-    Case 7: Test replicas scheduling when engine image DaemonSet is not fully
-    deployed
-    1. Continue from case #6
-    2. Set `Replica Replenishment Wait Interval` setting to 600
-    3. Crash the replica of vol-3 on node-x. Wait for the replica to fail
-    4. In a 2-min retry verify that Longhorn doesn't create new replica
-       for vol-3 and doesn't reuse the failed replica on node-x
-
-    Cleaning up:
-    1. Remove the taint from node-1 and node-x
-    2. Delete the new-ei
+    9. Verify that replica is on node-y and the volume successfully restored.
+    10. Wait for vol-rs to finish restoring
+    11. Expand vol-rs.
+    12. Verify that the expansion is ok
+    13. Set `Replica Replenishment Wait Interval` setting to 600
+    14. Crash the replica of vol-1 on node-x. Wait for the replica to fail
+    15. In a 2-min retry verify that Longhorn doesn't create new replica
+       for vol-1 and doesn't reuse the failed replica on node-x
     """
     pass
 


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/5014

Split case test_engine_image_missing_on_some_nodes skeleton to below
- test_engine_image_miss_scheduled_perform_volume_operations
- test_engine_image_not_fully_deployed_perform_volume_operations
- test_engine_image_not_fully_deployed_perform_engine_upgrade
- test_engine_image_not_fully_deployed_perform_replica_scheduling
- test_engine_image_not_fully_deployed_perform_autoup_grade_engine
- test_engine_image_not_fully_deployed_perform_dr_restoring_expanding_volume

Signed-off-by: Chris Chien <chris.chien@suse.com>