### PR TITLE
Fix e2e tests to work with new AD mechanism 

### DIFF
--- a/manager/integration/tests/test_backing_image.py
+++ b/manager/integration/tests/test_backing_image.py
@@ -486,7 +486,7 @@ def test_exporting_backing_image_from_volume(client, volume_name):  # NOQA
     data2 = write_volume_random_data(volume2)
 
     # Step7
-    volume2.detach(hostId="")
+    volume2.detach()
     volume2 = wait_for_volume_detached(client, volume2_name)
 
     # Step8

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -315,7 +315,7 @@ def volume_basic_test(client, volume_name, backing_image=""):  # NOQA
     volume = client.by_id_volume(volume_name)
     volume_rw_test(get_volume_endpoint(volume))
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
     assert volume.restoreRequired is False
 
@@ -454,7 +454,7 @@ def snapshot_test(client, volume_name, backing_image):  # NOQA
     assert "volume-head" in snap.children.keys()
     assert snap.removed is True
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=lht_hostId, disableFrontend=True)
@@ -467,7 +467,7 @@ def snapshot_test(client, volume_name, backing_image):  # NOQA
 
     volume.snapshotRevert(name=snap2.name)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=lht_hostId, disableFrontend=False)
@@ -1280,7 +1280,7 @@ def backupstore_test(client, host_id, volname, size):  # NOQA
     volume = volume.attach(hostId=host_id)
     volume = common.wait_for_volume_healthy(client, restore_name)
     check_volume_data(volume, data)
-    volume = volume.detach(hostId="")
+    volume = volume.detach()
     volume = common.wait_for_volume_detached(client, restore_name)
 
     delete_backup(client, bv.name, b.name)
@@ -1512,7 +1512,7 @@ def restore_inc_test(client, core_api, volume_name, pod):  # NOQA
     check_volume_data(sb_volume2, data0_modified2, False)
 
     # allocated this active volume to a pod
-    sb_volume2.detach(hostId="")
+    sb_volume2.detach()
     sb_volume2 = common.wait_for_volume_detached(client, sb_volume2_name)
 
     create_pv_for_volume(client, core_api, sb_volume2, sb_volume2_name)
@@ -1723,17 +1723,17 @@ def test_listing_backup_volume(client, backing_image=""):   # NOQA
     common.delete_backup_volume(client, volume3_name)
     common.wait_for_backup_volume_delete(client, volume3_name)
 
-    volume1.detach(hostId="")
+    volume1.detach()
     volume1 = common.wait_for_volume_detached(client, volume1_name)
     client.delete(volume1)
     wait_for_volume_delete(client, volume1_name)
 
-    volume2.detach(hostId="")
+    volume2.detach()
     volume2 = common.wait_for_volume_detached(client, volume2_name)
     client.delete(volume2)
     wait_for_volume_delete(client, volume2_name)
 
-    volume3.detach(hostId="")
+    volume3.detach()
     volume3 = common.wait_for_volume_detached(client, volume3_name)
     client.delete(volume3)
     wait_for_volume_delete(client, volume3_name)
@@ -1764,7 +1764,7 @@ def test_volume_multinode(client, volume_name):  # NOQA
                                                 volume_name)
         engine = get_volume_engine(volume)
         assert engine.hostId == host_id
-        volume = volume.detach(hostId="")
+        volume = volume.detach()
         volume = common.wait_for_volume_detached(client,
                                                  volume_name)
 
@@ -1826,7 +1826,7 @@ def test_volume_scheduling_failure(client, volume_name):  # NOQA
     endpoint = get_volume_endpoint(volume)
     volume_rw_test(endpoint)
 
-    volume = volume.detach(hostId="")
+    volume = volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     client.delete(volume)
@@ -1934,7 +1934,7 @@ def test_attach_without_frontend(client, volume_name):  # NOQA
     write_volume_random_data(volume)
     create_snapshot(client, volume_name)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=lht_hostId, disableFrontend=True)
@@ -1947,7 +1947,7 @@ def test_attach_without_frontend(client, volume_name):  # NOQA
 
     volume.snapshotRevert(name=snap1.name)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=lht_hostId, disableFrontend=False)
@@ -2144,7 +2144,7 @@ def test_expansion_basic(client, volume_name):  # NOQA
     create_snapshot(client, volume_name)
     check_volume_data(volume, snap3_data)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=lht_hostId, disableFrontend=False)
@@ -2152,7 +2152,7 @@ def test_expansion_basic(client, volume_name):  # NOQA
     volume = client.by_id_volume(volume_name)
     check_block_device_size(volume, int(EXPAND_SIZE))
     check_volume_data(volume, snap3_data)
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=lht_hostId, disableFrontend=True)
@@ -2161,7 +2161,7 @@ def test_expansion_basic(client, volume_name):  # NOQA
     assert volume.frontend == VOLUME_FRONTEND_BLOCKDEV
     check_volume_endpoint(volume)
     volume.snapshotRevert(name=snap2.name)
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=lht_hostId, disableFrontend=False)
     common.wait_for_volume_healthy(client, volume_name)
@@ -2174,13 +2174,13 @@ def test_expansion_basic(client, volume_name):  # NOQA
     snap4_data = write_volume_data(volume, snap4_data)
     create_snapshot(client, volume_name)
     check_volume_data(volume, snap4_data)
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=lht_hostId, disableFrontend=True)
     volume = common.wait_for_volume_healthy_no_frontend(client, volume_name)
     volume.snapshotRevert(name=snap1.name)
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=lht_hostId, disableFrontend=False)
     common.wait_for_volume_healthy(client, volume_name)
@@ -2210,7 +2210,7 @@ def test_expansion_with_size_round_up(client, core_api, volume_name):  # NOQA
     test_data = write_volume_random_data(volume)
 
     # Step 2: Offline expansion
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume_name)
     volume.expand(size="2000000000")
     wait_for_volume_expansion(client, volume_name)
@@ -2380,7 +2380,7 @@ def test_restore_inc_with_offline_expansion(set_random_backupstore, client, core
     check_volume_data(dr_volume2, data2)
 
     # allocated this active volume to a pod
-    dr_volume2.detach(hostId="")
+    dr_volume2.detach()
     dr_volume2 = common.wait_for_volume_detached(client, dr_volume2_name)
 
     create_pv_for_volume(client, core_api, dr_volume2, dr_volume2_name)
@@ -2424,9 +2424,9 @@ def test_restore_inc_with_offline_expansion(set_random_backupstore, client, core
     delete_and_wait_pv(core_api, dr_volume2_name)
 
     # cleanup
-    std_volume.detach(hostId="")
-    dr_volume0.detach(hostId="")
-    dr_volume1.detach(hostId="")
+    std_volume.detach()
+    dr_volume0.detach()
+    dr_volume1.detach()
     std_volume = common.wait_for_volume_detached(client, volume_name)
     dr_volume0 = common.wait_for_volume_detached(client, dr_volume0_name)
     dr_volume1 = common.wait_for_volume_detached(client, dr_volume1_name)
@@ -3261,7 +3261,7 @@ def test_allow_volume_creation_with_degraded_availability(client, volume_name): 
     data = write_volume_random_data(volume, {})
 
     # detach volume
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
     assert volume.conditions[VOLUME_CONDITION_SCHEDULED]['status'] == "True"
 
@@ -3277,7 +3277,7 @@ def test_allow_volume_creation_with_degraded_availability(client, volume_name): 
                                                "status", "True")
 
     # detach and re-attach the volume to verify the data
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=self_host)
@@ -3356,7 +3356,7 @@ def test_allow_volume_creation_with_degraded_availability_error(client, volume_n
     data = write_volume_random_data(volume, {})
 
     # detach and re-attach the volume to verify the data
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=self_host)
@@ -3992,7 +3992,7 @@ def test_expand_pvc_with_size_round_up(client, core_api, volume_name):  # NOQA
     volume.attach(hostId=self_hostId, disableFrontend=False)
     volume = wait_for_volume_healthy(client, volume_name)
     test_data = write_volume_random_data(volume)
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume_name)
 
     volume.expand(size="2000000000")
@@ -4011,7 +4011,7 @@ def test_expand_pvc_with_size_round_up(client, core_api, volume_name):  # NOQA
 
     volume = client.by_id_volume(volume_name)
     assert volume.size == "2000683008"
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume_name)
 
     self_hostId = get_self_host_id()
@@ -4019,7 +4019,7 @@ def test_expand_pvc_with_size_round_up(client, core_api, volume_name):  # NOQA
     volume = wait_for_volume_healthy(client, volume_name)
     check_volume_data(volume, test_data, False)
     test_data = write_volume_random_data(volume)
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume_name)
 
     volume.expand(size=str(2 * Gi))
@@ -4038,14 +4038,14 @@ def test_expand_pvc_with_size_round_up(client, core_api, volume_name):  # NOQA
 
     volume = client.by_id_volume(volume_name)
     assert volume.size == "2147483648"
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume_name)
 
     self_hostId = get_self_host_id()
     volume.attach(hostId=self_hostId, disableFrontend=False)
     volume = wait_for_volume_healthy(client, volume_name)
     check_volume_data(volume, test_data, False)
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume_name)
 
     client.delete(volume)
@@ -4606,7 +4606,7 @@ def snapshot_prune_test(client, volume_name, backing_image):  # NOQA
     create_snapshot(client, volume_name)
 
     # Prepare to do revert
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=lht_hostId, disableFrontend=True)
     volume = common.wait_for_volume_healthy_no_frontend(client, volume_name)
@@ -4618,7 +4618,7 @@ def snapshot_prune_test(client, volume_name, backing_image):  # NOQA
         volume.snapshotRevert(name=snap3_after.name)
     # Reverting to snap4 should succeed
     volume.snapshotRevert(name=snap4.name)
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=lht_hostId, disableFrontend=False)
     common.wait_for_volume_healthy(client, volume_name)
@@ -5169,7 +5169,7 @@ def test_filesystem_trim(client, fs_type):  # NOQA
         client, test_volume_name)
     volume.snapshotRevert(name=snap0_origin.name)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, test_volume_name)
     volume.attach(hostId=host_id)
     common.wait_for_volume_healthy(client, test_volume_name)
@@ -5342,7 +5342,7 @@ def test_filesystem_trim(client, fs_type):  # NOQA
         client, test_volume_name)
     volume.snapshotRevert(name=snap21_origin.name)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, test_volume_name)
     volume.attach(hostId=host_id)
     common.wait_for_volume_healthy(client, test_volume_name)

--- a/manager/integration/tests/test_cloning.py
+++ b/manager/integration/tests/test_cloning.py
@@ -175,7 +175,7 @@ def test_cloning_with_detached_source_volume(client, core_api, pvc, clone_pvc): 
                 - ReadWriteOnce
               resources:
                 requests:
-                  storage: 10Gi
+                  storage: 3Gi
             ```
         2. Wait for volume to be created and attach it to a node.
         3. Write some data to the mount path of the volume
@@ -195,16 +195,15 @@ def test_cloning_with_detached_source_volume(client, core_api, pvc, clone_pvc): 
                 - ReadWriteOnce
               resources:
                 requests:
-                  storage: 10Gi
+                  storage: 3Gi
             ```
-        6. Wait for `source-pvc` to be attached
-        7. Wait for the `CloneStatus.State` in `cloned-pvc` to be `completed`
-        8. Wait for `source-pvc` to be detached
-        9. Attach the cloned volume to a node
-        10. Verify the data in `cloned-pvc` is the same as in `source-pvc`.
-        11. In 2-min retry loop, verify the volume of the `clone-pvc`
+        6. Wait for the `CloneStatus.State` in `cloned-pvc` to be `completed`
+        7. Wait for `source-pvc` to be detached
+        8. Attach the cloned volume to a node
+        9. Verify the data in `cloned-pvc` is the same as in `source-pvc`.
+        10. In 2-min retry loop, verify the volume of the `clone-pvc`
             eventually becomes healthy.
-        12. Verify snapshot created in `source-pvc` volume because of the clone
+        11. Verify snapshot created in `source-pvc` volume because of the clone
     """
     # Step-1
     source_pvc_name = 'source-pvc' + generate_random_suffix()
@@ -225,7 +224,7 @@ def test_cloning_with_detached_source_volume(client, core_api, pvc, clone_pvc): 
     data = write_volume_random_data(source_volume)
 
     # Steps-4
-    source_volume.detach(hostId=lht_host_id)
+    source_volume.detach()
     wait_for_volume_detached(client, source_volume_name)
 
     # Step-5
@@ -241,30 +240,27 @@ def test_cloning_with_detached_source_volume(client, core_api, pvc, clone_pvc): 
     wait_for_pvc_phase(core_api, clone_pvc_name, "Bound")
 
     # Step-6
-    source_volume = wait_for_volume_attached(client, source_volume_name)
-
-    # Step-7
     clone_volume_name = get_volume_name(core_api, clone_pvc_name)
     wait_for_volume_clone_status(client, clone_volume_name, VOLUME_FIELD_STATE,
                                  VOLUME_FIELD_CLONE_COMPLETED)
     wait_for_volume_detached(client, clone_volume_name)
 
-    # Step-8
+    # Step-7
     wait_for_volume_detached(client, source_volume_name)
 
-    # Step-9
+    # Step-8
     clone_volume = client.by_id_volume(clone_volume_name)
     clone_volume.attach(hostId=lht_host_id)
     wait_for_volume_attached(client, clone_volume_name)
     clone_volume = wait_for_volume_endpoint(client, clone_volume_name)
 
-    # Step-10
+    # Step-9
     check_volume_data(clone_volume, data)
 
-    # Step-11
+    # Step-10
     wait_for_volume_healthy(client, clone_volume_name)
 
-    # Step-12
+    # Step-11
     source_volume = client.by_id_volume(source_volume_name)
     source_volume.attach(hostId=lht_host_id)
     source_volume = wait_for_volume_attached(client, source_volume_name)

--- a/manager/integration/tests/test_cluster_autoscaler.py
+++ b/manager/integration/tests/test_cluster_autoscaler.py
@@ -204,7 +204,7 @@ def test_cluster_autoscaler_all_nodes_with_volume_replicas(client, core_api, app
     volume = client.by_id_volume(volume.name)
     volume = volume.attach(hostId=new_nodes[0].id)
     volume = wait_for_volume_healthy(client, volume_name)
-    volume.detach(hostId="")
+    volume.detach()
 
     client = wait_cluster_autoscale_down(client, core_api, nodes, scale_size)
     create_and_wait_pod(core_api, pod_manifest)

--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -573,7 +573,7 @@ def test_xfs_pv_existing_volume(client, core_api, pod_manifest):  # NOQA
     cmd = ['mkfs.xfs', get_volume_endpoint(volume)]
     subprocess.check_call(cmd)
 
-    volume = volume.detach(hostId="")
+    volume = volume.detach()
 
     volume = wait_for_volume_detached(client, volume_name)
 

--- a/manager/integration/tests/test_engine_upgrade.py
+++ b/manager/integration/tests/test_engine_upgrade.py
@@ -184,7 +184,7 @@ def engine_offline_upgrade_test(client, core_api, volume_name, backing_image="")
 
     data = write_volume_random_data(volume)
 
-    volume = volume.detach(hostId="")
+    volume = volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.engineUpgrade(image=engine_upgrade_image)
@@ -212,7 +212,7 @@ def engine_offline_upgrade_test(client, core_api, volume_name, backing_image="")
 
     check_volume_data(volume, data)
 
-    volume = volume.detach(hostId="")
+    volume = volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.engineUpgrade(image=original_engine_image)
@@ -357,7 +357,7 @@ def engine_live_upgrade_test(client, core_api, volume_name, backing_image=""):  
 
     check_volume_data(volume, data)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
     assert len(volume.replicas) == REPLICA_COUNT
     assert volume.engineImage == engine_upgrade_image
@@ -408,7 +408,7 @@ def engine_live_upgrade_test(client, core_api, volume_name, backing_image=""):  
 
     check_volume_data(volume, data)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, volume_name)
     assert len(volume.replicas) == REPLICA_COUNT
 
@@ -582,7 +582,7 @@ def engine_live_upgrade_rollback_test(client, core_api, volume_name, backing_ima
         wait_for_volume_current_image(client, volume_name,
                                       wrong_engine_upgrade_image)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_current_image(client, volume_name,
                                            wrong_engine_upgrade_image)
     # all the images would be updated

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -263,15 +263,15 @@ def ha_salvage_test(client, core_api, # NOQA
     assert volume.replicas[1].failedAt != ""
 
     volume = wait_for_volume_detached(client, volume_name)
+    volume = common.wait_for_volume_faulted(client, volume_name)
 
     volume.salvage(names=[replica0_name, replica1_name])
+    volume = client.by_id_volume(volume_name)
 
-    volume = common.wait_for_volume_detached_unknown(client, volume_name)
     assert len(volume.replicas) == 2
     assert volume.replicas[0].failedAt == ""
     assert volume.replicas[1].failedAt == ""
 
-    volume = volume.attach(hostId=host_id)
     volume = wait_for_volume_healthy(client, volume_name)
 
     check_volume_data(volume, data)
@@ -304,15 +304,15 @@ def ha_salvage_test(client, core_api, # NOQA
     assert volume.replicas[1].failedAt != ""
 
     volume = common.wait_for_volume_detached(client, volume_name)
+    volume = common.wait_for_volume_faulted(client, volume_name)
 
     volume.salvage(names=[replica0_name, replica1_name])
+    volume = client.by_id_volume(volume_name)
 
-    volume = common.wait_for_volume_detached_unknown(client, volume_name)
     assert len(volume.replicas) == 2
     assert volume.replicas[0].failedAt == ""
     assert volume.replicas[1].failedAt == ""
 
-    volume.attach(hostId=host_id)
     volume = wait_for_volume_healthy(client, volume_name)
 
     check_volume_data(volume, data)
@@ -479,7 +479,7 @@ def ha_backup_deletion_recovery_test(client, volume_name, size, backing_image=""
 
     ha_rebuild_replica_test(client, res_name)
 
-    res_volume = res_volume.detach(hostId="")
+    res_volume = res_volume.detach()
     res_volume = wait_for_volume_detached(client, res_name)
 
     client.delete(res_volume)
@@ -2800,7 +2800,7 @@ def test_engine_image_not_fully_deployed_perform_volume_operations(client, core_
 
     assert snapMap[snap1.name].name == snap1.name
 
-    volume1.detach(hostId="")
+    volume1.detach()
     volume1 = wait_for_volume_detached(client, volume1.name)
 
     can_not_attach = False
@@ -2870,7 +2870,7 @@ def test_engine_image_not_fully_deployed_perform_engine_upgrade(client, core_api
         prepare_engine_not_fully_deployed_environment_with_volumes(client,
                                                                    core_api)
 
-    volume1.detach(hostId="")
+    volume1.detach()
     volume1 = wait_for_volume_detached(client, volume1.name)
 
     engine_upgrade_image, new_img = \

--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -2212,7 +2212,7 @@ def test_disk_migration(client):  # NOQA
     data = common.write_volume_random_data(volume)
     common.check_volume_data(volume, data)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = common.wait_for_volume_detached(client, vol_name)
 
     # Mount the volume disk to another path

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -742,7 +742,7 @@ def test_recurring_jobs_allow_detached_volume(set_random_backupstore, client, co
     # Give sometimes for data to flush to disk
     time.sleep(15)
 
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume.name)
 
     recurring_jobs = {

--- a/manager/integration/tests/test_scheduling.py
+++ b/manager/integration/tests/test_scheduling.py
@@ -164,7 +164,7 @@ def test_soft_anti_affinity_detach(client, volume_name):  # NOQA
     volume.replicaRemove(name=host_replica.name)
     wait_new_replica_ready(client, volume_name, replica_names)
     volume = wait_for_volume_healthy(client, volume_name)
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume_name)
     assert len(volume.replicas) == 3
 
@@ -268,7 +268,7 @@ def test_hard_anti_affinity_detach(client, volume_name):  # NOQA
     volume.replicaRemove(name=host_replica.name)
     volume = wait_for_volume_degraded(client, volume_name)
     wait_scheduling_failure(client, volume_name)
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume_name)
     assert len(volume.replicas) == 2
 
@@ -372,7 +372,7 @@ def test_hard_anti_affinity_offline_rebuild(client, volume_name):  # NOQA
     volume.replicaRemove(name=host_replica.name)
     volume = wait_for_volume_degraded(client, volume_name)
     wait_scheduling_failure(client, volume_name)
-    volume.detach(hostId="")
+    volume.detach()
     volume = wait_for_volume_detached(client, volume_name)
     set_node_scheduling(client, node, allowScheduling=True)
     volume.attach(hostId=host_id)

--- a/manager/integration/tests/test_settings.py
+++ b/manager/integration/tests/test_settings.py
@@ -163,7 +163,7 @@ def test_setting_toleration():
     data1 = write_volume_random_data(volume)
     check_volume_data(volume, data1)
 
-    volume.detach(hostId="")
+    volume.detach()
     wait_for_volume_detached(client, volume_name)
 
     setting = client.update(setting, value=setting_value_str)
@@ -178,7 +178,7 @@ def test_setting_toleration():
     check_volume_data(volume, data1)
     data2 = write_volume_random_data(volume)
     check_volume_data(volume, data2)
-    volume.detach(hostId="")
+    volume.detach()
     wait_for_volume_detached(client, volume_name)
 
     # cleanup
@@ -541,7 +541,7 @@ def test_setting_priority_class(core_api, apps_api, scheduling_api, priority_cla
     data1 = write_volume_random_data(volume)
     check_volume_data(volume, data1)
 
-    volume.detach(hostId="")
+    volume.detach()
     wait_for_volume_detached(client, volume_name)
 
     setting = client.update(setting, value=name)
@@ -557,7 +557,7 @@ def test_setting_priority_class(core_api, apps_api, scheduling_api, priority_cla
     check_volume_data(volume, data1)
     data2 = write_volume_random_data(volume)
     check_volume_data(volume, data2)
-    volume.detach(hostId="")
+    volume.detach()
     wait_for_volume_detached(client, volume_name)
 
     setting = client.by_id_setting(SETTING_PRIORITY_CLASS)
@@ -783,9 +783,9 @@ def test_setting_concurrent_rebuild_limit(client, core_api, volume_name):  # NOQ
     volume1_endpoint = get_volume_endpoint(volume1)
     volume2_endpoint = get_volume_endpoint(volume2)
     write_volume_dev_random_mb_data(volume1_endpoint,
-                                    1, 3500)
+                                    1, 3500, 5)
     write_volume_dev_random_mb_data(volume2_endpoint,
-                                    1, 3500)
+                                    1, 3500, 5)
 
     # Step 1-4, 1-5
     delete_replica_on_test_node(client, volume1_name)

--- a/manager/integration/tests/test_stress.py
+++ b/manager/integration/tests/test_stress.py
@@ -253,7 +253,7 @@ def revert_random_snapshot(client, core_api, volume_name, pod_manifest, snapshot
 
     volume = client.by_id_volume(volume_name)
 
-    volume.detach(hostId="")
+    volume.detach()
 
     wait_for_volume_detached(client, volume_name)
 
@@ -362,7 +362,7 @@ def restore_and_check_random_backup(client, core_api, volume_name, pod_name, sna
 
     res_volume = client.by_id_volume(res_volume_name)
 
-    res_volume.detach(hostId="")
+    res_volume.detach()
 
     wait_for_volume_detached(client, res_volume_name)
 

--- a/manager/integration/tests/test_upgrade.py
+++ b/manager/integration/tests/test_upgrade.py
@@ -304,7 +304,7 @@ def test_upgrade(longhorn_upgrade_type,
     for v in volumes:
         if v.name != vol_rebuild_name:
             volume = client.by_id_volume(v.name)
-            volume.detach(hostId="")
+            volume.detach()
             wait_for_volume_detached(client, v.name)
 
     engineimages = client.list_engine_image()


### PR DESCRIPTION
- [x] Test infa
    - [x] test_infra.py::test_offline_node
- [x] Test setting
    - [x] test_settings.py::test_setting_toleration
    - [x] test_settings.py::test_setting_toleration_extra
    - [x] test_settings.py::test_setting_priority_class
    - [x] test_settings.py::test_setting_concurrent_rebuild_limit
    - [x] test_settings.py::test_setting_concurrent_volume_backup_restore_limit
    - [x] test_settings.py::test_setting_concurrent_volume_backup_restore_limit_should_not_effect_dr_volumes
- [x] Test Scheduling 
    - [x] test_scheduling.py::test_replica_schedule_to_disk_with_most_usable_storage
- [x] Test recurring job
    - [x] test_recurring_job.py::test_recurring_job_snapshot_cleanup
- [x] Test orphan
    - [x] test_orphan.py::test_orphaned_dirs_with_wrong_naming_format
    - [x] test_orphan.py::test_orphaned_replica_dir_missing
    - [x] test_orphan.py::test_delete_orphans
    - [x] test_orphan.py::test_delete_orphan_after_orphaned_dir_is_deleted
    - [x] test_orphan.py::test_disk_evicted
    - [x] test_orphan.py::test_node_evicted
    - [x] test_orphan.py::test_orphaned_dirs_in_duplicated_disks
    - [x] test_orphan.py::test_orphan_with_same_orphaned_dir_name_in_another_disk
    - [x] test_orphan.py::test_orphan_creation_and_deletion_in_multiple_disks
    - [x] test_orphan.py::test_orphan_creation_and_background_deletion_in_multiple_disks
    - [x] test_orphan.py::test_orphan_auto_deletion
- [x] Test node
    - [x] test_node.py::test_replica_scheduler_large_volume_fit_small_disk
    - [x] test_node.py::test_node_controller_sync_storage_available
    - [x] test_node.py::test_node_default_disk_added_back_with_extra_disk_unmounted
    - [x] test_node.py::test_node_umount_disk
    - [x] test_node.py::test_replica_datapath_cleanup
    - [x] test_node.py::test_node_config_annotation_invalid
    - [x] test_node.py::test_replica_scheduler_rebuild_restore_is_too_big
    - [x] test_node.py::test_disk_migration
    - [x] test_node.py::test_disk_eviction_with_node_level_soft_anti_affinity_disabled
- [ ] Test HA
    - [x] test_ha.py::test_ha_salvage
    - [ ] test_ha.py::test_rebuild_replica_and_from_replica_on_the_same_node (`Looks like the rebuilding is fine but finished too fast and the test couldn't catch that event. TODO: the test can still catch it before`. Issue created for further investigation: [link](https://github.com/longhorn/longhorn/issues/5930))
    - [x] test_ha.py::test_auto_remount_with_subpath
    - [x] test_ha.py::test_replica_failure_during_attaching
- [x] Test engine upgrade
    - [x] test_engine_upgrade.py::test_engine_live_upgrade_with_intensive_data_writing
    - [x] test_engine_upgrade.py::test_engine_live_upgrade_while_replica_concurrent_rebuild
- [ ] Test cloning
    - [ ] test_cloning.py::test_cloning_with_detached_source_volume (failed due to https://github.com/longhorn/longhorn/issues/5835)
- [x] Test CSI
    - [x] test_csi.py::test_csi_block_volume_online_expansion
- [x] Test basic
    - [x] test_basic.py::test_space_usage_for_rebuilding_only_volume 
    - [x] test_basic.py::test_space_usage_for_rebuilding_only_volume_worst_scenario
- [x] Test backing images
    - [x]  test_backing_image.py::test_backup_with_backing_image
    - [x] test_backing_image.py::test_ha_backup_deletion_recovery
    - [x] test_backing_image.py::test_engine_offline_upgrade_with_backing_image
- [x] Live migration test cases
    - [x] test_migration.py::test_migration_confirm
    - [x] test_migration.py::test_migration_rollback
    - [x] test_migration.py::test_migration_with_unscheduled_replica
    - [x] test_migration.py::test_migration_with_failed_replica
    - [x] test_migration.py::test_migration_with_rebuilding_replica
    - [x] test_migration.py::test_migration_with_restore_volume

longhorn/longhorn#3715