### PR TITLE
fix(negative): 'CRD' object has no attribute 'cr_api'

### DIFF
--- a/e2e/libs/engine/crd.py
+++ b/e2e/libs/engine/crd.py
@@ -22,7 +22,7 @@ class CRD(Base):
         if node_name != "":
             label_selector.append(f"longhornnode={node_name}")
 
-        api_response = self.cr_api.list_namespaced_custom_object(
+        api_response = self.obj_api.list_namespaced_custom_object(
             group="longhorn.io",
             version="v1beta2",
             namespace="longhorn-system",


### PR DESCRIPTION
```
Getting the volume vol-v7f6au engine on the node ip-10-0-2-85 state
Failed getting volume vol-v7f6au engine state: 'CRD' object has no attribute 'cr_api'
```