### PR TITLE
Fix test_disk_eviction_with_node_level_soft_anti_affinity_disabled

### DIFF
--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -2626,6 +2626,14 @@ def test_disk_eviction_with_node_level_soft_anti_affinity_disabled(client, # NOQ
     replica_path = test_disk_path + '/replicas'
     assert os.path.isdir(replica_path)
 
+    # Since https://github.com/longhorn/longhorn-manager/pull/2138, the node
+    # controller is responsible for triggering replica eviction. If the timing
+    # of the node controller and node monitor are off, the node controller
+    # may take extra time to do so. Wait for evidence eviction is in progress
+    # before proceeding.
+    wait_for_volume_replica_count(client, volume.name,
+                                  volume.numberOfReplicas + 1)
+
     for i in range(common.RETRY_COMMAND_COUNT):
         if len(os.listdir(replica_path)) > 0:
             break


### PR DESCRIPTION
longhorn/longhorn#7210

The node controller refuses to update a node until its disk monitor has synced. In v1.6.0, the node controller is responsible for triggering replica eviction. This means it may take longer for replica eviction to start than it did in the past. In the long term, we may want to try to tighten up this timing again, but unfortunately, there is no obvious and easy way to do so.

test_disk_eviction_with_node_level_soft_anti_affinity_disabled is currently failing because it does not wait long enough for a replica to be evicted from one disk before checking for it on another. This PR ensures the eviction process has started before proceeding to do the check.