### PR TITLE
ci: fix sle-micro transactional-update related error when setup k3s cluster.

### DIFF
--- a/test_framework/terraform/aws/sle-micro/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/sle-micro/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -18,5 +18,5 @@ elif [ -b "/dev/xvdh" ]; then
   sudo mount /dev/xvdh /var/lib/longhorn
 fi
 
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret}" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -
+curl -sfL https://get.k3s.io | sudo INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret}" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -
 sudo systemctl start k3s-agent

--- a/test_framework/terraform/aws/sle-micro/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/sle-micro/user-data-scripts/provision_k3s_server.sh.tpl
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret}" INSTALL_K3S_VERSION="${k3s_version}" sh -
+curl -sfL https://get.k3s.io | sudo INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret}" INSTALL_K3S_VERSION="${k3s_version}" sh -
 sudo systemctl start k3s


### PR DESCRIPTION
After merging https://github.com/k3s-io/k3s/pull/7635, we discovered that when setting up `k3s` on `SUSE Linux Enterprise Micro`, it encountered a permission-related error because it attempted to execute `transactional-update` without using `sudo`.

```bash
suse@ip-172-31-1-245:~> curl -fL https://get.k3s.io/ | sh -s - server --cluster-init --disable-apiserver --disable-controller-manager --disable-scheduler
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 32067  100 32067    0     0   108k      0 --:--:-- --:--:-- --:--:--  108k
[INFO]  Finding release for channel stable
[INFO]  Using v1.26.5+k3s1 as release
[INFO]  Downloading hash https://github.com/k3s-io/k3s/releases/download/v1.26.5+k3s1/sha256sum-amd64.txt
[INFO]  Downloading binary https://github.com/k3s-io/k3s/releases/download/v1.26.5+k3s1/k3s
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Finding available k3s-selinux versions
main: line 604: transactional-update: command not found
```