### PR TITLE
Update upgrade test case to support the validation of both 'spec.engi…

### DIFF
--- a/manager/integration/tests/test_upgrade.py
+++ b/manager/integration/tests/test_upgrade.py
@@ -567,7 +567,12 @@ def test_upgrade(longhorn_upgrade_type,
         if v.name != restore_vol_name:
             volume = client.by_id_volume(v.name)
             engine = get_volume_engine(volume)
-            assert engine.image == new_ei.image
+            if hasattr(engine, 'engineImage'):
+                print("Checking engineImage...")
+                assert engine.engineImage == new_ei.image
+            else:
+                print("Checking image...")
+                assert engine.image == new_ei.image
             assert engine.currentImage == new_ei.image
 
     # Check All volumes data


### PR DESCRIPTION
…neImage' and 'spec.image' fields.

The [Replace engineImage field in CRDs with image](https://github.com/longhorn/longhorn/issues/6647) feature was introduced as an enhancement in `1.6.0`, The existing 2-stage upgrade test cases are not handled this scenario, as versions `1.4.x` and `1.5.x` do not support this feature.

Ref: https://github.com/longhorn/longhorn/issues/6777

[`v1.5.1` upgrade to `master-head`](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/4958/testReport/tests/)

[`v1.4.3`  upgrade to `v1.5.1` and then upgrade to `master-head` ](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/4959/testReport/tests/)