### PR TITLE
ci: refine sles ami filter to avoid using ecs optimized image

### DIFF
--- a/test_framework/terraform/aws/sles/data.tf
+++ b/test_framework/terraform/aws/sles/data.tf
@@ -6,11 +6,7 @@ locals {
 data "aws_ami" "aws_ami_sles" {
   most_recent      = true
   owners           = [var.aws_ami_sles_account_number]
-
-  filter {
-    name   = "name"
-    values = ["suse-sles-${var.os_distro_version}-v*-hvm-ssd-${local.aws_ami_sles_arch}"]
-  }
+  name_regex       = "^suse-sles-${var.os_distro_version}-v\\d+-hvm-ssd-${local.aws_ami_sles_arch}"
 }
 
 


### PR DESCRIPTION
ci: refine sles ami filter to avoid using ecs optimized image

it's possible that unable to run any pods on the ecs optimized instance and then causes longhorn installation failed.

Signed-off-by: Yang Chiu <yang.chiu@suse.com>