### PR TITLE
Update k8s.gcr.io to registry.k8s.io

### DIFF
--- a/docs/content/manual/release-specific/v1.2.3/test-scalability-with-backing-image.md
+++ b/docs/content/manual/release-specific/v1.2.3/test-scalability-with-backing-image.md
@@ -220,7 +220,7 @@ title: Test scalability with backing image
           terminationGracePeriodSeconds: 10
           containers:
           - name: nginx
-            image: k8s.gcr.io/nginx-slim:0.8
+            image: registry.k8s.io/nginx-slim:0.8
             ports:
             - containerPort: 80
               name: web

--- a/docs/content/manual/release-specific/v1.3.0/test-longhorn-manager-starting-scalability.md
+++ b/docs/content/manual/release-specific/v1.3.0/test-longhorn-manager-starting-scalability.md
@@ -67,7 +67,7 @@ title: Test longhorn manager pod starting scalability
           terminationGracePeriodSeconds: 10
           containers:
             - name: nginx
-              image: k8s.gcr.io/nginx-slim:0.8
+              image: registry.k8s.io/nginx-slim:0.8
               ports:
                 - containerPort: 80
                   name: web

--- a/mirror_csi_images/scripts/publish.sh
+++ b/mirror_csi_images/scripts/publish.sh
@@ -12,14 +12,14 @@ if [[ -n "${LONGHORN_IMAGES_FILE_URL}" ]]; then
     if [[ "${LINE}" =~ "csi-" ]]; then
       CSI_IMAGE=$(echo "${LINE}" | sed -e "s/longhornio\///g")
       IFS=: read -ra IMAGE_TAG_PAIR <<< "${CSI_IMAGE}"
-      echo "k8s.gcr.io/sig-storage/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
+      echo "registry.k8s.io/sig-storage/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
     fi
   done < "${LONGHORN_IMAGES_FILE}"
 else
   IFS=, read -ra CSI_IMAGES_ARR <<< "${CSI_IMAGES}"
   for CSI_IMAGE in "${CSI_IMAGES_ARR[@]}"; do
     IFS=: read -ra IMAGE_TAG_PAIR <<< "$CSI_IMAGE"
-    echo "k8s.gcr.io/sig-storage/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
+    echo "registry.k8s.io/sig-storage/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
   done
 fi
 


### PR DESCRIPTION
This PR updates k8s.gcr.io to registry.k8s.io

Part of https://github.com/kubernetes/k8s.io/issues/4780