### PR TITLE
Enlarge volume size for increasing backup time

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -4874,11 +4874,12 @@ def backup_failed_cleanup(client, core_api, volume_name, volume_size,  # NOQA
     vol.snapshotBackup(name=snap.name)
 
     # write some data to the volume
-    data = {
-        'pos': 0,
-        'content': common.generate_random_data(volume_size),
-    }
-    write_volume_data(vol, data)
+    volume_endpoint = get_volume_endpoint(vol)
+
+    # Take snapshots4 without overlapping
+    data_size = volume_size/Mi
+    write_volume_dev_random_mb_data(
+        volume_endpoint, 0, data_size)
 
     # create a snapshot and a backup
     snap = create_snapshot(client, volume_name)
@@ -4926,7 +4927,7 @@ def test_backup_failed_enable_auto_cleanup(set_random_backupstore,  # NOQA
     9.   Wait and check if the backup was deleted automatically
     10.  Cleanup
     """
-    backup_name = backup_failed_cleanup(client, core_api, volume_name, 256*Mi)
+    backup_name = backup_failed_cleanup(client, core_api, volume_name, 1024*Mi)
 
     # wait in 5 minutes for automatic failed backup cleanup
     wait_for_backup_delete(client, volume_name, backup_name)

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -841,7 +841,7 @@ def test_recurring_jobs_when_volume_detached_unexpectedly(set_random_backupstore
     common.update_setting(client,
                           SETTING_RECURRING_JOB_WHILE_VOLUME_DETACHED, "true")
 
-    volume = create_and_check_volume(client, volume_name, size=str(1 * Gi))
+    volume = create_and_check_volume(client, volume_name, size=str(2 * Gi))
     volume = wait_for_volume_detached(client, volume.name)
 
     pv_name = volume_name + "-pv"
@@ -854,7 +854,7 @@ def test_recurring_jobs_when_volume_detached_unexpectedly(set_random_backupstore
     deployment = make_deployment_with_pvc(deployment_name, pvc_name)
     create_and_wait_deployment(apps_api, deployment)
 
-    size_mb = 500
+    size_mb = 1000
     pod_names = common.get_deployment_pod_names(core_api, deployment)
     write_pod_volume_random_data(core_api, pod_names[0], "/data/test",
                                  size_mb)


### PR DESCRIPTION
Fix some failed test cases by increasing volume size after introducing fast lz4 compression method.

longhorn/longhorn#5189

