### PR TITLE
ci: enable live logging in pytest by disabling python buffer

### DIFF
--- a/manager/integration/tests/run.sh
+++ b/manager/integration/tests/run.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+export PYTHONUNBUFFERED=1
 pytest -v "$@"


### PR DESCRIPTION
ci: enable live logging in pytest by disabling python buffer

For https://github.com/longhorn/longhorn/issues/7490

Signed-off-by: Yang Chiu <yang.chiu@suse.com>