### PR TITLE
test: fix flaky test case test_volume_reattach_after_engine_sigkill

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -5000,11 +5000,14 @@ def wait_for_pod_restart(core_api, pod_name, namespace="default"):
 def wait_for_pod_phase(core_api, pod_name, pod_phase, namespace="default"):
     is_phase = False
     for _ in range(RETRY_COUNTS):
-        pod = core_api.read_namespaced_pod(name=pod_name,
-                                           namespace=namespace)
-        if pod.status.phase == pod_phase:
-            is_phase = True
-            break
+        try:
+            pod = core_api.read_namespaced_pod(name=pod_name,
+                                               namespace=namespace)
+            if pod.status.phase == pod_phase:
+                is_phase = True
+                break
+        except Exception as e:
+            print(f"Waiting for pod {pod_name} {pod_phase} failed: {e}")
 
         time.sleep(RETRY_INTERVAL_LONG)
     assert is_phase


### PR DESCRIPTION
test: fix flaky test case test_volume_reattach_after_engine_sigkill

The pod we're waiting could be terminated and recreated, so reading the pod could raise not found exception. Wrapping it in try/except to make the waiting continue.

For https://github.com/longhorn/longhorn/issues/7491

Signed-off-by: Yang Chiu <yang.chiu@suse.com>