### PR TITLE
ci: wait for csi components created when installing longhorn

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -136,8 +136,11 @@ wait_longhorn_status_running(){
   local RETRY_COUNTS=10 # in minutes
   local RETRY_INTERVAL="1m"
 
+  # csi components are installed after longhorn components.
+  # it's possible that all longhorn components are running but csi components aren't created yet.
   RETRIES=0
-  while [[ -n `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $3}' | grep -v Running` ]]; do
+  while [[ -z `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $1}' | grep csi-` ]] || \
+    [[ -n `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $3}' | grep -v Running` ]]; do
     echo "Longhorn is still installing ... re-checking in 1m"
     sleep ${RETRY_INTERVAL}
     RETRIES=$((RETRIES+1))


### PR DESCRIPTION
ci: wait for csi components created when installing longhorn

For https://github.com/longhorn/longhorn/issues/6111

Signed-off-by: Yang Chiu <yang.chiu@suse.com>