### PR TITLE
ci: implement helm install/upgrade regression test pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,6 @@ steps:
     build_args:
     - ARCH=amd64
     custom_dns: 1.1.1.1
-    context: manager/integration
     dockerfile: manager/integration/Dockerfile
     password:
       from_secret: docker_password
@@ -52,7 +51,6 @@ steps:
     build_args:
     - ARCH=amd64
     custom_dns: 1.1.1.1
-    context: manager/integration
     dockerfile: manager/integration/Dockerfile
     password:
       from_secret: docker_password
@@ -105,7 +103,6 @@ steps:
     build_args:
     - ARCH=arm64
     custom_dns: 1.1.1.1
-    context: manager/integration
     dockerfile: manager/integration/Dockerfile
     password:
       from_secret: docker_password
@@ -123,7 +120,6 @@ steps:
     build_args:
     - ARCH=arm64
     custom_dns: 1.1.1.1
-    context: manager/integration
     dockerfile: manager/integration/Dockerfile
     password:
       from_secret: docker_password

--- a/manager/integration/Dockerfile
+++ b/manager/integration/Dockerfile
@@ -1,22 +1,32 @@
 FROM registry.suse.com/bci/python:3.9
 
 ARG KUBECTL_VERSION=v1.17.0
+ARG YQ_VERSION=v4.24.2
 ARG ARCH=amd64
 
 RUN zypper ref -f
-RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python39-devel gawk java-11-openjdk && \
+RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python39-devel gawk java-11-openjdk tar awk gzip wget && \
     rm -rf /var/cache/zypp/*
 
 RUN curl -sO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/${ARCH}/kubectl && \
     mv kubectl /usr/local/bin/kubectl && \
-    chmod +x /usr/local/bin/kubectl
+    chmod +x /usr/local/bin/kubectl && \
+    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod 700 get_helm.sh && \
+    ./get_helm.sh && \
+    wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}" && \
+    mv yq_linux_${ARCH} /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq
 
 RUN curl -L https://github.com/jonelo/jacksum/releases/download/v3.4.0/jacksum-3.4.0.jar --output /jacksum.jar
 
-ADD tests/requirements.txt .
+ADD manager/integration/tests/requirements.txt .
 RUN pip install -r requirements.txt
 
-ADD . /integration
+ADD manager/integration /integration
 WORKDIR /integration/tests
+
+ADD pipelines/utilities ./pipelines/utilities
+ADD pipelines/helm/scripts/upgrade-longhorn.sh ./pipelines/helm/scripts/upgrade-longhorn.sh
 
 ENTRYPOINT ["./run.sh"]

--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -35,7 +35,7 @@ rules:
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: ["batch"]
-  resources: ["cronjobs"]
+  resources: ["cronjobs", "jobs"]
   verbs: ["*"]
 - apiGroups: ["longhorn.io"]
   resources: ["supportbundles", "supportbundles/status"]

--- a/manager/integration/tests/conftest.py
+++ b/manager/integration/tests/conftest.py
@@ -16,6 +16,7 @@ INCLUDE_STRESS_OPT = "--include-stress-test"
 INCLUDE_UPGRADE_OPT = "--include-upgrade-test"
 INCLUDE_CA_OPT = "--include-cluster-autoscaler-test"
 
+LH_INSTALL_METHOD = "--lh-install-method"
 UPGRADE_LH_REPO_URL = "--upgrade-lh-repo-url"
 UPGRADE_LH_REPO_BRANCH = "--upgrade-lh-repo-branch"
 UPGRADE_LH_MANAGER_IMAGE = "--upgrade-lh-manager-image"
@@ -49,6 +50,12 @@ def pytest_addoption(parser):
     parser.addoption(INCLUDE_CA_OPT, action="store_true",
                      default=False,
                      help="include cluster autoscaler tests (default: False)")
+
+    parser.addoption(LH_INSTALL_METHOD, action="store",
+                     default="manifest",
+                     help='''set longhorn install method, this will be used
+                     to determine how to upgrade longhorn for test_upgrade
+                     (default: manifest''')
 
     longhorn_repo_url =\
         "https://github.com/longhorn/longhorn.git"

--- a/pipelines/helm/Dockerfile.setup
+++ b/pipelines/helm/Dockerfile.setup
@@ -1,0 +1,34 @@
+From alpine:latest
+
+ARG KUBECTL_VERSION=v1.20.2
+
+ARG RKE_VERSION=v1.3.4
+
+ARG TERRAFORM_VERSION=1.3.5
+
+ARG YQ_VERSION=v4.24.2
+
+ENV WORKSPACE /src/longhorn-tests
+
+WORKDIR $WORKSPACE
+
+RUN wget -q https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl && \
+    mv kubectl /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    wget -q https://github.com/rancher/rke/releases/download/$RKE_VERSION/rke_linux-amd64 && \
+    mv rke_linux-amd64 /usr/bin/rke && \
+    chmod +x /usr/bin/rke && \
+    wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    mv terraform /usr/bin/terraform && \
+    chmod +x /usr/bin/terraform && \
+    wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" && \
+    mv yq_linux_amd64 /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && \
+    apk add openssl openssh-client ca-certificates git rsync bash curl jq python3 py3-pip && \
+    ssh-keygen -t rsa -b 4096 -N "" -f ~/.ssh/id_rsa && \
+    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod 700 get_helm.sh && \
+    ./get_helm.sh
+
+COPY [".", "$WORKSPACE"]

--- a/pipelines/helm/Jenkinsfile
+++ b/pipelines/helm/Jenkinsfile
@@ -1,0 +1,212 @@
+def imageName = "${JOB_BASE_NAME}-${env.BUILD_NUMBER}"
+def summary
+def WORKSPACE = "/src/longhorn-tests"
+def BUILD_TRIGGER_BY = "\n${currentBuild.getBuildCauses()[0].shortDescription}"
+
+// define optional parameters
+def SELINUX_MODE = params.SELINUX_MODE ? params.SELINUX_MODE : ""
+
+def CREDS_ID = JOB_BASE_NAME == "longhorn-tests-regression" ? "AWS_CREDS_RANCHER_QA" : "AWS_CREDS"
+def REGISTRATION_CODE_ID = params.ARCH == "amd64" ? "REGISTRATION_CODE" : "REGISTRATION_CODE_ARM64"
+
+// parameters for air gap installation
+def AIR_GAP_INSTALLATION = params.AIR_GAP_INSTALLATION ? params.AIR_GAP_INSTALLATION : false
+def LONGHORN_INSTALL_VERSION = params.LONGHORN_INSTALL_VERSION ? params.LONGHORN_INSTALL_VERSION : "master"
+def LONGHORN_TRANSIENT_VERSION = params.LONGHORN_TRANSIENT_VERSION ? params.LONGHORN_TRANSIENT_VERSION : ""
+def CIS_HARDENING = params.CIS_HARDENING ? params.CIS_HARDENING : false
+def REGISTRY_URL
+def REGISTRY_USERNAME
+def REGISTRY_PASSWORD
+
+// parameter for hdd test
+def USE_HDD = params.USE_HDD ? params.USE_HDD : false
+
+node {
+
+    withCredentials([
+        usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
+        string(credentialsId: 'DO_CREDS', variable: 'DO_TOKEN'),
+        string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
+    ]) {
+
+        if (params.SEND_SLACK_NOTIFICATION) {
+            notifyBuild('STARTED', BUILD_TRIGGER_BY, params.NOTIFY_SLACK_CHANNEL)
+        }
+
+        checkout scm
+
+        try {
+
+            if (params.AIR_GAP_INSTALLATION) {
+
+                stage('airgap build') {
+                    sh "airgap/scripts/build.sh"
+                    sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
+                                           --env TF_VAR_longhorn_version=${LONGHORN_INSTALL_VERSION} \
+                                           --env TF_VAR_do_token=${DO_TOKEN} \
+                                           --env TF_VAR_aws_access_key=${AWS_ACCESS_KEY} \
+                                           --env TF_VAR_aws_secret_key=${AWS_SECRET_KEY} \
+                                           airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}
+                    """
+                }
+
+                stage ('airgap setup') {
+                    sh "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} ./airgap/scripts/terraform-setup.sh"
+                    REGISTRY_URL = sh (
+                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_url",
+                        returnStdout: true
+                    )
+                    println REGISTRY_URL
+                    REGISTRY_USERNAME = sh (
+                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_username",
+                        returnStdout: true
+                    )
+                    REGISTRY_PASSWORD = sh (
+                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_password",
+                        returnStdout: true
+                    )
+                }
+
+            }
+
+            stage('build') {
+
+                echo "Using credentials: $CREDS_ID"
+                echo "Using registration code: $REGISTRATION_CODE_ID"
+
+                sh "pipelines/helm/scripts/build.sh"
+                sh """ docker run -itd --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
+                                       --env AIR_GAP_INSTALLATION=${AIR_GAP_INSTALLATION} \
+                                       --env REGISTRY_URL=${REGISTRY_URL} \
+                                       --env REGISTRY_USERNAME=${REGISTRY_USERNAME} \
+                                       --env REGISTRY_PASSWORD=${REGISTRY_PASSWORD} \
+                                       --env LONGHORN_INSTALL_VERSION=${LONGHORN_INSTALL_VERSION} \
+                                       --env CUSTOM_LONGHORN_ENGINE_IMAGE=${CUSTOM_LONGHORN_ENGINE_IMAGE} \
+                                       --env CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE=${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE} \
+                                       --env CUSTOM_LONGHORN_MANAGER_IMAGE=${CUSTOM_LONGHORN_MANAGER_IMAGE} \
+                                       --env CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE=${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE} \
+                                       --env CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE=${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE} \
+                                       --env LONGHORN_TESTS_CUSTOM_IMAGE=${LONGHORN_TESTS_CUSTOM_IMAGE} \
+                                       --env DISTRO=${DISTRO} \
+                                       --env LONGHORN_REPO_URI=${LONGHORN_REPO_URI} \
+                                       --env LONGHORN_REPO_BRANCH=${LONGHORN_REPO_BRANCH} \
+                                       --env LONGHORN_STABLE_VERSION=${LONGHORN_STABLE_VERSION} \
+                                       --env LONGHORN_TRANSIENT_VERSION=${LONGHORN_TRANSIENT_VERSION} \
+                                       --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} \
+                                       --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} \
+                                       --env PYTEST_CUSTOM_OPTIONS="${PYTEST_CUSTOM_OPTIONS}" \
+                                       --env BACKUP_STORE_TYPE="${BACKUP_STORE_TYPE}" \
+                                       --env TF_VAR_use_hdd=${USE_HDD} \
+                                       --env TF_VAR_arch=${ARCH} \
+                                       --env TF_VAR_k8s_distro_name=${K8S_DISTRO_NAME} \
+                                       --env TF_VAR_k8s_distro_version=${K8S_DISTRO_VERSION} \
+                                       --env TF_VAR_aws_availability_zone=${AWS_AVAILABILITY_ZONE} \
+                                       --env TF_VAR_aws_region=${AWS_REGION} \
+                                       --env TF_VAR_os_distro_version=${DISTRO_VERSION} \
+                                       --env TF_VAR_do_token=${env.TF_VAR_do_token} \
+                                       --env TF_VAR_lh_aws_access_key=${AWS_ACCESS_KEY} \
+                                       --env TF_VAR_lh_aws_instance_name_controlplane="${JOB_BASE_NAME}-ctrl" \
+                                       --env TF_VAR_lh_aws_instance_name_worker="${JOB_BASE_NAME}-wrk" \
+                                       --env TF_VAR_lh_aws_instance_type_controlplane=${CONTROLPLANE_INSTANCE_TYPE} \
+                                       --env TF_VAR_lh_aws_instance_type_worker=${WORKER_INSTANCE_TYPE}\
+                                       --env TF_VAR_lh_aws_secret_key=${AWS_SECRET_KEY} \
+                                       --env TF_VAR_selinux_mode=${SELINUX_MODE} \
+                                       --env TF_VAR_registration_code=${REGISTRATION_CODE} \
+                                       --env TF_VAR_cis_hardening=${CIS_HARDENING} \
+                                       ${imageName}
+                """
+            }
+
+            timeout(60) {
+                stage ('terraform') {
+                    sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/helm/scripts/terraform-setup.sh"
+                }
+			}
+
+            stage ('longhorn setup & tests') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/helm/scripts/longhorn-setup.sh"
+            }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/helm/scripts/download-support-bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
+
+            stage ('report generation') {
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-junit-report.xml ."
+
+                if(params.LONGHORN_UPGRADE_TEST && params.LONGHORN_TRANSIENT_VERSION) {
+                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-upgrade-from-stable-junit-report.xml ."
+                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-upgrade-from-transient-junit-report.xml ."
+                    summary = junit 'longhorn-test-upgrade-from-stable-junit-report.xml, longhorn-test-upgrade-from-transient-junit-report.xml, longhorn-test-junit-report.xml'
+                }
+                else if(params.LONGHORN_UPGRADE_TEST) {
+                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-upgrade-from-stable-junit-report.xml ."
+                    summary = junit 'longhorn-test-upgrade-from-stable-junit-report.xml, longhorn-test-junit-report.xml'
+                }
+                else {
+                    summary = junit 'longhorn-test-junit-report.xml'
+                }
+            }
+
+        } catch (e) {
+            currentBuild.result = "FAILED"
+            throw e
+        } finally {
+            stage ('releasing resources') {
+                if (sh (script: "docker container inspect airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} > /dev/null 2>&1", returnStatus: true) == 0) {
+                    sh "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} ./airgap/scripts/cleanup.sh"
+                    sh "docker stop airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}"
+                    sh "docker rm -v airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}"
+                    sh "docker rmi airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}"
+                }
+
+                if (sh (script: "docker container inspect ${JOB_BASE_NAME}-${BUILD_NUMBER} > /dev/null 2>&1", returnStatus: true) == 0) {
+                    sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/helm/scripts/cleanup.sh"
+                    sh "docker stop ${JOB_BASE_NAME}-${BUILD_NUMBER}"
+                    sh "docker rm -v ${JOB_BASE_NAME}-${BUILD_NUMBER}"
+                    sh "docker rmi ${imageName}"
+                }
+
+                if (summary) {
+                    summary_msg = "\nTest Summary - Failures: ${summary.failCount}, Skipped: ${summary.skipCount}, Passed: ${summary.passCount}  -- Job completed in ${currentBuild.durationString.replace(' and counting', '')}"
+                } else {
+                    summary_msg = "\n Test Failed: No Junit report"
+                }
+
+                if(params.SEND_SLACK_NOTIFICATION){
+                    notifyBuild(currentBuild.result, summary_msg, params.NOTIFY_SLACK_CHANNEL)
+                }
+            }
+        }
+    }
+
+}
+
+
+def notifyBuild(String buildStatus = 'STARTED', String summary_msg, String slack_channel) {
+  // build status of null means successful
+  buildStatus =  buildStatus ?: 'SUCCESSFUL'
+
+  // Default values
+  def colorName = 'RED'
+  def colorCode = '#FF0000'
+  def subject = "${buildStatus}: Job '${env.JOB_BASE_NAME} [${env.BUILD_NUMBER}]'"
+  def summary = "${subject} (${env.BUILD_URL})" + summary_msg
+
+  // Override default values based on build status
+  if (buildStatus == 'STARTED') {
+    color = 'YELLOW'
+    colorCode = '#FFFF00'
+  } else if (buildStatus == 'SUCCESSFUL') {
+    color = 'GREEN'
+    colorCode = '#00FF00'
+  } else {
+    color = 'RED'
+    colorCode = '#FF0000'
+  }
+
+  // Send notifications
+  slackSend (color: colorCode, message: summary, channel: slack_channel,  tokenCredentialId: 'longhorn-tests-slack-token')
+}

--- a/pipelines/helm/scripts/build.sh
+++ b/pipelines/helm/scripts/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --no-cache -f ./pipelines/helm/Dockerfile.setup -t "${JOB_BASE_NAME}-${BUILD_NUMBER}" .

--- a/pipelines/helm/scripts/cleanup.sh
+++ b/pipelines/helm/scripts/cleanup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# terminate any terraform processes
+TERRAFORM_PIDS=( `ps aux | grep -i terraform | grep -v grep | awk '{printf("%s ",$1)}'` )
+if [[ -n ${TERRAFORM_PIDS[@]} ]] ; then
+	for PID in "${TERRAFORM_PIDS[@]}"; do
+		kill "${TERRAFORM_PIDS}"
+	done
+fi
+
+# wait 30 seconds for graceful terraform termination
+sleep 30
+
+terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -auto-approve -no-color

--- a/pipelines/helm/scripts/download-support-bundle.sh
+++ b/pipelines/helm/scripts/download-support-bundle.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+source pipelines/utilities/kubeconfig.sh
+
+SUPPORT_BUNDLE_FILE_NAME=${1:-"lh-support-bundle.zip"}
+SUPPORT_BUNDLE_ISSUE_URL=${2:-""}
+SUPPORT_BUNDLE_ISSUE_DESC=${3:-"Auto-generated support buundle"}
+
+
+set_kubeconfig
+
+LH_FRONTEND_ADDR=`kubectl get svc -n longhorn-system longhorn-frontend -o json | jq -r '.spec.clusterIP + ":" + (.spec.ports[0].port|tostring)'`
+
+JSON_PAYLOAD="{\"issueURL\": \"${SUPPORT_BUNDLE_ISSUE_DESC}\", \"description\": \"${SUPPORT_BUNDLE_ISSUE_DESC}\"}"
+
+CURL_CMD="curl -XPOST http://${LH_FRONTEND_ADDR}/v1/supportbundles -H 'Accept: application/json' -H 'Accept-Encoding: gzip, deflate' -d '"${JSON_PAYLOAD}"'"
+
+SUPPORT_BUNDLE_URL=`kubectl exec -n longhorn-system svc/longhorn-frontend -- bash -c "${CURL_CMD}"  | jq -r '.links.self + "/" + .name'`
+
+SUPPORT_BUNDLE_READY=false
+while [[ ${SUPPORT_BUNDLE_READY} == false ]]; do
+    PERCENT=`kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -H 'Accept: application/json' ${SUPPORT_BUNDLE_URL} | jq -r '.progressPercentage' || true`
+    echo ${PERCENT}
+    
+    if [[ ${PERCENT} == 100 ]]; then SUPPORT_BUNDLE_READY=true; fi
+done
+
+kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -H 'Accept-Encoding: gzip, deflate' ${SUPPORT_BUNDLE_URL}/download > ${SUPPORT_BUNDLE_FILE_NAME}

--- a/pipelines/helm/scripts/longhorn-setup.sh
+++ b/pipelines/helm/scripts/longhorn-setup.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -x
+
+source pipelines/utilities/kubeconfig.sh
+source pipelines/utilities/install_csi_snapshotter.sh
+source pipelines/utilities/create_aws_secret.sh
+source pipelines/utilities/install_backupstores.sh
+source pipelines/utilities/create_longhorn_namespace.sh
+source pipelines/utilities/longhorn_helm_chart.sh
+source pipelines/utilities/run_longhorn_test.sh
+
+# create and clean tmpdir
+TMPDIR="/tmp/longhorn"
+mkdir -p ${TMPDIR}
+rm -rf "${TMPDIR}/"
+
+export LONGHORN_NAMESPACE="longhorn-system"
+export LONGHORN_REPO_DIR="${TMPDIR}/longhorn"
+export LONGHORN_INSTALL_METHOD="helm"
+
+
+apply_selinux_workaround(){
+  kubectl apply -f "https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/prerequisite/longhorn-iscsi-selinux-workaround.yaml"
+}
+
+
+create_registry_secret(){
+  kubectl -n ${LONGHORN_NAMESPACE} create secret docker-registry docker-registry-secret --docker-server=${REGISTRY_URL} --docker-username=${REGISTRY_USERNAME} --docker-password=${REGISTRY_PASSWORD}
+}
+
+
+main(){
+  set_kubeconfig
+
+  if [[ ${DISTRO} == "rhel" ]] || [[ ${DISTRO} == "rockylinux" ]] || [[ ${DISTRO} == "oracle" ]]; then
+    apply_selinux_workaround
+  fi
+
+  # set debugging mode off to avoid leaking aws secrets to the logs.
+  # DON'T REMOVE!
+  set +x
+  create_aws_secret
+  set -x
+
+  create_longhorn_namespace
+  install_backupstores
+  install_csi_snapshotter
+
+  if [[ "${LONGHORN_UPGRADE_TEST}" == true ]]; then
+    get_longhorn_chart "${LONGHORN_STABLE_VERSION}"
+    install_longhorn
+    LONGHORN_UPGRADE_TYPE="from_stable"
+    LONGHORN_UPGRADE_TEST_POD_NAME="longhorn-test-upgrade-from-stable"
+    if [[ -n "${LONGHORN_TRANSIENT_VERSION}" ]]; then
+      UPGRADE_LH_REPO_URL="${LONGHORN_REPO_URI}"
+      UPGRADE_LH_REPO_BRANCH="${LONGHORN_TRANSIENT_VERSION}"
+      UPGRADE_LH_ENGINE_IMAGE="longhornio/longhorn-engine:${LONGHORN_TRANSIENT_VERSION}"
+      run_longhorn_upgrade_test
+      LONGHORN_UPGRADE_TYPE="from_transient"
+      LONGHORN_UPGRADE_TEST_POD_NAME="longhorn-test-upgrade-from-transient"
+    fi
+    UPGRADE_LH_REPO_URL="${LONGHORN_REPO_URI}"
+    UPGRADE_LH_REPO_BRANCH="${LONGHORN_REPO_BRANCH}"
+    UPGRADE_LH_MANAGER_IMAGE="${CUSTOM_LONGHORN_MANAGER_IMAGE}"
+    UPGRADE_LH_ENGINE_IMAGE="${CUSTOM_LONGHORN_ENGINE_IMAGE}"
+    UPGRADE_LH_INSTANCE_MANAGER_IMAGE="${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE}"
+    UPGRADE_LH_SHARE_MANAGER_IMAGE="${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE}"
+    UPGRADE_LH_BACKING_IMAGE_MANAGER_IMAGE="${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE}"
+    run_longhorn_upgrade_test
+    run_longhorn_test
+  else
+    get_longhorn_chart
+    install_longhorn
+    run_longhorn_test
+  fi
+
+}
+
+main

--- a/pipelines/helm/scripts/terraform-setup.sh
+++ b/pipelines/helm/scripts/terraform-setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -x
+
+if [[ ${TF_VAR_arch} == "amd64" ]]; then
+  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} init
+  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} apply -auto-approve -no-color
+  if [[ ${TF_VAR_k8s_distro_name} == "rke" ]]; then
+    terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} apply -auto-approve -no-color -refresh-only
+    terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} output -raw rke_config > test_framework/rke.yml
+    sleep 30
+    rke up --config test_framework/rke.yml
+  fi
+else
+  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} init
+  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} apply -auto-approve -no-color
+fi
+
+exit $?

--- a/pipelines/helm/scripts/upgrade-longhorn.sh
+++ b/pipelines/helm/scripts/upgrade-longhorn.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -x
+
+export LONGHORN_REPO_URI="${1}"
+export LONGHORN_REPO_BRANCH="${2}"
+export CUSTOM_LONGHORN_MANAGER_IMAGE="${3}"
+export CUSTOM_LONGHORN_ENGINE_IMAGE="${4}"
+export CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE="${5}"
+export CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE="${6}"
+export CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE="${7}"
+
+source pipelines/utilities/kubeconfig.sh
+source pipelines/utilities/install_csi_snapshotter.sh
+source pipelines/utilities/create_aws_secret.sh
+source pipelines/utilities/install_backupstores.sh
+source pipelines/utilities/create_longhorn_namespace.sh
+source pipelines/utilities/longhorn_helm_chart.sh
+
+# create and clean tmpdir
+TMPDIR="/tmp/longhorn"
+mkdir -p ${TMPDIR}
+rm -rf "${TMPDIR}/"
+
+export LONGHORN_NAMESPACE="longhorn-system"
+export LONGHORN_REPO_DIR="${TMPDIR}/longhorn"
+
+get_longhorn_chart
+customize_longhorn_chart
+install_longhorn

--- a/pipelines/templates/aws_cred_secrets.yml
+++ b/pipelines/templates/aws_cred_secrets.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-cred-secret
+type: Opaque
+data:
+  AWS_ACCESS_KEY_ID: "set aws-access-key-id base64 encoded"
+  AWS_SECRET_ACCESS_KEY: "set aws-secret-key base64 encoded"
+  AWS_DEFAULT_REGION: "set aws-default-region base64 encoded"

--- a/pipelines/utilities/create_aws_secret.sh
+++ b/pipelines/utilities/create_aws_secret.sh
@@ -1,0 +1,12 @@
+create_aws_secret(){
+  AWS_ACCESS_KEY_ID_BASE64=`echo -n "${TF_VAR_lh_aws_access_key}" | base64`
+  AWS_SECRET_ACCESS_KEY_BASE64=`echo -n "${TF_VAR_lh_aws_secret_key}" | base64`
+  AWS_DEFAULT_REGION_BASE64=`echo -n "${TF_VAR_aws_region}" | base64`
+
+  yq e -i '.data.AWS_ACCESS_KEY_ID |= "'${AWS_ACCESS_KEY_ID_BASE64}'"' "pipelines/templates/aws_cred_secrets.yml"
+  yq e -i '.data.AWS_SECRET_ACCESS_KEY |= "'${AWS_SECRET_ACCESS_KEY_BASE64}'"' "pipelines/templates/aws_cred_secrets.yml"
+  yq e -i '.data.AWS_DEFAULT_REGION |= "'${AWS_DEFAULT_REGION_BASE64}'"' "pipelines/templates/aws_cred_secrets.yml"
+
+  kubectl apply -f "pipelines/templates/aws_cred_secrets.yml"
+  kubectl apply -f "pipelines/templates/aws_cred_secrets.yml" -n kube-system
+}

--- a/pipelines/utilities/create_longhorn_namespace.sh
+++ b/pipelines/utilities/create_longhorn_namespace.sh
@@ -1,0 +1,11 @@
+create_longhorn_namespace(){
+  kubectl create ns "${LONGHORN_NAMESPACE}"
+  if [[ "${TF_VAR_cis_hardening}" == true ]]; then
+    kubectl label ns default "${LONGHORN_NAMESPACE}" pod-security.kubernetes.io/enforce=privileged
+    kubectl label ns default "${LONGHORN_NAMESPACE}" pod-security.kubernetes.io/enforce-version=latest
+    kubectl label ns default "${LONGHORN_NAMESPACE}" pod-security.kubernetes.io/audit=privileged
+    kubectl label ns default "${LONGHORN_NAMESPACE}" pod-security.kubernetes.io/audit-version=latest
+    kubectl label ns default "${LONGHORN_NAMESPACE}" pod-security.kubernetes.io/warn=privileged
+    kubectl label ns default "${LONGHORN_NAMESPACE}" pod-security.kubernetes.io/warn-version=latest
+  fi
+}

--- a/pipelines/utilities/install_backupstores.sh
+++ b/pipelines/utilities/install_backupstores.sh
@@ -1,0 +1,6 @@
+install_backupstores(){
+  MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/minio-backupstore.yaml"
+  NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml"
+  kubectl create -f ${MINIO_BACKUPSTORE_URL} \
+                 -f ${NFS_BACKUPSTORE_URL}
+}

--- a/pipelines/utilities/install_csi_snapshotter.sh
+++ b/pipelines/utilities/install_csi_snapshotter.sh
@@ -1,0 +1,13 @@
+install_csi_snapshotter(){
+  CSI_SNAPSHOTTER_REPO_URL="https://github.com/kubernetes-csi/external-snapshotter.git"
+  CSI_SNAPSHOTTER_REPO_BRANCH="v6.2.1"
+  CSI_SNAPSHOTTER_REPO_DIR="${TMPDIR}/k8s-csi-external-snapshotter"
+
+  git clone --single-branch \
+            --branch "${CSI_SNAPSHOTTER_REPO_BRANCH}" \
+            "${CSI_SNAPSHOTTER_REPO_URL}" \
+            "${CSI_SNAPSHOTTER_REPO_DIR}"
+
+  kubectl apply -f "${CSI_SNAPSHOTTER_REPO_DIR}/client/config/crd" \
+                -f "${CSI_SNAPSHOTTER_REPO_DIR}/deploy/kubernetes/snapshot-controller"
+}

--- a/pipelines/utilities/kubeconfig.sh
+++ b/pipelines/utilities/kubeconfig.sh
@@ -1,0 +1,15 @@
+set_kubeconfig(){
+  # rke2, rke and k3s all support amd64
+  # but only k3s supports arm64
+  if [[ "${TF_VAR_arch}" == "amd64" ]] ; then
+    if [[ "${TF_VAR_k8s_distro_name}" == "rke" ]]; then
+        export KUBECONFIG="test_framework/kube_config_rke.yml"
+    elif [[ "${TF_VAR_k8s_distro_name}" == "rke2" ]]; then
+        export KUBECONFIG="test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO}/rke2.yaml"
+    else
+        export KUBECONFIG="test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO}/k3s.yaml"
+    fi
+  elif [[ "${TF_VAR_arch}" == "arm64"  ]]; then
+    export KUBECONFIG="test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO}/k3s.yaml"
+  fi
+}

--- a/pipelines/utilities/longhorn_helm_chart.sh
+++ b/pipelines/utilities/longhorn_helm_chart.sh
@@ -1,0 +1,62 @@
+source pipelines/utilities/longhorn_status.sh
+
+
+get_longhorn_chart(){
+  CHART_VERSION="${1:-$LONGHORN_REPO_BRANCH}"
+  git clone --single-branch \
+            --branch "${CHART_VERSION}" \
+            "${LONGHORN_REPO_URI}" \
+            "${LONGHORN_REPO_DIR}"
+}
+
+
+customize_longhorn_chart_registry(){
+  # specify private registry secret in chart/values.yaml
+  yq -i '.privateRegistry.createSecret=true' "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  yq -i ".privateRegistry.registryUrl=\"${REGISTRY_URL}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  yq -i ".privateRegistry.registryUser=\"${REGISTRY_USERNAME}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  yq -i ".privateRegistry.registryPasswd=\"${REGISTRY_PASSWORD}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  yq -i '.privateRegistry.registrySecret="docker-registry-secret"' "${LONGHORN_REPO_DIR}/chart/values.yaml"
+}
+
+
+customize_longhorn_chart(){
+  # customize longhorn components repository and tag (version) in chart/values.yaml
+  IFS=':'
+  if [[ -n "${CUSTOM_LONGHORN_MANAGER_IMAGE}" ]]; then
+    read -ra ARR <<< "${CUSTOM_LONGHORN_MANAGER_IMAGE}"
+    yq -i ".image.longhorn.manager.repository=\"${ARR[0]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+    yq -i ".image.longhorn.manager.tag=\"${ARR[1]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  fi
+  if [[ -n "${CUSTOM_LONGHORN_ENGINE_IMAGE}" ]]; then
+    read -ra ARR <<< "${CUSTOM_LONGHORN_ENGINE_IMAGE}"
+    yq -i ".image.longhorn.engine.repository=\"${ARR[0]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+    yq -i ".image.longhorn.engine.tag=\"${ARR[1]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  fi
+  if [[ -n "${CUSTOM_LONGHORN_UI_IMAGE}" ]]; then
+    read -ra ARR <<< "${CUSTOM_LONGHORN_UI_IMAGE}"
+    yq -i ".image.longhorn.ui.repository=\"${ARR[0]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+    yq -i ".image.longhorn.ui.tag=\"${ARR[1]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  fi
+  if [[ -n "${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE}" ]]; then
+    read -ra ARR <<< "${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE}"
+    yq -i ".image.longhorn.instanceManager.repository=\"${ARR[0]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+    yq -i ".image.longhorn.instanceManager.tag=\"${ARR[1]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  fi
+  if [[ -n "${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE}" ]]; then
+    read -ra ARR <<< "${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE}"
+    yq -i ".image.longhorn.shareManager.repository=\"${ARR[0]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+    yq -i ".image.longhorn.shareManager.tag=\"${ARR[1]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  fi
+  if [[ -n "${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE}" ]]; then
+    read -ra ARR <<< "${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE}"
+    yq -i ".image.longhorn.backingImageManager.repository=\"${ARR[0]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+    yq -i ".image.longhorn.backingImageManager.tag=\"${ARR[1]}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  fi
+}
+
+
+install_longhorn(){
+  helm upgrade --install longhorn "${LONGHORN_REPO_DIR}/chart/" --namespace "${LONGHORN_NAMESPACE}"
+  wait_longhorn_status_running
+}

--- a/pipelines/utilities/longhorn_status.sh
+++ b/pipelines/utilities/longhorn_status.sh
@@ -1,0 +1,17 @@
+wait_longhorn_status_running(){
+  local RETRY_COUNTS=10 # in minutes
+  local RETRY_INTERVAL="1m"
+
+  # csi components are installed after longhorn components.
+  # it's possible that all longhorn components are running but csi components aren't created yet.
+  RETRIES=0
+  while [[ -z `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $1}' | grep csi-` ]] || \
+    [[ -n `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $3}' | grep -v "Running\|Completed"` ]]; do
+    echo "Longhorn is still installing ... re-checking in 1m"
+    sleep ${RETRY_INTERVAL}
+    RETRIES=$((RETRIES+1))
+
+    if [[ ${RETRIES} -eq ${RETRY_COUNTS} ]]; then echo "Error: longhorn installation timeout"; exit 1 ; fi
+  done
+
+}

--- a/pipelines/utilities/run_longhorn_test.sh
+++ b/pipelines/utilities/run_longhorn_test.sh
@@ -1,0 +1,121 @@
+run_longhorn_test(){
+
+  LONGHORN_TESTS_CUSTOM_IMAGE=${LONGHORN_TESTS_CUSTOM_IMAGE:-"longhornio/longhorn-manager-test:master-head"}
+
+  LONGHORN_TESTS_MANIFEST_FILE_PATH="manager/integration/deploy/test.yaml"
+
+  LONGHORN_JUNIT_REPORT_PATH=`yq e '.spec.containers[0].env[] | select(.name == "LONGHORN_JUNIT_REPORT_PATH").value' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"`
+
+  local PYTEST_COMMAND_ARGS='"-s", "--junitxml='${LONGHORN_JUNIT_REPORT_PATH}'"'
+  if [[ -n ${PYTEST_CUSTOM_OPTIONS} ]]; then
+    PYTEST_CUSTOM_OPTIONS=(${PYTEST_CUSTOM_OPTIONS})
+    for OPT in "${PYTEST_CUSTOM_OPTIONS[@]}"; do
+      PYTEST_COMMAND_ARGS=${PYTEST_COMMAND_ARGS}', "'${OPT}'"'
+    done
+  fi
+
+  ## generate test pod manifest
+  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].args=['"${PYTEST_COMMAND_ARGS}"']' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
+  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].image="'${LONGHORN_TESTS_CUSTOM_IMAGE}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+
+  if [[ $BACKUP_STORE_TYPE = "s3" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $1}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  fi
+
+  if [[ "${TF_VAR_use_hdd}" == true ]]; then
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[3].value="hdd"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  fi
+
+  if [[ "${TF_VAR_k8s_distro_name}" == "eks" ]] || [[ "${TF_VAR_k8s_distro_name}" == "aks" ]]; then
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[6].value="true"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  fi
+
+  set +x
+  ## inject aws cloudprovider and credentials env variables from created secret
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "CLOUDPROVIDER", "value": "aws"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "AWS_ACCESS_KEY_ID", "valueFrom": {"secretKeyRef": {"name": "aws-cred-secret", "key": "AWS_ACCESS_KEY_ID"}}}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": "aws-cred-secret", "key": "AWS_SECRET_ACCESS_KEY"}}}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "AWS_DEFAULT_REGION", "valueFrom": {"secretKeyRef": {"name": "aws-cred-secret", "key": "AWS_DEFAULT_REGION"}}}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
+  set -x
+
+  LONGHORN_TEST_POD_NAME=`yq e 'select(.spec.containers[0] != null).metadata.name' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}`
+
+  kubectl apply -f ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+
+  local RETRY_COUNTS=60
+  local RETRIES=0
+  # wait longhorn tests pod to start running
+  while [[ -n "`kubectl get pod longhorn-test -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' | grep -v \"running\|terminated\"`"  ]]; do
+    echo "waiting longhorn test pod to be in running state ... rechecking in 10s"
+    sleep 10s
+    RETRIES=$((RETRIES+1))
+
+    if [[ ${RETRIES} -eq ${RETRY_COUNTS} ]]; then echo "Error: longhorn test pod start timeout"; exit 1 ; fi
+  done
+
+  # wait longhorn tests to complete
+  while [[ "`kubectl get pod longhorn-test -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' 2>&1 | grep -v \"terminated\"`"  ]]; do
+    kubectl logs ${LONGHORN_TEST_POD_NAME} -c longhorn-test -f --since=10s
+  done
+
+  kubectl cp ${LONGHORN_TEST_POD_NAME}:${LONGHORN_JUNIT_REPORT_PATH} "longhorn-test-junit-report.xml" -c longhorn-test-report
+}
+
+
+run_longhorn_upgrade_test(){
+  LONGHORN_TESTS_CUSTOM_IMAGE=${LONGHORN_TESTS_CUSTOM_IMAGE:-"longhornio/longhorn-manager-test:master-head"}
+
+  LONGHORN_TESTS_MANIFEST_FILE_PATH="${WORKSPACE}/manager/integration/deploy/test.yaml"
+  LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH="${WORKSPACE}/manager/integration/deploy/upgrade_test.yaml"
+
+  LONGHORN_JUNIT_REPORT_PATH=`yq e '.spec.containers[0].env[] | select(.name == "LONGHORN_JUNIT_REPORT_PATH").value' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"`
+
+  local PYTEST_COMMAND_ARGS='''"-s",
+                                 "--junitxml='${LONGHORN_JUNIT_REPORT_PATH}'",
+                                 "--include-upgrade-test",
+                                 "-k", "test_upgrade",
+                                 "--lh-install-method", "'${LONGHORN_INSTALL_METHOD}'",
+                                 "--upgrade-lh-repo-url", "'${UPGRADE_LH_REPO_URL}'",
+                                 "--upgrade-lh-repo-branch", "'${UPGRADE_LH_REPO_BRANCH}'",
+                                 "--upgrade-lh-manager-image", "'${UPGRADE_LH_MANAGER_IMAGE}'",
+                                 "--upgrade-lh-engine-image", "'${UPGRADE_LH_ENGINE_IMAGE}'",
+                                 "--upgrade-lh-instance-manager-image", "'${UPGRADE_LH_INSTANCE_MANAGER_IMAGE}'",
+                                 "--upgrade-lh-share-manager-image", "'${UPGRADE_LH_SHARE_MANAGER_IMAGE}'",
+                                 "--upgrade-lh-backing-image-manager-image", "'${UPGRADE_LH_BACKING_IMAGE_MANAGER_IMAGE}'"
+                              '''
+
+  ## generate upgrade_test pod manifest
+  yq e 'select(.spec.containers[0] != null).spec.containers[0].args=['"${PYTEST_COMMAND_ARGS}"']' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}" > ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].image="'${LONGHORN_TESTS_CUSTOM_IMAGE}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+  yq e -i 'select(.spec.containers[0] != null).metadata.name="'${LONGHORN_UPGRADE_TEST_POD_NAME}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+
+  if [[ $BACKUP_STORE_TYPE = "s3" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $1}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+  fi
+
+  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[4].value="'${LONGHORN_UPGRADE_TYPE}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+
+  kubectl apply -f ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+
+  # wait upgrade test pod to start running
+  while [[ -n "`kubectl get pod ${LONGHORN_UPGRADE_TEST_POD_NAME} -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' | grep -v \"running\|terminated\"`"  ]]; do
+    echo "waiting upgrade test pod to be in running state ... rechecking in 10s"
+    sleep 10s
+  done
+
+  # wait upgrade test to complete
+  while [[ -n "`kubectl get pod ${LONGHORN_UPGRADE_TEST_POD_NAME} -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' | grep \"running\"`"  ]]; do
+    kubectl logs ${LONGHORN_UPGRADE_TEST_POD_NAME} -c longhorn-test -f --since=10s
+  done
+
+  # get upgrade test junit xml report
+  kubectl cp ${LONGHORN_UPGRADE_TEST_POD_NAME}:${LONGHORN_JUNIT_REPORT_PATH} "${LONGHORN_UPGRADE_TEST_POD_NAME}-junit-report.xml" -c longhorn-test-report
+}


### PR DESCRIPTION
ci: implement helm install/upgrade regression test pipeline

(1) add a separate independent pipeline for helm to avoid heavy Jenkinsfile and longhorn-setup.sh
(2) implement refresh install longhorn helm chart and run regression test
(3) implement (2 stage) upgrade longhorn helm chart for test_upgrade
(4) for setup scripts, separate common functions into utility functions for code reuse

For https://github.com/longhorn/longhorn/issues/3987 https://github.com/longhorn/longhorn/issues/5936

Signed-off-by: Yang Chiu <yang.chiu@suse.com>