### PR TITLE
test: fix flaky test case test_auto_remount_with_subpath

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -117,8 +117,8 @@ DEFAULT_STATEFULSET_INTERVAL = 1
 DEFAULT_STATEFULSET_TIMEOUT = 180
 
 DEFAULT_DEPLOYMENT_INTERVAL = 1
-DEFAULT_DEPLOYMENT_TIMEOUT = 120
-WAIT_FOR_POD_STABLE_MAX_RETRY = 30
+DEFAULT_DEPLOYMENT_TIMEOUT = 240
+WAIT_FOR_POD_STABLE_MAX_RETRY = 90
 
 
 DEFAULT_VOLUME_SIZE = 3  # In Gi
@@ -4533,7 +4533,7 @@ def wait_and_get_any_deployment_pod(core_api, deployment_name,
         for pod in pods.items:
             if pod.status.phase == is_phase:
                 if stable_pod is None or \
-                        stable_pod.metadata.name != pod.metadata.name:
+                        stable_pod.status.start_time != pod.status.start_time:
                     stable_pod = pod
                     wait_for_stable_retry = 0
                     break

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -2236,6 +2236,8 @@ def test_auto_remount_with_subpath(client, core_api, storage_class, sts_name, st
     storage_class['parameters']['numberOfReplicas'] = "1"
 
     statefulset['spec']['replicas'] = 1
+    statefulset['spec']['selector']['matchLabels']['name'] = sts_name
+    statefulset['spec']['template']['metadata']['labels']['name'] = sts_name
     statefulset['spec']['template']['spec']['containers'] = \
         [{
             'image': 'busybox:1.34.0',
@@ -2267,7 +2269,7 @@ def test_auto_remount_with_subpath(client, core_api, storage_class, sts_name, st
                             namespace='longhorn-system',
                             wait=True)
         wait_for_volume_healthy(client, vol_name)
-        wait_for_pod_remount(core_api, pod_name, chk_path=data_path)
+        common.wait_and_get_any_deployment_pod(core_api, sts_name)
         expect_md5sum = get_pod_data_md5sum(core_api, pod_name, data_path)
         assert expect_md5sum == md5sum
 
@@ -2281,13 +2283,12 @@ def test_auto_remount_with_subpath(client, core_api, storage_class, sts_name, st
                         namespace='longhorn-system',
                         wait=True)
     wait_for_volume_healthy(client, vol_name)
-    wait_for_pod_remount(core_api, pod_name, chk_path=data_path)
+    common.wait_and_get_any_deployment_pod(core_api, sts_name)
     expect_md5sum = get_pod_data_md5sum(core_api, pod_name, data_path)
     assert expect_md5sum == md5sum
 
     delete_and_wait_pod(core_api, pod_name, wait=True)
-    common.wait_for_pod_phase(core_api, pod_name, pod_phase="Running")
-    wait_for_pod_remount(core_api, pod_name, chk_path=data_path)
+    common.wait_and_get_any_deployment_pod(core_api, sts_name)
     expect_md5sum = get_pod_data_md5sum(core_api, pod_name, data_path)
     assert expect_md5sum == md5sum
 


### PR DESCRIPTION
test: fix flaky test case test_auto_remount_with_subpath

(1) The statefulset pod will be deleted/restarted automatically. If we stick to the to-be-deleted pod and try to read data, we will always get i/o error. Need to access the newly restarted pod.

(2) In the above scenario, the waiting time before the old pod being deleted and a new pod being created could be ~50 seconds long. So the 30s timout is still risky, change it to 90s.

For https://github.com/longhorn/longhorn/issues/6007

Signed-off-by: Yang Chiu <yang.chiu@suse.com>