### PR TITLE
Rework user data scripts to enable Rocky SELinux testing

### DIFF
--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-sudo dnf update -y
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
+
+if [[ ${selinux_mode} == "enforcing" ]] ; then
+  sudo setenforce  1
+  # k3s-selinux does not have the same fix applied as rke2-selinux.
+  echo '(allow iscsid_t self (capability (dac_override)))' > local_longhorn.cil && sudo semodule -vi local_longhorn.cil
+elif [[  ${selinux_mode} == "permissive" ]]; then
+  sudo setenforce  0
+fi
+
+# Do not arbitrarily run "dnf update", as this will effectively move us up to the latest minor release.
 sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools
 sudo systemctl -q enable iscsid
@@ -10,14 +20,6 @@ if [ -b "/dev/xvdh" ]; then
   sudo mkfs.ext4 -E nodiscard /dev/xvdh
   sudo mkdir /var/lib/longhorn
   sudo mount /dev/xvdh /var/lib/longhorn
-fi
-
-sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
-
-if [[ ${selinux_mode} == "enforcing" ]] ; then
-    sudo setenforce  1
-elif [[  ${selinux_mode} == "permissive" ]]; then
-    sudo setenforce  0
 fi
 
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret}" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-set -e
+sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
-sudo dnf update -y                                                              
+if [[ ${selinux_mode} == "enforcing" ]] ; then
+  sudo setenforce  1
+elif [[  ${selinux_mode} == "permissive" ]]; then
+  sudo setenforce  0
+  # k3s-selinux does not have the same fix applied as rke2-selinux.
+  echo '(allow iscsid_t self (capability (dac_override)))' > local_longhorn.cil && sudo semodule -vi local_longhorn.cil
+fi
+
+# Do not arbitrarily run "dnf update", as this will effectively move us up to the latest minor release.                                                         
 sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq
 sudo systemctl -q enable iscsid                                                 
 sudo systemctl start iscsid
-
-sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
-
-if [[ ${selinux_mode} == "enforcing" ]] ; then
-    sudo setenforce  1
-elif [[  ${selinux_mode} == "permissive" ]]; then
-    sudo setenforce  0
-fi
 
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
   echo 'k3s server did not install correctly'

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke.sh.tpl
@@ -5,9 +5,9 @@ DOCKER_VERSION=20.10
 sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    sudo setenforce  1
+  sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    sudo setenforce  0
+  sudo setenforce  0
 fi
 
 sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -3,12 +3,12 @@
 sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    sudo setenforce  1
+  sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    sudo setenforce  0
+  sudo setenforce  0
 fi
 
-sudo dnf update -y
+# Do not arbitrarily run "dnf update", as this will effectively move us up to the latest minor release.
 sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq nmap-ncat
 sudo systemctl -q enable iscsid
@@ -27,11 +27,11 @@ while ! nc -z $${RKE_SERVER_IP} $${RKE_SERVER_PORT}; do
   sleep 10 #
 done
 
-curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="agent" INSTALL_RKE2_VERSION="${rke2_version}" sh -
+curl -sfL https://get.rke2.io | sudo INSTALL_RKE2_TYPE="agent" INSTALL_RKE2_VERSION="${rke2_version}" sh -
 
 sudo mkdir -p /etc/rancher/rke2
 
-sudo cat << EOF > /etc/rancher/rke2/config.yaml
+sudo tee -a /etc/rancher/rke2/config.yaml >/dev/null <<EOF
 server: ${rke2_server_url}
 token: ${rke2_cluster_secret}
 EOF

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_server.sh.tpl
@@ -3,32 +3,34 @@
 sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
-    sudo setenforce  1
+  sudo setenforce  1
 elif [[  ${selinux_mode} == "permissive" ]]; then
-    sudo setenforce  0
+  sudo setenforce  0
 fi
 
-sudo dnf update -y
+# Do not arbitrarily run "dnf update", as this will effectively move us up to the latest minor release.
 sudo dnf group install -y "Development Tools"
 sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 
-curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="server" INSTALL_RKE2_VERSION="${rke2_version}" sh -
+curl -sfL https://get.rke2.io | sudo INSTALL_RKE2_TYPE="server" INSTALL_RKE2_VERSION="${rke2_version}" sh -
 
 sudo mkdir -p /etc/rancher/rke2
 
-sudo cat << EOF > /etc/rancher/rke2/config.yaml
+sudo tee -a /etc/rancher/rke2/config.yaml >/dev/null <<EOF
 write-kubeconfig-mode: "0644"
 token: ${rke2_cluster_secret}
 tls-san:
   - ${rke2_server_public_ip}
+node-taint:
+  - "node-role.kubernetes.io/control-plane=true:NoSchedule"
 EOF
 
 sudo systemctl enable rke2-server.service
 sudo systemctl start rke2-server.service
 
-until (KUBECONFIG=/etc/rancher/rke2/rke2.yaml sudo /var/lib/rancher/rke2/bin/kubectl get pods -A | grep 'Running'); do
+until (KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get pods -A | grep 'Running'); do
   echo 'Waiting for rke2 startup'
   sleep 5
 done


### PR DESCRIPTION
longhorn/longhorn#6088

Tagging this slightly unrelated PR to the above issue since its required to get Rocky testing fully working the way we want/need.

Needed:

1. A rule to allow isciadm the dac_override capability in k3s (only RKE2 provides it by default now).
2. A taint preventing Longhorn from scheduling on the control plane in an RKE2 deployment. Without it, we always fail in [this fixture](https://github.com/longhorn/longhorn-tests/blob/754a03f48d9d75c2655ba64de4cce2221a4fc2b5/manager/integration/tests/common.py#L3319-L3339)

Also rearranged and cleaned up a couple of things for consistency among scripts.