### PR TITLE
fix flaky test_backuptarget_invalid by increase loop time

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -100,6 +100,7 @@ from common import BACKUP_COMPRESSION_METHOD_GZIP
 from common import BACKUP_COMPRESSION_METHOD_NONE
 from common import create_and_wait_deployment
 from common import get_custom_object_api_client
+from common import RETRY_COUNTS_SHORT
 
 from backupstore import backupstore_delete_volume_cfg_file
 from backupstore import backupstore_cleanup
@@ -5547,7 +5548,7 @@ def test_backuptarget_invalid(apps_api, # NOQA
     snap = create_snapshot(client, volume_name)
     volume.snapshotBackup(name=snap.name)
 
-    for i in range(RETRY_COMMAND_COUNT):
+    for i in range(RETRY_COUNTS_SHORT):
         api = get_custom_object_api_client()
         backups = api.list_namespaced_custom_object("longhorn.io",
                                                     "v1beta2",


### PR DESCRIPTION
Fix flaky `test_backuptarget_invalid` by increase loop time from 3 sec to 30 sec.

Test [result](https://ci.longhorn.io/job/public/job/master/job/sles/job/amd64/job/longhorn-2-stage-upgrade-tests-sles-amd64/355/testReport/tests/test_basic/) (20 times)