### PR TITLE
ci: fix unable to cp junit report in selinux enforcing mode

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -104,6 +104,8 @@ spec:
       mountPath: /tmp/test-report
   - name: longhorn-test-report
     image: busybox:1.34.0
+    securityContext:
+      privileged: true
     command: [ "tail", "-f", "/dev/null" ]
     volumeMounts:
     - name: test-report


### PR DESCRIPTION
ci: fix unable to cp junit report in selinux enforcing mode

For https://github.com/longhorn/longhorn/issues/6187

Signed-off-by: Yang Chiu <yang.chiu@suse.com>