### PR TITLE
test: fix flaky test case test_backup_failed_disable_auto_cleanup

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -4953,7 +4953,7 @@ def test_backup_failed_disable_auto_cleanup(set_random_backupstore,  # NOQA
     9.    Wait and check if the backup was not deleted.
     10.   Cleanup
     """
-    backup_name = backup_failed_cleanup(client, core_api, volume_name, 256*Mi,
+    backup_name = backup_failed_cleanup(client, core_api, volume_name, 1024*Mi,
                                         failed_backup_ttl="0")
 
     # wait for 5 minutes to check if the failed backup exists


### PR DESCRIPTION
test: fix flaky test case test_backup_failed_disable_auto_cleanup by increasing volume size so the backup in-progress state can be caught

For https://github.com/longhorn/longhorn/issues/5838

Signed-off-by: Yang Chiu <yang.chiu@suse.com>