### PR TITLE
Explicitly enable SELinux if it is desired for k3s Rocky testing

### DIFF
--- a/test_framework/terraform/aws/rockylinux/data.tf
+++ b/test_framework/terraform/aws/rockylinux/data.tf
@@ -35,6 +35,7 @@ data "template_file" "provision_k3s_server" {
     k3s_server_public_ip = aws_eip.lh_aws_eip_controlplane[0].public_ip
     k3s_version =  var.k8s_distro_version
     selinux_mode = var.selinux_mode
+    enable_selinux = var.selinux_mode == "permissive" ? "false" : "true"
   }
 }
 
@@ -46,6 +47,7 @@ data "template_file" "provision_k3s_agent" {
     k3s_cluster_secret = random_password.cluster_secret.result
     k3s_version =  var.k8s_distro_version
     selinux_mode = var.selinux_mode
+    enable_selinux = var.selinux_mode == "permissive" ? "false" : "true"
   }
 }
 

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -22,7 +22,7 @@ if [ -b "/dev/xvdh" ]; then
   sudo mount /dev/xvdh /var/lib/longhorn
 fi
 
-until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret}" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
+until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret} --selinux=${enable_selinux}" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
   echo 'k3s agent did not install correctly'
   sleep 2
 done

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
@@ -4,10 +4,10 @@ sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
   sudo setenforce  1
-elif [[  ${selinux_mode} == "permissive" ]]; then
-  sudo setenforce  0
   # k3s-selinux does not have the same fix applied as rke2-selinux.
   echo '(allow iscsid_t self (capability (dac_override)))' > local_longhorn.cil && sudo semodule -vi local_longhorn.cil
+elif [[  ${selinux_mode} == "permissive" ]]; then
+  sudo setenforce  0
 fi
 
 # Do not arbitrarily run "dnf update", as this will effectively move us up to the latest minor release.                                                         
@@ -16,7 +16,7 @@ sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq
 sudo systemctl -q enable iscsid                                                 
 sudo systemctl start iscsid
 
-until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
+until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint node-role.kubernetes.io/master=true:NoExecute --node-taint node-role.kubernetes.io/master=true:NoSchedule --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret} --selinux=${enable_selinux}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
   echo 'k3s server did not install correctly'
   sleep 2
 done


### PR DESCRIPTION
longhorn/longhorn#6108

The behavior of Longhorn with SELinux "enabled" on RKE2 is different than on k3s. This is because the current k3s deployment scripts don't go far enough to actually enable it.
