### PR TITLE
test: fix flaky test case test_node_eviction_multiple_volume

### DIFF
--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -2572,10 +2572,12 @@ def test_node_eviction_multiple_volume(client, core_api, csi_pv, pvc, pod_make, 
 
     common.wait_for_replica_scheduled(client, volume1_name,
                                       to_nodes=[node2.name, node3.name],
-                                      chk_vol_healthy=False)
+                                      chk_vol_healthy=False,
+                                      chk_replica_running=False)
     common.wait_for_replica_scheduled(client, volume2_name,
                                       to_nodes=[node2.name, node3.name],
-                                      chk_vol_healthy=False)
+                                      chk_vol_healthy=False,
+                                      chk_replica_running=False)
 
     pod1 = pod_make(name=pod1_name)
     pod1['spec']['volumes'] = [common.create_pvc_spec(pvc1_name)]


### PR DESCRIPTION
test: fix flaky test case test_node_eviction_multiple_volume

by avoiding checking replica running status of an auto-detached volume

For https://github.com/longhorn/longhorn/issues/5475

Signed-off-by: Yang Chiu <yang.chiu@suse.com>