### PR TITLE
Update test-storage-network.md

### DIFF
--- a/docs/content/manual/release-specific/v1.6.0/test-storage-network.md
+++ b/docs/content/manual/release-specific/v1.6.0/test-storage-network.md
@@ -185,8 +185,10 @@ kubectl apply -f nad-192-168-0-0.yaml
 
 *And* (For K3s) Establish symbolic links on all cluster nodes.
   ```bash
-  ln -s /var/lib/rancher/k3s/agent/etc/cni/net.d /etc/cni
-  ln -s /var/lib/rancher/k3s/data/current/bin /opt/cni
+  mkdir /etc/cni
+  mkdir /opt/cni
+  ln -s /var/lib/rancher/k3s/agent/etc/cni/net.d /etc/cni/
+  ln -s /var/lib/rancher/k3s/data/current/bin /opt/cni/
   ```
 
 *And* Deploy Multus DaemonSet on the control-plane node.


### PR DESCRIPTION
Update test-storage-network.md

ref: [6953](https://github.com/longhorn/longhorn/issues/6953)

On Ubuntu 22.04 the original symbolic link command shows no error but the link content not correct. 
```
ln -s /var/lib/rancher/k3s/agent/etc/cni/net.d /etc/cni
ln -s /var/lib/rancher/k3s/data/current/bin /opt/cni
```
```shell
oot@ip-172-31-36-164:/home/ubuntu# rm -r /etc/cni/
root@ip-172-31-36-164:/home/ubuntu# rm -r /opt/cni/
root@ip-172-31-36-164:/home/ubuntu# ln -s /var/lib/rancher/k3s/agent/etc/cni/net.d /etc/cni
ln -s /var/lib/rancher/k3s/data/current/bin /opt/cni
root@ip-172-31-36-164:/home/ubuntu# 
root@ip-172-31-36-164:/home/ubuntu# tree /etc/cni
/etc/cni  [error opening dir]

0 directories, 0 files
root@ip-172-31-36-164:/home/ubuntu# tree /opt/cni
/opt/cni  [error opening dir]

0 directories, 0 files
```

Use below command on Ubuntu 22.04, the multus 4.02 thick plugin worled well
```
mkdir /etc/cni
mkdir /opt/cni
ln -s /var/lib/rancher/k3s/agent/etc/cni/net.d /etc/cni/
ln -s /var/lib/rancher/k3s/data/current/bin /opt/cni/
```
```
root@ip-172-31-36-164:/home/ubuntu# 
root@ip-172-31-36-164:/home/ubuntu# rm -r /etc/cni 
root@ip-172-31-36-164:/home/ubuntu# rm -r /opt/cni 
root@ip-172-31-36-164:/home/ubuntu# 
root@ip-172-31-36-164:/home/ubuntu# mkdir /etc/cni
mkdir /opt/cni
ln -s /var/lib/rancher/k3s/agent/etc/cni/net.d /etc/cni/
ln -s /var/lib/rancher/k3s/data/current/bin /opt/cni/
root@ip-172-31-36-164:/home/ubuntu# 
root@ip-172-31-36-164:/home/ubuntu# tree /etc/cni
/etc/cni
└── net.d -> /var/lib/rancher/k3s/agent/etc/cni/net.d

0 directories, 1 file
root@ip-172-31-36-164:/home/ubuntu# tree /opt/cni
/opt/cni
└── bin -> /var/lib/rancher/k3s/data/current/bin

0 directories, 1 file

```