### PR TITLE
test: sync test.yaml file to use cluster admin role

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -5,50 +5,13 @@ metadata:
   namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: longhorn-test-role
-rules:
-- apiGroups: [""]
-  resources: ["nodes", "nodes/status", "pods", "pods/exec", "persistentvolumes", "persistentvolumeclaims",
-              "persistentvolumeclaims/status", "secrets", "services", "serviceaccounts", "namespaces", "configmaps"]
-  verbs: ["*"]
-- apiGroups: ["scheduling.k8s.io"]
-  resources: ["priorityclasses"]
-  verbs: ["*"]
-- apiGroups: ["storage.k8s.io"]
-  resources: ["storageclasses"]
-  verbs: ["*"]
-- apiGroups: ["apps"]
-  resources: ["statefulsets", "deployments", "daemonsets"]
-  verbs: ["*"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterroles", "clusterrolebindings", "rolebindings", "roles"]
-  verbs: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["*"]
-- apiGroups: ["policy"]
-  resources: ["podsecuritypolicies", "poddisruptionbudgets"]
-  verbs: ["*"]
-- apiGroups: ["snapshot.storage.k8s.io"]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["batch"]
-  resources: ["cronjobs"]
-  verbs: ["*"]
-- apiGroups: ["longhorn.io"]
-  resources: ["supportbundles", "supportbundles/status"]
-  verbs: ["*"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: longhorn-test-bind
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: longhorn-test-role
+  name: cluster-admin
 subjects:
 - kind: ServiceAccount
   name: longhorn-test-service-account
@@ -107,6 +70,8 @@ spec:
       mountPath: /tmp/test-report
   - name: longhorn-test-report
     image: busybox:1.34.0
+    securityContext:
+      privileged: true
     command: [ "tail", "-f", "/dev/null" ]
     volumeMounts:
     - name: test-report


### PR DESCRIPTION
test: sync test.yaml file with PR https://github.com/longhorn/longhorn-tests/pull/1486 to use cluster admin role to run the test

Signed-off-by: Yang Chiu <yang.chiu@suse.com>



