### PR TITLE
[BACKPORT][v1.4.x] test(auto/manual): system backup/restore

### DIFF
--- a/docs/content/manual/release-specific/v1.4.0/test-system-backup.md
+++ b/docs/content/manual/release-specific/v1.4.0/test-system-backup.md
@@ -1,0 +1,25 @@
+---
+title: Test Longhorn system backup should sync from the remote backup target
+---
+
+## Steps
+
+**Given** Custom resource SystemBackup (foo) exist in AWS S3,
+
+*And* System backup (foo) downloaded from AWS S3. 
+
+*And* Custom resource SystemBackup (foo) deleted.
+
+**When** Upload the system backup (foo) to AWS S3.
+
+*And* Create a new custom resource SystemBackup(foo).
+> This needs to be done before the system backup gets synced to the cluster.
+
+**Then** Should see the synced messages in the custom resource SystemBackup(foo).
+```
+Events:
+  Type    Reason   Age    From                               Message
+  ----    ------   ----   ----                               -------
+  Normal  Syncing  9m29s  longhorn-system-backup-controller  Syncing system backup from backup target
+  Normal  Synced   9m28s  longhorn-system-backup-controller  Synced system backup from backup target
+```

--- a/manager/integration/pytest.ini
+++ b/manager/integration/pytest.ini
@@ -14,3 +14,4 @@ markers =
   migration
   orphan
   support_bundle
+  system_backup_restore

--- a/manager/integration/tests/backupstore.py
+++ b/manager/integration/tests/backupstore.py
@@ -22,6 +22,7 @@ from common import delete_backup_volume
 from common import get_backupstore_url
 from common import get_backupstore_poll_interval
 from common import get_backupstores
+from common import system_backups_cleanup
 
 BACKUPSTORE_BV_PREFIX = "/backupstore/volumes/"
 BACKUPSTORE_LOCK_DURATION = 150
@@ -56,6 +57,7 @@ def set_random_backupstore(request, client):
     yield
     cleanup_all_volumes(client)
     backupstore_cleanup(client)
+    system_backups_cleanup(client)
     reset_backupstore_setting(client)
 
     if request.param == "nfs":

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1513,7 +1513,8 @@ def cleanup_client():
         cleanup_all_backing_images(client)
 
     cleanup_storage_class()
-    system_restores_cleanup(client)
+    if system_backup_feature_supported(client):
+        system_restores_cleanup(client)
 
     cleanup_all_support_bundles(client)
 
@@ -4701,6 +4702,15 @@ def backing_image_feature_supported(client):
 # for the case of test_upgrade starting from Longhorn >= v1.2.0
 def recurring_job_feature_supported(client):
     if hasattr(client.by_id_schema("volumeRecurringJob"), "id"):
+        return True
+    else:
+        return False
+
+
+# this function will check if system backup feature is supported, and is added
+# for the case of test_upgrade starting from Longhorn >= v1.4.0
+def system_backup_feature_supported(client):
+    if hasattr(client.by_id_schema("systemBackup"), "id"):
         return True
     else:
         return False

--- a/manager/integration/tests/test_system_backup_restore.py
+++ b/manager/integration/tests/test_system_backup_restore.py
@@ -1,11 +1,20 @@
 import pytest
 
 from common import client  # NOQA
+from common import volume_name # NOQA
 
+from common import check_volume_data
+from common import cleanup_volume
+from common import create_and_check_volume
+from common import create_backup
+from common import get_self_host_id
 from common import system_backup_random_name
 from common import system_backup_wait_for_state
 from common import system_restore_random_name
 from common import system_restore_wait_for_state
+from common import wait_for_volume_detached
+from common import wait_for_volume_healthy
+from common import wait_for_volume_restoration_completed
 
 from backupstore import set_random_backupstore  # NOQA
 
@@ -35,3 +44,59 @@ def test_system_backup_and_restore(client, set_random_backupstore):  # NOQA
                                  SystemBackup=system_backup_name)
 
     system_restore_wait_for_state("Completed", system_restore_name, client)
+
+
+@pytest.mark.system_backup_restore   # NOQA
+def test_system_backup_and_restore_volume_with_data(client, volume_name, set_random_backupstore):  # NOQA
+    """
+    Scenario: test system backup and restore volume with data
+
+    Issue: https://github.com/longhorn/longhorn/issues/1455
+
+    Given volume created
+    And data written to volume
+    And volume backup created
+    And system backup created
+    And system backup in state Ready
+    And volume deleted
+
+    When restore system backup
+    Then system restore should be in state Completed
+
+    When wait for volume restoration to complete
+    And volume detached
+
+    Then attach volume
+    And volume should be healthy
+    And volume data should exist
+
+    """
+    host_id = get_self_host_id()
+
+    volume = create_and_check_volume(client, volume_name)
+    volume.attach(hostId=host_id)
+    volume = wait_for_volume_healthy(client, volume_name)
+
+    _, _, _, data = create_backup(client, volume_name)
+
+    system_backup_name = system_backup_random_name()
+    client.create_system_backup(Name=system_backup_name)
+
+    system_backup_wait_for_state("Ready", system_backup_name, client)
+
+    cleanup_volume(client, volume)
+
+    system_restore_name = system_restore_random_name()
+    client.create_system_restore(Name=system_restore_name,
+                                 SystemBackup=system_backup_name)
+
+    system_restore_wait_for_state("Completed", system_restore_name, client)
+
+    restored_volume = client.by_id_volume(volume_name)
+    wait_for_volume_restoration_completed(client, volume_name)
+    wait_for_volume_detached(client, volume_name)
+
+    restored_volume.attach(hostId=host_id)
+    restored_volume = wait_for_volume_healthy(client, volume_name)
+
+    check_volume_data(restored_volume, data)

--- a/manager/integration/tests/test_system_backup_restore.py
+++ b/manager/integration/tests/test_system_backup_restore.py
@@ -1,0 +1,37 @@
+import pytest
+
+from common import client  # NOQA
+
+from common import system_backup_random_name
+from common import system_backup_wait_for_state
+from common import system_restore_random_name
+from common import system_restore_wait_for_state
+
+from backupstore import set_random_backupstore  # NOQA
+
+
+@pytest.mark.system_backup_restore   # NOQA
+def test_system_backup_and_restore(client, set_random_backupstore):  # NOQA
+    """
+    Scenario: test system backup and restore
+
+    Issue: https://github.com/longhorn/longhorn/issues/1455
+
+    Given setup backup target
+    When create system backup
+    Then system backup should be in state Ready
+
+    When restore system backup
+    Then system restore should be in state Completed
+
+    """
+    system_backup_name = system_backup_random_name()
+    client.create_system_backup(Name=system_backup_name)
+
+    system_backup_wait_for_state("Ready", system_backup_name, client)
+
+    system_restore_name = system_restore_random_name()
+    client.create_system_restore(Name=system_restore_name,
+                                 SystemBackup=system_backup_name)
+
+    system_restore_wait_for_state("Completed", system_restore_name, client)


### PR DESCRIPTION
Backport https://github.com/longhorn/longhorn-tests/pull/1191 & https://github.com/longhorn/longhorn-tests/pull/1239 to v1.4.x

Test [result](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/2870/testReport/tests/) on pipeline were passed

https://github.com/longhorn/longhorn/issues/5232

Signed-off-by: Roger Yao <roger.yao@suse.com>