### PR TITLE
fix: change the command for killing processes

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2194,8 +2194,7 @@ def crash_replica_processes(client, api, volname, replicas=None,
 
     for r in replicas:
         assert r.instanceManagerName != ""
-        kill_command = "kill `ps aux | grep '" + r['dataPath'] +\
-                       "' | grep -v grep | awk '{print $2}'`"
+        kill_command = "kill `pgrep -f " + r['dataPath'] + "`"
         exec_instance_manager(api, r.instanceManagerName, kill_command)
 
         if wait_to_fail is True:
@@ -4772,8 +4771,7 @@ def crash_engine_process_with_sigkill(client, core_api, volume_name):
 
     kill_command = [
             '/bin/sh', '-c',
-            "kill -9 `ps aux | grep -i \"controller " +
-            volume_name + "\" | grep -v grep | awk '{print $2}'`"]
+            "kill `pgrep -f \"controller " + volume_name + "\"`",]
 
     with timeout(seconds=STREAM_EXEC_TIMEOUT,
                  error_message='Timeout on executing stream read'):


### PR DESCRIPTION
It needs to change the command instead `awk` because it is not installed in default for the `registry.suse.com/bci/bci-base:15.4`.

Use `pgrep -f` to get the process id.

Regression test for `test_ha.py`:
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/4055

Local tests
```text
============================= test session starts ==============================
platform linux -- Python 3.9.16, pytest-5.3.1, py-1.11.0, pluggy-0.13.1 -- /usr/bin/python3.9
cachedir: .pytest_cache
rootdir: /integration, inifile: pytest.ini
plugins: order-1.0.1, repeat-0.9.1
collecting ... collected 11 items

test_recurring_job.py::test_recurring_jobs_when_volume_detached_unexpectedly[s3] PASSED [  9%]
test_recurring_job.py::test_recurring_jobs_when_volume_detached_unexpectedly[nfs] FAILED [ 18%]
test_scheduling.py::test_data_locality_basic PASSED                      [ 27%]
test_basic.py::test_running_volume_with_scheduling_failure PASSED        [ 36%]
test_basic.py::test_expansion_with_scheduling_failure PASSED             [ 45%]
test_basic.py::test_backup_failed_enable_auto_cleanup[s3] PASSED         [ 54%]
test_basic.py::test_backup_failed_enable_auto_cleanup[nfs] PASSED        [ 63%]
test_basic.py::test_backup_failed_disable_auto_cleanup[s3] PASSED        [ 72%]
test_basic.py::test_backup_failed_disable_auto_cleanup[nfs] PASSED       [ 81%]
test_cloning.py::test_cloning_interrupted PASSED                         [ 90%]
test_settings.py::test_setting_concurrent_rebuild_limit FAILED           [100%]

```

Ref: longhorn/longhorn#5460