### PR TITLE
Change aws_availability_zone from us-east-1c to 1b

### DIFF
--- a/build_engine_test_images/terraform/aws/ubuntu/variables.tf
+++ b/build_engine_test_images/terraform/aws/ubuntu/variables.tf
@@ -21,7 +21,7 @@ variable "tf_workspace" {
 
 variable "aws_availability_zone" {
   type        = string
-  default     = "us-east-1c"
+  default     = "us-east-1b"
 }
 
 variable "build_engine_aws_vpc_name" {


### PR DESCRIPTION
The [build-engine-test-images pipeline](https://ci.longhorn.io/job/private/job/build-engine-test-images/) was failing. Since the engine identity PRs bumped engine versions, this pipeline needed to run to allow [live upgrade tests to pass](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/4754/). The live upgrade tests were specifically failing because they couldn't pull an image tagged `longhornio/longhorn-test:upgrade-test.9-3.5-3.1-1`. However, there was an engine called `longhornio/longhorn-test:upgrade-test.9-3.5-3.1-1-amd64` in Docker Hub. This [block of code](https://github.com/longhorn/longhorn-tests/blob/52653904465252c91f2ad3929ca65d17a611f0fd/build_engine_test_images/scripts/generate_images.sh#L58-L62) is responsible for pushing the multi-architecture manifest (without `-amd64` or `-arm64`), but it only runs when the ARM images are built and pushed. Unfortunately, the Terraform manifests responsible for building the ARM images failed with:

```
Error: Error launching source instance: Unsupported: Your requested instance type (a1.medium) is not supported in your requested Availability Zone (us-east-1c). Please retry your request by not specifying an Availability Zone or choosing us-east-1a, us-east-1b, us-east-1d.
	status code: 400, request id: 0b4382c5-88ea-4ddd-8592-2a1c183c2b19
```

The solution is just to choose an availability zone that supports `a1.medium` instances. According to the AWS CLI, these include:

```
[cloudshell-user@ip-10-6-103-41 ~]$ aws ec2 describe-instance-type-offerings --location-type availability-zone  --filters Name=instance-type,Values=a1.medium --region us-east-1 --output table
-------------------------------------------------------
|            DescribeInstanceTypeOfferings            |
+-----------------------------------------------------+
||               InstanceTypeOfferings               ||
|+--------------+--------------+---------------------+|
|| InstanceType |  Location    |    LocationType     ||
|+--------------+--------------+---------------------+|
||  a1.medium   |  us-east-1d  |  availability-zone  ||
||  a1.medium   |  us-east-1b  |  availability-zone  ||
||  a1.medium   |  us-east-1a  |  availability-zone  ||
|+--------------+--------------+---------------------+|
```

This is annoying, because @chriscchien specifically switched TO `us-east-1c` previously to fix this exact same problem in https://github.com/longhorn/longhorn-tests/pull/1130. It seems AWS likes to change which availability zones support which instances...