### PR TITLE
Ensure SLES registration is complete before zypper install

### DIFF
--- a/test_framework/terraform/aws/sles/k3s_instances.tf
+++ b/test_framework/terraform/aws/sles/k3s_instances.tf
@@ -35,8 +35,7 @@ resource "aws_instance" "lh_aws_instance_controlplane_k3s" {
 # Create worker instances for k3s
 resource "aws_instance" "lh_aws_instance_worker_k3s" {
   depends_on = [
-    aws_internet_gateway.lh_aws_igw,
-    aws_subnet.lh_aws_private_subnet,
+    aws_route_table_association.lh_aws_private_subnet_rt_association,
     aws_instance.lh_aws_instance_controlplane_k3s
   ]
 

--- a/test_framework/terraform/aws/sles/rke2_instances.tf
+++ b/test_framework/terraform/aws/sles/rke2_instances.tf
@@ -35,8 +35,7 @@ resource "aws_instance" "lh_aws_instance_controlplane_rke2" {
 # Create worker instances for rke2
 resource "aws_instance" "lh_aws_instance_worker_rke2" {
   depends_on = [
-    aws_internet_gateway.lh_aws_igw,
-    aws_subnet.lh_aws_private_subnet,
+    aws_route_table_association.lh_aws_private_subnet_rt_association,
     aws_instance.lh_aws_instance_controlplane_rke2
   ]
 

--- a/test_framework/terraform/aws/sles/rke_instances.tf
+++ b/test_framework/terraform/aws/sles/rke_instances.tf
@@ -59,8 +59,7 @@ resource "null_resource" "wait_for_docker_start_controlplane" {
 # Create worker instances for rke
 resource "aws_instance" "lh_aws_instance_worker_rke" {
   depends_on = [
-    aws_internet_gateway.lh_aws_igw,
-    aws_subnet.lh_aws_private_subnet,
+    aws_route_table_association.lh_aws_private_subnet_rt_association,
     aws_instance.lh_aws_instance_controlplane_rke
   ]
 

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-sudo zypper ref -y
+set -e
+
+sudo systemctl restart guestregister # Sometimes registration fails on first boot.
+sudo zypper ref
 sudo zypper install -y -t pattern devel_basis
 sudo zypper install -y open-iscsi nfs-client
 sudo systemctl -q enable iscsid
@@ -23,6 +26,9 @@ elif [ -b "/dev/xvdh" ]; then
   mkdir /var/lib/longhorn
   mount /dev/xvdh /var/lib/longhorn
 fi
+
+# TODO: It looks like "set -e" will break the intended functionality of the remaining code. Consider a refactor.
+set +e
 
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --token ${k3s_cluster_secret}" K3S_URL="${k3s_server_url}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
   echo 'k3s agent did not install correctly'

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_server.sh.tpl
@@ -2,6 +2,7 @@
 
 set -e
 
+sudo systemctl restart guestregister # Sometimes registration fails on first boot.
 sudo zypper ref
 sudo zypper install -y -t pattern devel_basis
 sudo zypper install -y open-iscsi nfs-client jq

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_rke.sh
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_rke.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-sudo zypper ref -y
+set -e
+
+sudo systemctl restart guestregister # Sometimes registration fails on first boot.
+sudo zypper ref
 sudo zypper install -y -t pattern devel_basis
 sudo zypper install -y open-iscsi docker nfs-client
 sudo usermod -aG docker ec2-user

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-sudo zypper ref -y
+set -e
+
+sudo systemctl restart guestregister # Sometimes registration fails on first boot.
+sudo zypper ref
 sudo zypper install -y -t pattern devel_basis
 sudo zypper install -y open-iscsi nfs-client 
 sudo systemctl -q enable iscsid

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_server.sh.tpl
@@ -1,6 +1,9 @@
 #!/bin/bash 
 
-sudo zypper ref -y
+set -e
+
+sudo systemctl restart guestregister # Sometimes registration fails on first boot.
+sudo zypper ref
 sudo zypper install -y -t pattern devel_basis 
 sudo zypper install -y open-iscsi nfs-client jq
 sudo systemctl -q enable iscsid
@@ -36,6 +39,9 @@ EOF
 fi
 
 systemctl start rke2-server.service
+
+# TODO: It looks like "set -e" will break the intended functionality of the remaining code. Consider a refactor.
+set +e
 
 until (KUBECONFIG=/etc/rancher/rke2/rke2.yaml /var/lib/rancher/rke2/bin/kubectl get pods -A | grep 'Running'); do
   echo 'Waiting for rke2 startup'


### PR DESCRIPTION
longhorn/longhorn#6504

Changes:

1. Don't create worker instances until we are sure a route to the internet is available.
2. Fail immediately if packages can't be installed (`set -e` in all user-data-scripts).
3. Always manually attempt to register with SUSE servers before installing packages.