### PR TITLE
Change Rocky Linux AMI

### DIFF
--- a/test_framework/terraform/aws/rockylinux/data.tf
+++ b/test_framework/terraform/aws/rockylinux/data.tf
@@ -10,7 +10,7 @@ data "aws_ami" "aws_ami_rockylinux" {
 
   filter {
     name   = "name"
-    values = ["*RockyLinux-${var.os_distro_version}*"]
+    values = ["*Rocky-*-EC2-Base-${var.os_distro_version}*"]
   }
 
   filter {

--- a/test_framework/terraform/aws/rockylinux/variables.tf
+++ b/test_framework/terraform/aws/rockylinux/variables.tf
@@ -30,7 +30,7 @@ variable "arch" {
 
 variable "os_distro_version" {
   type        = string
-  default     = "8.6"
+  default     = "9.2"
 }
 
 variable "aws_ami_rockylinux_account_number" {


### PR DESCRIPTION
longhorn/longhorn#6088

This change makes use of the official Rocky AMI instead of the one we were using.

Drawbacks:
- Only the latest few versions of Rocky can be used (8.7, 8.9, 9.0, 9.1. 9.2 right now).

Benefits:
- There are ARM versions.
- The latest versions of Rocky are available.