### PR TITLE
add test case test_backuptarget_invalid

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -98,6 +98,8 @@ from common import DEFAULT_BACKUP_COMPRESSION_METHOD
 from common import BACKUP_COMPRESSION_METHOD_LZ4
 from common import BACKUP_COMPRESSION_METHOD_GZIP
 from common import BACKUP_COMPRESSION_METHOD_NONE
+from common import create_and_wait_deployment
+from common import get_custom_object_api_client
 
 from backupstore import backupstore_delete_volume_cfg_file
 from backupstore import backupstore_cleanup
@@ -111,6 +113,7 @@ from backupstore import backupstore_get_backup_volume_prefix
 from backupstore import set_backupstore_url, set_backupstore_credential_secret, set_backupstore_poll_interval  # NOQA
 from backupstore import reset_backupstore_setting  # NOQA
 from backupstore import set_backupstore_s3, backupstore_get_secret  # NOQA
+from backupstore import backupstore_invalid # NOQA
 
 from kubernetes import client as k8sclient
 
@@ -5501,8 +5504,14 @@ def test_filesystem_trim(client, fs_type):  # NOQA
     wait_for_volume_delete(client, test_volume_name)
 
 
-@pytest.mark.skip(reason="TODO")
-def test_backuptarget_invalid(): # NOQA
+def test_backuptarget_invalid(apps_api, # NOQA
+                              client, # NOQA
+                              core_api, # NOQA
+                              backupstore_invalid, # NOQA
+                              make_deployment_with_pvc, # NOQA
+                              pvc_name, # NOQA
+                              request, # NOQA
+                              volume_name): # NOQA
     """
     Related issue :
     https://github.com/longhorn/longhorn/issues/1249
@@ -5522,7 +5531,36 @@ def test_backuptarget_invalid(): # NOQA
     Then
     - Backup will be failed and the backup state is Error.
     """
-    pass
+    volume = create_and_check_volume(client, volume_name)
+    pvc_name = volume_name + "-pvc"
+    create_pv_for_volume(client, core_api, volume, volume_name)
+    create_pvc_for_volume(client, core_api, volume, pvc_name)
+
+    deployment_name = volume_name + "-dep"
+    deployment = make_deployment_with_pvc(deployment_name, pvc_name)
+    create_and_wait_deployment(apps_api, deployment)
+
+    pod_names = common.get_deployment_pod_names(core_api, deployment)
+    write_pod_volume_random_data(core_api, pod_names[0], "/data/test",
+                                 DATA_SIZE_IN_MB_1)
+
+    volume = client.by_id_volume(volume_name)
+    snap = create_snapshot(client, volume_name)
+    volume.snapshotBackup(name=snap.name)
+
+    for i in range(RETRY_COMMAND_COUNT):
+        api = get_custom_object_api_client()
+        backups = api.list_namespaced_custom_object("longhorn.io",
+                                                    "v1beta2",
+                                                    "longhorn-system",
+                                                    "backups")
+
+        if backups["items"][0]["status"]["state"] != "":
+            break
+        time.sleep(RETRY_INTERVAL)
+
+    assert backups["items"][0]["spec"]["snapshotName"] == snap.name
+    assert backups["items"][0]["status"]["state"] == "Error"
 
 
 @pytest.mark.volume_backup_restore   # NOQA


### PR DESCRIPTION
Add test case `test_backuptarget_invalid`

ref: [6638](https://github.com/longhorn/longhorn/issues/6638)

Backup in error state did not have correspond `backupvolume` so in test case I cannot utilize below functions. That's the reason I use k8s API to get/delete backup which in error state
 - [delete_backup](https://github.com/longhorn/longhorn-tests/blob/f3324d7535b6f76dd46696c9ec17935ff4123cd0/manager/integration/tests/common.py#L474)
 - [find_backup](https://github.com/longhorn/longhorn-tests/blob/f3324d7535b6f76dd46696c9ec17935ff4123cd0/manager/integration/tests/common.py#L3613)

~longhorn-test pod need to delete backup through k8s API, I modified `ClusterRole` `longhorn-test-role` add permission for pod longhorn-test~ (no need after this [PR](https://github.com/longhorn/longhorn-tests/pull/1486/) 

Pipeline use specific test.yaml, hence I tested on local for reference
![image](https://github.com/longhorn/longhorn-tests/assets/73337386/acea479d-a589-4e9f-86d4-923439c46112)
