### PR TITLE
Fix awk notfound

### DIFF
--- a/manager/integration/Dockerfile
+++ b/manager/integration/Dockerfile
@@ -4,7 +4,7 @@ ARG KUBECTL_VERSION=v1.17.0
 ARG ARCH=amd64
 
 RUN zypper ref -f
-RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python39-devel && \
+RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python39-devel gawk && \
     rm -rf /var/cache/zypp/*
 
 RUN curl -sO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/${ARCH}/kubectl && \


### PR DESCRIPTION
The `registry.suse.com/bci/python:3.9` image does not have `awk` installed by default. We need to install it.

![Screenshot_20230615_111734](https://github.com/longhorn/longhorn-tests/assets/104337648/7cd42d69-e637-43bb-a86f-5ba13562839d)
