### PR TITLE
Revert PR-1336: Fix test_backup_failed_disable_auto_cleanup failure o…

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -4539,7 +4539,7 @@ def test_backup_failed_disable_auto_cleanup(set_random_backupstore,  # NOQA
     9.    Wait and check if the backup was not deleted.
     10.   Cleanup
     """
-    backup_name = backup_failed_cleanup(client, core_api, volume_name, 1024*Mi,
+    backup_name = backup_failed_cleanup(client, core_api, volume_name, 256*Mi,
                                         failed_backup_ttl="0")
 
     # wait for 5 minutes to check if the failed backup exists


### PR DESCRIPTION
…n arm64

After executing the test case test_backup_failed_disable_auto_cleanup, we encountered an error specifically on the arm64 architecture. The longhorn-test pod crashed during the test.

Ref: https://github.com/longhorn/longhorn/issues/5461#issuecomment-1567633437