### PR TITLE
test: fix rancher provisioning failure caused by supportBundleManager syntax error

### DIFF
--- a/test_framework/scripts/rancher/terraform/main.tf
+++ b/test_framework/scripts/rancher/terraform/main.tf
@@ -58,7 +58,7 @@ image:
       repository: longhornio/longhorn-manager
     shareManager:
       repository: longhornio/longhorn-share-manager
-    supportBundleManager
+    supportBundleManager:
       repository: longhornio/support-bundle-kit
     ui:
       repository: longhornio/longhorn-ui


### PR DESCRIPTION
test: fix rancher provisioning failure caused by supportBundleManager syntax error

Signed-off-by: Yang Chiu <yang.chiu@suse.com>