### PR TITLE
Update test cases to exclude RWX from physical node down test cases

### DIFF
--- a/docs/content/manual/pre-release/node-not-ready/node-down/physical-node-down.md
+++ b/docs/content/manual/pre-release/node-not-ready/node-down/physical-node-down.md
@@ -2,4 +2,10 @@
 title: Physical node down
 ---
 1. One physical node down should result in the state of that node change to `Down`.
-2. When using with CSI driver, one node with controller (StatefulSet/Deployment) and pod down should result in Kubernetes migrate the pod to another node, and Longhorn volume should be able to be used on that node as well. Test scenarios for this are documented [here](../improve-node-failure-handling/).
+2. When using with CSI driver, one node with controller (StatefulSet/Deployment) and pod down should result in Kubernetes migrate the pod to another node, and Longhorn volume should be able to be used on that node as well. Test scenarios for this are documented [here](../../../node/improve-node-failure-handling/).
+
+   > **Note:**
+   > 
+   > In this case, RWX should be excluded.  
+   >
+   > Ref: https://github.com/longhorn/longhorn/issues/5900#issuecomment-1541360552


### PR DESCRIPTION
Ref: longhorn/longhorn#5900