### PR TITLE
ci: apply selinux workaround to fix iscsiadm permission issue

### DIFF
--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -3,7 +3,7 @@ def summary
 def BUILD_TRIGGER_BY = "\n${currentBuild.getBuildCauses()[0].shortDescription}"
 
 // define optional parameters
-def SELINUX_MODE = params.SELINUX_MODE ? "SELINUX_MODE=${params.SELINUX_MODE}" : ""
+def SELINUX_MODE = params.SELINUX_MODE ? params.SELINUX_MODE : ""
 
 def CREDS_ID = JOB_BASE_NAME == "longhorn-tests-regression" ? "AWS_CREDS_RANCHER_QA" : "AWS_CREDS"
 def REGISTRATION_CODE_ID = params.ARCH == "amd64" ? "REGISTRATION_CODE" : "REGISTRATION_CODE_ARM64"
@@ -127,7 +127,7 @@ node {
                                        --env TF_VAR_lh_aws_instance_type_worker=${WORKER_INSTANCE_TYPE}\
                                        --env TF_VAR_lh_aws_secret_key=${AWS_SECRET_KEY} \
                                        --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} \
-                                       --env TF_VAR_tf_selinux_mode=${SELINUX_MODE} \
+                                       --env TF_VAR_selinux_mode=${SELINUX_MODE} \
                                        --env TF_VAR_registration_code=${REGISTRATION_CODE} \
                                        --env TF_VAR_azure_client_id=${AZURE_CLIENT_ID} \
                                        --env TF_VAR_azure_crt_path=/src/longhorn-tests/azure_client.pfx \

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -56,6 +56,11 @@ create_admin_service_account(){
 }
 
 
+apply_selinux_workaround(){
+  kubectl apply -f "https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/prerequisite/longhorn-iscsi-selinux-workaround.yaml"
+}
+
+
 install_iscsi(){
   kubectl apply -f "https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/prerequisite/longhorn-iscsi-installation.yaml"
 }
@@ -417,6 +422,10 @@ run_longhorn_tests(){
 
 main(){
   set_kubeconfig_envvar ${TF_VAR_arch} ${TF_VAR_tf_workspace}
+
+  if [[ ${DISTRO} == "rhel" ]] || [[ ${DISTRO} == "rockylinux" ]] || [[ ${DISTRO} == "oracle" ]]; then
+    apply_selinux_workaround
+  fi
 
   # set debugging mode off to avoid leaking aws secrets to the logs.
   # DON'T REMOVE!

--- a/test_framework/terraform/aws/oracle/k3s_instances.tf
+++ b/test_framework/terraform/aws/oracle/k3s_instances.tf
@@ -117,6 +117,7 @@ resource "null_resource" "rsync_kubeconfig_file" {
   provisioner "remote-exec" {
     inline = [
       "sudo cloud-init status --wait",
+      "sudo sestatus",
       "if [ \"`sudo cloud-init status | grep error`\" ]; then sudo cat /var/log/cloud-init-output.log; fi",
       "until([ -f /etc/rancher/k3s/k3s.yaml ] && [ `sudo /usr/local/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for k3s cluster nodes to be running\"; sleep 2; done"
     ]

--- a/test_framework/terraform/aws/oracle/rke2_instances.tf
+++ b/test_framework/terraform/aws/oracle/rke2_instances.tf
@@ -114,7 +114,7 @@ resource "null_resource" "rsync_kubeconfig_file_rke2" {
   ]
 
   provisioner "remote-exec" {
-    inline = ["until([ -f /etc/rancher/rke2/rke2.yaml ] && [ `sudo KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for rke2 cluster nodes to be running\"; sleep 2; done"]
+    inline = ["until([ -f /etc/rancher/rke2/rke2.yaml ] && [ `sudo KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for rke2 cluster nodes to be running\"; sleep 2; done; sudo sestatus;"]
 
 
     connection {

--- a/test_framework/terraform/aws/oracle/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/oracle/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+sudo systemctl stop firewalld
+sudo systemctl disable firewalld
+
 sudo yum update -y
 sudo yum group install -y "Development Tools"
 sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools nc
@@ -15,7 +18,7 @@ fi
 RKE_SERVER_IP=`echo ${rke2_server_url} | sed 's#https://##' | awk -F ":" '{print $1}'`
 RKE_SERVER_PORT=`echo ${rke2_server_url} | sed 's#https://##' | awk -F ":" '{print $2}'`
 
-while ! nc -z $${RKE_SERVER_IP} $${RKE_SERVER_PORT}; do   
+while ! nc -z $${RKE_SERVER_IP} $${RKE_SERVER_PORT}; do
   sleep 10 #
 done
 
@@ -23,7 +26,7 @@ curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="agent" INSTALL_RKE2_VERSION="
 
 mkdir -p /etc/rancher/rke2
 
-cat << EOF > /etc/rancher/rke2/config.yaml 
+cat << EOF > /etc/rancher/rke2/config.yaml
 server: ${rke2_server_url}
 token: ${rke2_cluster_secret}
 EOF

--- a/test_framework/terraform/aws/oracle/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/oracle/user-data-scripts/provision_rke2_server.sh.tpl
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+sudo systemctl stop firewalld
+sudo systemctl disable firewalld
+
 sudo yum update -y
 sudo yum group install -y "Development Tools"
-sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq nc
+sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq nc rsync
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 
@@ -15,6 +18,8 @@ write-kubeconfig-mode: "0644"
 token: ${rke2_cluster_secret}
 tls-san:
   - ${rke2_server_public_ip}
+node-taint:
+  - "node-role.kubernetes.io/control-plane=true:NoSchedule"
 EOF
 
 systemctl enable rke2-server.service

--- a/test_framework/terraform/aws/rhel/k3s_instances.tf
+++ b/test_framework/terraform/aws/rhel/k3s_instances.tf
@@ -116,6 +116,7 @@ resource "null_resource" "rsync_kubeconfig_file" {
   provisioner "remote-exec" {
     inline = [
       "sudo cloud-init status --wait",
+      "sudo sestatus",
       "if [ \"`sudo cloud-init status | grep error`\" ]; then sudo cat /var/log/cloud-init-output.log; fi",
       "until([ -f /etc/rancher/k3s/k3s.yaml ] && [ `sudo /usr/local/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for k3s cluster nodes to be running\"; sleep 2; done"
     ]

--- a/test_framework/terraform/aws/rhel/rke2_instances.tf
+++ b/test_framework/terraform/aws/rhel/rke2_instances.tf
@@ -114,7 +114,7 @@ resource "null_resource" "rsync_kubeconfig_file_rke2" {
   ]
 
   provisioner "remote-exec" {
-    inline = ["until([ -f /etc/rancher/rke2/rke2.yaml ] && [ `sudo KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for rke2 cluster nodes to be running\"; sleep 2; done"]
+    inline = ["until([ -f /etc/rancher/rke2/rke2.yaml ] && [ `sudo KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for rke2 cluster nodes to be running\"; sleep 2; done; sudo sestatus;"]
 
 
     connection {

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke2_server.sh.tpl
@@ -24,6 +24,8 @@ write-kubeconfig-mode: "0644"
 token: ${rke2_cluster_secret}
 tls-san:
   - ${rke2_server_public_ip}
+node-taint:
+  - "node-role.kubernetes.io/control-plane=true:NoSchedule"
 EOF
 
 sudo systemctl enable rke2-server.service

--- a/test_framework/terraform/aws/rockylinux/k3s_instances.tf
+++ b/test_framework/terraform/aws/rockylinux/k3s_instances.tf
@@ -116,6 +116,7 @@ resource "null_resource" "rsync_kubeconfig_file" {
   provisioner "remote-exec" {
     inline = [
       "sudo cloud-init status --wait",
+      "sudo sestatus",
       "if [ \"`sudo cloud-init status | grep error`\" ]; then sudo cat /var/log/cloud-init-output.log; fi",
       "until([ -f /etc/rancher/k3s/k3s.yaml ] && [ `sudo /usr/local/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for k3s cluster nodes to be running\"; sleep 2; done"
     ]

--- a/test_framework/terraform/aws/rockylinux/rke2_instances.tf
+++ b/test_framework/terraform/aws/rockylinux/rke2_instances.tf
@@ -114,7 +114,7 @@ resource "null_resource" "rsync_kubeconfig_file_rke2" {
   ]
 
   provisioner "remote-exec" {
-    inline = ["until([ -f /etc/rancher/rke2/rke2.yaml ] && [ `sudo KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for rke2 cluster nodes to be running\"; sleep 2; done"]
+    inline = ["until([ -f /etc/rancher/rke2/rke2.yaml ] && [ `sudo KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get node -o jsonpath='{.items[*].status.conditions}'  | jq '.[] | select(.type  == \"Ready\").status' | grep -ci true` -eq $((${var.lh_aws_instance_count_controlplane} + ${var.lh_aws_instance_count_worker})) ]); do echo \"waiting for rke2 cluster nodes to be running\"; sleep 2; done; sudo sestatus;"]
 
 
     connection {

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -4,8 +4,6 @@ sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
   sudo setenforce  1
-  # k3s-selinux does not have the same fix applied as rke2-selinux.
-  echo '(allow iscsid_t self (capability (dac_override)))' > local_longhorn.cil && sudo semodule -vi local_longhorn.cil
 elif [[  ${selinux_mode} == "permissive" ]]; then
   sudo setenforce  0
 fi

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_server.sh.tpl
@@ -4,8 +4,6 @@ sudo sed -i 's#^SELINUX=.*$#SELINUX='"${selinux_mode}"'#' /etc/selinux/config
 
 if [[ ${selinux_mode} == "enforcing" ]] ; then
   sudo setenforce  1
-  # k3s-selinux does not have the same fix applied as rke2-selinux.
-  echo '(allow iscsid_t self (capability (dac_override)))' > local_longhorn.cil && sudo semodule -vi local_longhorn.cil
 elif [[  ${selinux_mode} == "permissive" ]]; then
   sudo setenforce  0
 fi

--- a/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_rke2_server.sh.tpl
@@ -14,6 +14,8 @@ write-kubeconfig-mode: "0644"
 token: ${rke2_cluster_secret}
 tls-san:
   - ${rke2_server_public_ip}
+node-taint:
+  - "node-role.kubernetes.io/control-plane=true:NoSchedule"
 EOF
 
 systemctl enable rke2-server.service


### PR DESCRIPTION
ci: apply selinux workaround to fix iscsiadm permission issue

1. apply selinux workaround to oracle/rocky/rhel to fix iscsiadm permission issue
2. correct selinux_mode parameter passing to make permissive/enforcing mode can be set correctly in the selinux enabled instances
3. fix missing NoSchedule taint in rke2 setup script for some distros to make tests can be run on these rke2 clusters
4. stop firewalld in oracle rke2 setup script otherwise the cluster setup will fail

For https://github.com/longhorn/longhorn/issues/6168

Signed-off-by: Yang Chiu <yang.chiu@suse.com>