### PR TITLE
ci: explicitly enable selinux if it's desired for k3s rhel/oracle testing

### DIFF
--- a/test_framework/terraform/aws/oracle/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/oracle/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -15,7 +15,7 @@ if [ -b "/dev/xvdh" ]; then
   mount /dev/xvdh /var/lib/longhorn
 fi
 
-until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret}" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
+until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret} --selinux=true" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
   echo 'k3s agent did not install correctly'
   sleep 2
 done

--- a/test_framework/terraform/aws/oracle/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/oracle/user-data-scripts/provision_k3s_server.sh.tpl
@@ -11,7 +11,7 @@ sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools jq rsync
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 
-until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
+until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret} --selinux=true" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
   echo 'k3s server did not install correctly'
   sleep 2
 done

--- a/test_framework/terraform/aws/rhel/data.tf
+++ b/test_framework/terraform/aws/rhel/data.tf
@@ -30,6 +30,7 @@ data "template_file" "provision_k3s_server" {
     k3s_server_public_ip = aws_eip.lh_aws_eip_controlplane[0].public_ip
     k3s_version =  var.k8s_distro_version
     selinux_mode = var.selinux_mode
+    enable_selinux = var.selinux_mode == "permissive" ? "false" : "true"
   }
 }
 
@@ -41,7 +42,7 @@ data "template_file" "provision_k3s_agent" {
     k3s_cluster_secret = random_password.cluster_secret.result
     k3s_version =  var.k8s_distro_version
     selinux_mode = var.selinux_mode
-
+    enable_selinux = var.selinux_mode == "permissive" ? "false" : "true"
   }
 }
 

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -21,7 +21,7 @@ if [ -b "/dev/xvdh" ]; then
   sudo mount /dev/xvdh /var/lib/longhorn
 fi
 
-until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret}" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
+until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret} --selinux=${enable_selinux}" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
   echo 'k3s agent did not install correctly'
   sleep 2
 done

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_server.sh.tpl
@@ -17,7 +17,7 @@ sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
 
-until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
+until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret} --selinux=${enable_selinux}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
   echo 'k3s server did not install correctly'
   sleep 2
 done


### PR DESCRIPTION
ci: explicitly enable selinux if it's desired for k3s rhel/oracle testing

Sync https://github.com/longhorn/longhorn-tests/pull/1426 to rhel and oracle

Signed-off-by: Yang Chiu <yang.chiu@suse.com>