### PR TITLE
test: add try/except for generate support bundle function to avoid internal error

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -5473,7 +5473,13 @@ def generate_support_bundle(case_name):  # NOQA
 
     url = client._url.replace('schemas', 'supportbundles')
     data = {'description': case_name, 'issueURL': case_name}
-    res = requests.post(url, json=data).json()
+    try:
+        res_raw = requests.post(url, json=data)
+        res_raw.raise_for_status()
+        res = res_raw.json()
+    except Exception as e:
+        warnings.warn(f"Error while generating support bundle: {e}")
+        return
     id = res['id']
     name = res['name']
 


### PR DESCRIPTION
test: add try/except for generate support bundle function to avoid internal error

In gke environment, the credential will keep expire and automatically renew during the test running. If the test tries to make requests when the credntial expired and without this try/except, it would cause internal error and fail the whole test process instead of just failing the current test case.

Signed-off-by: Yang Chiu <yang.chiu@suse.com>