### PR TITLE
ci: enable mirror support-bundle-kit in mirror-csi-images pipeline

### DIFF
--- a/mirror_csi_images/scripts/publish.sh
+++ b/mirror_csi_images/scripts/publish.sh
@@ -13,13 +13,21 @@ if [[ -n "${LONGHORN_IMAGES_FILE_URL}" ]]; then
       CSI_IMAGE=$(echo "${LINE}" | sed -e "s/longhornio\///g")
       IFS=: read -ra IMAGE_TAG_PAIR <<< "${CSI_IMAGE}"
       echo "registry.k8s.io/sig-storage/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
+    elif [[ "${LINE}" =~ "support-bundle-kit" ]]; then
+      SUPPORT_BUNDLE_KIT_IMAGE=$(echo "${LINE}" | sed -e "s/longhornio\///g")
+      IFS=: read -ra IMAGE_TAG_PAIR <<< "${SUPPORT_BUNDLE_KIT_IMAGE}"
+      echo "rancher/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
     fi
   done < "${LONGHORN_IMAGES_FILE}"
 else
   IFS=, read -ra CSI_IMAGES_ARR <<< "${CSI_IMAGES}"
   for CSI_IMAGE in "${CSI_IMAGES_ARR[@]}"; do
     IFS=: read -ra IMAGE_TAG_PAIR <<< "$CSI_IMAGE"
-    echo "registry.k8s.io/sig-storage/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
+    if [[ "${CSI_IMAGE}" =~ "csi-" ]]; then
+      echo "registry.k8s.io/sig-storage/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
+    elif [[ "${CSI_IMAGE}" =~ "support-bundle-kit" ]]; then
+      echo "rancher/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
+    fi
   done
 fi
 


### PR DESCRIPTION
ci: enable mirror support-bundle-kit in mirror-csi-images pipeline

For https://github.com/longhorn/longhorn/issues/7286

Signed-off-by: Yang Chiu <yang.chiu@suse.com>