### PR TITLE
test: fix flaky test case test_default_storage_class_syncup

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -4512,7 +4512,6 @@ def test_default_storage_class_syncup(core_api, request):  # NOQA
                 print(e)
             finally:
                 time.sleep(RETRY_INTERVAL)
-        longhorn_storage_class = storage_api.read_storage_class("longhorn")
         assert longhorn_storage_class.allow_volume_expansion is allow_exp
 
     def finalizer():


### PR DESCRIPTION
test: fix flaky test case test_default_storage_class_syncup

Since storage_api.read_storage_class is flaky, it should be wrapped in try-catch and for-loop.

For https://github.com/longhorn/longhorn/issues/6141 https://github.com/longhorn/longhorn/issues/6913

Signed-off-by: Yang Chiu <yang.chiu@suse.com>