### PR TITLE
Fix flaky test test_engine_image_daemonset_restart

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2187,11 +2187,23 @@ def wait_for_engine_image_condition(client, image_name, state):
     """
     state: "True", "False"
     """
+    # Indicate many times we want to see the ENGINE_NAME in the STATE.
+    # This helps to prevent the flaky test case in which the ENGINE_NAME
+    # is flapping between ready and not ready a few times before settling
+    # down to the ready state
+    # https://github.com/longhorn/longhorn-tests/pull/1638
+    state_count = 1
+    if state == "True":
+        state_count = 5
+
+    c = 0
     for i in range(RETRY_COUNTS):
         wait_for_engine_image_creation(client, image_name)
         image = client.by_id_engine_image(image_name)
         if image['conditions'][0]['status'] == state:
-            break
+            c += 1
+            if c >= state_count:
+                break
         time.sleep(RETRY_INTERVAL_SHORT)
     assert image['conditions'][0]['status'] == state
     return image


### PR DESCRIPTION
Analysis https://github.com/longhorn/longhorn/issues/7438#issuecomment-1870733295

longhorn/longhorn#7438

Test passed 50 times:
```bash
➜  .kube k exec -it longhorn-test -- bash
Defaulted container "longhorn-test" out of: longhorn-test, longhorn-test-report
longhorn-test:/integration/tests # pytest -svvlx test_basic.py::test_engine_image_daemonset_restart --count=50
============================================================================ test session starts ============================================================================
platform linux -- Python 3.9.18, pytest-5.3.1, py-1.11.0, pluggy-0.13.1 -- /usr/bin/python3.9
cachedir: .pytest_cache
rootdir: /integration, inifile: pytest.ini
plugins: repeat-0.9.1, order-1.0.1
collected 50 items                                                                                                                                                          

test_basic.py::test_engine_image_daemonset_restart[1-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[2-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[3-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[4-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[5-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[6-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[7-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[8-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[9-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[10-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[11-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[12-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[13-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[14-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[15-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[16-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[17-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[18-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[19-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[20-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[21-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[22-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[23-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[24-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[25-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[26-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[27-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[28-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[29-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[30-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[31-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[32-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[33-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[34-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[35-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[36-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[37-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[38-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[39-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[40-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[41-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[42-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[43-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[44-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[45-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[46-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[47-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[48-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[49-50] PASSED
test_basic.py::test_engine_image_daemonset_restart[50-50] PASSED

============================================================================= warnings summary ==============================================================================
/usr/local/lib/python3.9/site-packages/_pytest/mark/structures.py:323
  /usr/local/lib/python3.9/site-packages/_pytest/mark/structures.py:323: PytestUnknownMarkWarning: Unknown pytest.mark.volume_backup_restore - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    warnings.warn(

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================ 50 passed, 1 warning in 1179.79s (0:19:39) =================================================================

```

