### PR TITLE
fix(restore): forcibly activate DR/restoring volume

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -2933,6 +2933,9 @@ def test_backup_lock_deletion_during_restoration(set_random_backupstore, client,
     10. Assert the data from the restored volume with md5sum.
     11. Assert the backup count in the backup store with 0.
     """
+    common.update_setting(client,
+                          common.SETTING_DEGRADED_AVAILABILITY, "false")
+
     backupstore_cleanup(client)
     std_volume_name = volume_name + "-std"
     restore_volume_name = volume_name + "-restore"
@@ -3001,6 +3004,9 @@ def test_backup_lock_deletion_during_backup(set_random_backupstore, client, core
     11. Restore the latest backup.
     12. Wait for the restoration to be completed. Assert md5sum from step 6.
     """
+    common.update_setting(client,
+                          common.SETTING_DEGRADED_AVAILABILITY, "false")
+
     backupstore_cleanup(client)
     std_volume_name = volume_name + "-std"
     restore_volume_name_1 = volume_name + "-restore-1"

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -806,6 +806,8 @@ def test_rebuild_with_restoration(set_random_backupstore, client, core_api, volu
     11. Check md5sum of the data in the restored volume.
     12. Do cleanup.
     """
+    update_setting(client, common.SETTING_DEGRADED_AVAILABILITY, "false")
+
     original_volume_name = volume_name + "-origin"
     data_path = "/data/test"
     original_pod_name, original_pv_name, original_pvc_name, original_md5sum = \
@@ -897,6 +899,8 @@ def test_rebuild_with_inc_restoration(set_random_backupstore, client, core_api, 
     12. Check md5sum of the data in the activated volume.
     13. Do cleanup.
     """
+    update_setting(client, common.SETTING_DEGRADED_AVAILABILITY, "false")
+
     std_volume_name = volume_name + "-std"
     data_path1 = "/data/test1"
     std_pod_name, std_pv_name, std_pvc_name, std_md5sum1 = \
@@ -1011,6 +1015,7 @@ def test_inc_restoration_with_multiple_rebuild_and_expansion(set_random_backupst
         the activated volume.
     22. Do cleanup.
     """
+    update_setting(client, common.SETTING_DEGRADED_AVAILABILITY, "false")
     create_storage_class(storage_class)
 
     original_size = 1 * Gi
@@ -1524,6 +1529,8 @@ def test_single_replica_restore_failure(set_random_backupstore, client, core_api
     assert auto_salvage_setting.name == SETTING_AUTO_SALVAGE
     assert auto_salvage_setting.value == "true"
 
+    update_setting(client, common.SETTING_DEGRADED_AVAILABILITY, "false")
+
     backupstore_cleanup(client)
 
     data_path = "/data/test"
@@ -1630,6 +1637,8 @@ def test_dr_volume_with_restore_command_error(set_random_backupstore, client, co
     13. Validate the volume content.
     14. Verify Writing data to the activated volume is fine.
     """
+    update_setting(client, common.SETTING_DEGRADED_AVAILABILITY, "false")
+
     std_volume_name = volume_name + "-std"
     data_path1 = "/data/test1"
     std_pod_name, std_pv_name, std_pvc_name, std_md5sum1 = \
@@ -3059,6 +3068,8 @@ def test_engine_image_not_fully_deployed_perform_dr_restoring_expanding_volume(c
     15. In a 2-min retry verify that Longhorn doesn't create new replica
        for vol-1 and doesn't reuse the failed replica on node-x
     """
+    update_setting(client, common.SETTING_DEGRADED_AVAILABILITY, "false")
+
     tainted_node_id = \
         prepare_engine_not_fully_deployed_environment(client, core_api)
 

--- a/manager/integration/tests/test_kubernetes.py
+++ b/manager/integration/tests/test_kubernetes.py
@@ -27,6 +27,9 @@ from common import delete_backup
 from common import create_and_check_volume, create_pvc, \
     wait_and_get_pv_for_pvc, wait_delete_pvc
 from common import volume_name # NOQA
+from common import update_setting
+from common import SETTING_DEGRADED_AVAILABILITY
+
 from backupstore import backupstore_cleanup
 
 from kubernetes import client as k8sclient
@@ -541,6 +544,7 @@ def test_backup_kubernetes_status(set_random_backupstore, client, core_api, pod)
         1. Make sure `lastPodRefAt` and `lastPVCRefAt` matched volume on step
         12
     """
+    update_setting(client, SETTING_DEGRADED_AVAILABILITY, "false")
 
     host_id = get_self_host_id()
     static_sc_name = "longhorn-static-test"

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -1982,6 +1982,9 @@ def test_recurring_job_restored_from_backup_target(set_random_backupstore, clien
     11. Check if recurring jobs have been created.
     12. Check if restoring volume has labels of recurring jobs and groups.
     """
+    common.update_setting(client,
+                          common.SETTING_DEGRADED_AVAILABILITY, "false")
+
     SCHEDULE_1WEEK = "0 0 * * 0"
     SCHEDULE_2MIN = "*/2 * * * *"
     snap1 = SNAPSHOT + "1"

--- a/manager/integration/tests/test_settings.py
+++ b/manager/integration/tests/test_settings.py
@@ -42,6 +42,7 @@ from common import (  # NOQA
     wait_for_rebuild_start, wait_for_rebuild_complete,
     wait_for_volume_degraded, write_volume_dev_random_mb_data,
     get_volume_endpoint, RETRY_EXEC_COUNTS, RETRY_SNAPSHOT_INTERVAL,
+    SETTING_DEGRADED_AVAILABILITY,
     delete_replica_on_test_node
 )
 
@@ -933,6 +934,8 @@ def setting_concurrent_volume_backup_restore_limit_concurrent_restoring_test(cli
     Then Number of restoring volumes per node should be expected based on
          if they are normal volumes or DR volumes.
     """
+    update_setting(client, SETTING_DEGRADED_AVAILABILITY, "false")
+
     concurrent_limit = 2
     update_setting(client, SETTING_CONCURRENT_VOLUME_BACKUP_RESTORE,
                    str(concurrent_limit))


### PR DESCRIPTION
Fix some test cases of the restoration that needs all replicas ready.

Regression test for the restoration:
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/4007/

Test Passed at my local environment:
- tests.test_ha.test_inc_restoration_with_multiple_rebuild_and_expansion[s3]
- tests.test_ha.test_inc_restoration_with_multiple_rebuild_and_expansion[nfs]


Ref: longhorn/longhorn#5460, longhorn/longhorn#6061