### PR TITLE
ci: fix wrong longhorn-images.txt path for external-snapshotter installation

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -58,7 +58,7 @@ install_csi_snapshotter_crds(){
     CSI_SNAPSHOTTER_REPO_URL="https://github.com/kubernetes-csi/external-snapshotter.git"
     CSI_SNAPSHOTTER_REPO_DIR="${TMPDIR}/k8s-csi-external-snapshotter"
 
-    [[ "${LONGHORN_REPO_URL}" =~ https://([^/]+)/([^/]+)/([^/.]+)(.git)? ]]
+    [[ "${LONGHORN_REPO_URI}" =~ https://([^/]+)/([^/]+)/([^/.]+)(.git)? ]]
     wget "https://raw.githubusercontent.com/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${LONGHORN_REPO_BRANCH}/deploy/longhorn-images.txt" -O "/tmp/longhorn-images.txt"
     IFS=: read -ra IMAGE_TAG_PAIR <<< $(grep csi-snapshotter /tmp/longhorn-images.txt)
     CSI_SNAPSHOTTER_REPO_BRANCH="${IMAGE_TAG_PAIR[1]}"


### PR DESCRIPTION
ci: fix wrong longhorn-images.txt path for external-snapshotter installation

For https://github.com/longhorn/longhorn/issues/7383

Signed-off-by: Yang Chiu [yang.chiu@suse.com](mailto:yang.chiu@suse.com)