### PR TITLE
test: fix flaky test case test_ha_salvage

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2312,13 +2312,18 @@ def crash_replica_processes(client, api, volname, replicas=None,
 
     for r in replicas:
         assert r.instanceManagerName != ""
-        kill_command = "kill `pgrep -f " + r['dataPath'] + "`"
+
+        pgrep_command = f"pgrep -f {r['dataPath']}"
+        pid = exec_instance_manager(api, r.instanceManagerName, pgrep_command)
+        assert pid != ""
+
+        kill_command = f"kill {pid}"
         exec_instance_manager(api, r.instanceManagerName, kill_command)
 
         if wait_to_fail is True:
             thread = create_assert_error_check_thread(
                 wait_for_replica_failed,
-                client, volname, r['name'], RETRY_COUNTS*2, RETRY_INTERVAL/2
+                client, volname, r['name'], RETRY_COUNTS, RETRY_INTERVAL_SHORT
             )
             threads.append(thread)
 
@@ -2331,10 +2336,11 @@ def exec_instance_manager(api, im_name, cmd):
 
     with timeout(seconds=STREAM_EXEC_TIMEOUT,
                  error_message='Timeout on executing stream read'):
-        stream(api.connect_get_namespaced_pod_exec,
-               im_name,
-               LONGHORN_NAMESPACE, command=exec_cmd,
-               stderr=True, stdin=False, stdout=True, tty=False)
+        output = stream(api.connect_get_namespaced_pod_exec,
+                        im_name,
+                        LONGHORN_NAMESPACE, command=exec_cmd,
+                        stderr=True, stdin=False, stdout=True, tty=False)
+        return output
 
 
 def wait_for_replica_failed(client, volname, replica_name,


### PR DESCRIPTION
test: fix flaky test case test_ha_salvage

By separate the `pgrep` command from the `kill` command. The original command format will cause the `pgrep` command also selects the `kill` process itself in addition to the `engine-binary` process, and potentially cause the `kill` process being killed by itself first, so no `engine-binary` process will be killed.

Normally it won't happen because the pid is increasing, a newly created process always has a large pid than an old process, which means the `kill` process always has a large pid than the `engine-binary` process. In this case, the `engine-binary` process will be killed first, and then the `kill` process, the test case won't fail.

But when the pid wraps around at `32768`, the newly created `kill` process gets assigned to a small pid (e.g. `300`), it will kill itself before the `engine-binary` process, and fail the test case.

For https://github.com/longhorn/longhorn/issues/7471

Signed-off-by: Yang Chiu <yang.chiu@suse.com>