### PR TITLE
Fix e2e tests

### DIFF
--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -51,7 +51,10 @@ def create_pv_storage(api, cli, pv, claim, backing_image, from_backup):
         numberOfReplicas=int(pv['spec']['csi']['volumeAttributes']
                              ['numberOfReplicas']),
         backingImage=backing_image, fromBackup=from_backup)
-    common.wait_for_volume_restoration_completed(cli, pv['metadata']['name'])
+    if from_backup:
+        common.wait_for_volume_restoration_completed(cli,
+                                                     pv['metadata']['name'])
+
     common.wait_for_volume_detached(cli, pv['metadata']['name'])
 
     api.create_persistent_volume(pv)

--- a/manager/integration/tests/test_csi_snapshotter.py
+++ b/manager/integration/tests/test_csi_snapshotter.py
@@ -745,7 +745,7 @@ def test_csi_snapshot_snap_create_csi_snapshot(apps_api, # NOQA
     Context:
 
     After deploy the CSI snapshot CRDs, Controller at
-    https://longhorn.io/docs/1.2.4/snapshots-and-backups/
+    https://longhorn.io/docs/1.4.2/snapshots-and-backups/
     csi-snapshot-support/enable-csi-snapshot-support/
 
     Create VolumeSnapshotClass with type=snap
@@ -764,7 +764,7 @@ def test_csi_snapshot_snap_create_csi_snapshot(apps_api, # NOQA
         - Volume is in detached state
             - Scale down the workload
             - Create VolumeSnapshot with class longhorn-snap
-            - Verify that the volumesnapshot object is not ready
+            - Verify that the volumesnapshot object is ready
         - Volume is in attached state
             - Scale up the workload
             - Verify the Longhorn snapshot generated
@@ -798,7 +798,7 @@ def test_csi_snapshot_snap_create_csi_snapshot(apps_api, # NOQA
     wait_for_volumesnapshot_ready(
                             volumesnapshot_name=csivolsnap["metadata"]["name"],
                             namespace='default',
-                            ready_to_use=False)
+                            ready_to_use=True)
 
     # Volume is in attached state
     deployment['spec']['replicas'] = 1
@@ -827,7 +827,7 @@ def test_csi_snapshot_snap_create_volume_from_snapshot(apps_api, # NOQA
     Context:
 
     After deploy the CSI snapshot CRDs, Controller at
-    https://longhorn.io/docs/1.2.4/snapshots-and-backups/
+    https://longhorn.io/docs/1.4.2/snapshots-and-backups/
     csi-snapshot-support/enable-csi-snapshot-support/
 
     Create VolumeSnapshotClass with type=snap
@@ -927,16 +927,6 @@ def test_csi_snapshot_snap_create_volume_from_snapshot(apps_api, # NOQA
     new_pvc1 = pvc
     new_pvc1['metadata']['name'] = pvc['metadata']['name'] + "new-pvc1"
     create_pvc(new_pvc1)
-    check_pvc_in_specific_status(core_api,
-                                 new_pvc1['metadata']['name'], "Pending")
-
-    deployment["spec"]["replicas"] = 1
-    apps_api.patch_namespaced_deployment(body=deployment,
-                                         namespace='default',
-                                         name=deployment_name)
-    common.wait_for_volume_status(client, vol.name,
-                                  common.VOLUME_FIELD_STATE,
-                                  common.VOLUME_STATE_ATTACHED)
 
     wait_for_pvc_phase(core_api, new_pvc1['metadata']['name'], "Bound")
     pv_name_2 = \
@@ -962,6 +952,13 @@ def test_csi_snapshot_snap_create_volume_from_snapshot(apps_api, # NOQA
     assert expected_md5sum == created_md5sum_2
 
     # Source volume is attached && Longhorn snapshot doesn’t exist
+    deployment["spec"]["replicas"] = 1
+    apps_api.patch_namespaced_deployment(body=deployment,
+                                         namespace='default',
+                                         name=deployment_name)
+    common.wait_for_volume_status(client, vol.name,
+                                  common.VOLUME_FIELD_STATE,
+                                  common.VOLUME_STATE_ATTACHED)
     vol = client.by_id_volume(vol.name)
     # create new snapshot to avoid the case the volume only has 1
     # snapshot so the snapshot can not deleted
@@ -1122,7 +1119,7 @@ def test_csi_snapshot_snap_delete_csi_snapshot_volume_detached(apps_api, # NOQA
 
     wait_volumesnapshot_deleted(csivolsnap["metadata"]["name"],
                                 "default",
-                                can_be_deleted=False)
+                                can_be_deleted=True)
 
 
 def test_csi_snapshot_with_invalid_param(

--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -499,6 +499,11 @@ def test_replica_scheduler_too_large_volume_fit_any_disks(client):  # NOQA
     7. Make sure every replica landed on different nodes's default disk.
     """
 
+    over_provisioning_setting = client.by_id_setting(
+        SETTING_STORAGE_OVER_PROVISIONING_PERCENTAGE)
+    client.update(over_provisioning_setting,
+                  value=DEFAULT_STORAGE_OVER_PROVISIONING_PERCENTAGE)
+
     nodes = client.list_node()
     lht_hostId = get_self_host_id()
     expect_node_disk = {}


### PR DESCRIPTION
- [x] Fix test test_backing_image.py::test_csi_mount_with_backing_image
        If `volume.spec.fromBackup` is empty, do not wait for volume restoration finished because the volume doesn't require restoration
- [x] test_backing_image.py::test_csi_io_with_backing_image
- [x] test_backing_image.py::test_csi_backup_with_backing_image
- [x] test_csi.py::test_csi_mount
- [x] test_csi.py::test_csi_io
- [x] test_csi.py::test_csi_backup
- [x] test_csi_snapshotter.py::test_csi_snapshot_snap_create_csi_snapshot
- [x] test_csi_snapshotter.py::test_csi_snapshot_snap_create_volume_from_snapshot
- [x] test_csi_snapshotter.py::test_csi_snapshot_snap_delete_csi_snapshot_volume_detached
- [x] test_node.py::test_replica_scheduler_too_large_volume_fit_any_disks
- [x] test_ha.py::test_inc_restoration_with_multiple_rebuild_and_expansion (Flaky test. Existed before https://github.com/longhorn/longhorn/issues/5460)
- [x] test_ha.py::test_auto_remount_with_subpath (No fix but retested 3 times and all passed. Will wait for next daily test run)
- [x] test_ha.py::test_engine_image_not_fully_deployed_perform_auto_upgrade_engine (No fix but retested 5 times and all passed. Will wait for next daily test run)
- [x] test_settings.py::test_setting_concurrent_volume_backup_restore_limit_should_not_effect_dr_volumes (No fix but passed manual test run. Will wait for next daily test run)
- [x] test_cloning.py::test_cloning_with_detached_source_volume (root cause is same as https://github.com/longhorn/longhorn/issues/5835)
- [x] test_ha.py::test_autosalvage_with_data_locality_enabled (No fix but retested 3 times and all passed. Will wait for next daily test run)

