### PR TITLE
 Fix error log "Found unknown instance manager" and bug failed to find a node that is ready and has the default engine image

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3538,7 +3538,7 @@ def wait_for_all_instance_manager_running(client):
         node_to_instance_manager_map = {}
         try:
             for im in instance_managers:
-                if im.managerType == "aio" and im.currentState == "running":
+                if im.managerType == "aio":
                     node_to_instance_manager_map[im.nodeID] = im
                 else:
                     print("\nFound unknown instance manager:", im)

--- a/pipelines/utilities/longhorn_status.sh
+++ b/pipelines/utilities/longhorn_status.sh
@@ -2,10 +2,11 @@ wait_longhorn_status_running(){
   local RETRY_COUNTS=10 # in minutes
   local RETRY_INTERVAL="1m"
 
-  # csi components are installed after longhorn components.
+  # csi and engine image components are installed after longhorn components.
   # it's possible that all longhorn components are running but csi components aren't created yet.
   RETRIES=0
   while [[ -z `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $1}' | grep csi-` ]] || \
+    [[ -z `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $1}' | grep engine-image-` ]] || \
     [[ -n `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $3}' | grep -v "Running\|Completed"` ]]; do
     echo "Longhorn is still installing ... re-checking in 1m"
     sleep ${RETRY_INTERVAL}

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -121,10 +121,11 @@ wait_longhorn_status_running(){
   local RETRY_COUNTS=10 # in minutes
   local RETRY_INTERVAL="1m"
 
-  # csi components are installed after longhorn components.
+  # csi and engine image components are installed after longhorn components.
   # it's possible that all longhorn components are running but csi components aren't created yet.
   RETRIES=0
   while [[ -z `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $1}' | grep csi-` ]] || \
+    [[ -z `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $1}' | grep engine-image-` ]] || \
     [[ -n `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $3}' | grep -v Running` ]]; do
     echo "Longhorn is still installing ... re-checking in 1m"
     sleep ${RETRY_INTERVAL}


### PR DESCRIPTION
1. Fix error log "Found unknown instance manager"
When we found an instance manager with the correct type but not in the
running state, don't print out the log "Found unknown instance manager"
because it is misleading
The function wait_for_instance_manager_desire_state() below it already
taking care of waiting for the instance manager to be running.
1. Fix bug failed to find a node that is ready and has the default engine image
Wait for the engine image pods to be running before starting the tests

longhorn/longhorn#7413