### PR TITLE
Fix flaky test_setting_concurrent_rebuild_limit Extend Volume Rebuild Timeout

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -62,6 +62,7 @@ PORT = ":9500"
 RETRY_COMMAND_COUNT = 3
 RETRY_COUNTS = 150
 RETRY_COUNTS_SHORT = 30
+RETRY_COUNTS_LONG = 360
 RETRY_INTERVAL = 1
 RETRY_INTERVAL_LONG = 2
 RETRY_BACKUP_COUNTS = 300
@@ -4061,10 +4062,10 @@ def wait_for_expansion_failure(client, volume_name, last_failed_at=""):
     assert failed
 
 
-def wait_for_rebuild_complete(client, volume_name):
+def wait_for_rebuild_complete(client, volume_name, retry_count=RETRY_COUNTS):
     completed = 0
     rebuild_statuses = {}
-    for i in range(RETRY_COUNTS):
+    for i in range(retry_count):
         completed = 0
         v = client.by_id_volume(volume_name)
         rebuild_statuses = v.rebuildStatus


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/6382

The [Volume Replica Rebuilding Speedup](https://github.com/longhorn/longhorn/issues/4783) feature was introduced as an enhancement in `1.4.0`

The current timeout value for checking the rebuild status may not be sufficient for `v1.3.x`.

To address this, we propose extending the timeout for checking the rebuild volume status on `v1.3.x` branch.

The execution time for each test case to approximately 15-20 minutes.


![Screenshot_20230802_172123](https://github.com/longhorn/longhorn-tests/assets/104337648/6643a6bf-086d-4802-ae96-4f6816193f3e)


Private image test result 
- [x] coretest : https://ci.longhorn.io/job/private/job/longhorn-tests-regression/4727/
- [x] test case test : https://ci.longhorn.io/job/private/job/longhorn-tests-regression/4725/

