### PR TITLE
Change build test engine availability-zone to us-east-1a

### DIFF
--- a/build_engine_test_images/terraform/aws/ubuntu/variables.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/variables.tf
@@ -21,7 +21,7 @@ variable "tf_workspace" {
 
 variable "aws_availability_zone" {
   type        = string
-  default     = "us-east-1c"
+  default     = "us-east-1a"
 }
 
 variable "build_engine_aws_vpc_name" {


### PR DESCRIPTION
Build test engine image pipeline [failed](https://ci.longhorn.io/job/private/job/build-engine-test-images/47/consoleFull) start ARM64 instance because
```
Error launching source instance: Unsupported: Your requested instance type (a1.medium) is not supported in your requested Availability Zone (us-east-1c)
```

Currently build test engine pipeline use instance type=`t2.micro` for AMD64 architecture , use instance type=`a1.medium` for ARM64 architecture. Change availability-zone to us-east-1a because it support both of those instance types.
![Screenshot from 2023-08-07 10-52-02](https://github.com/longhorn/longhorn-tests/assets/73337386/a30ab65b-9693-424c-bf7b-d25c45a2961b)
