### PR TITLE
fix(integration): csi_minimal_volume_size

### DIFF
--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -891,6 +891,7 @@ def test_csi_minimal_volume_size(
     csi_pv['metadata']['name'] = pv_name
     csi_pv['spec']['csi']['volumeHandle'] = vol_name
     csi_pv['spec']['capacity']['storage'] = min_storage
+    csi_pv['spec']['persistentVolumeReclaimPolicy'] = 'Retain'
     core_api.create_persistent_volume(csi_pv)
 
     pvc_name = vol_name + "-pvc"


### PR DESCRIPTION
After upgrading csi-node-driver-registrar to v2.9.0, deleting the PVC also deletes the PV due to the PV reclaim policy.

ref: https://github.com/longhorn/longhorn/issues/6916