### PR TITLE
fix(integration): unknown pytest.mark.volume_backup_restore

### DIFF
--- a/manager/integration/pytest.ini
+++ b/manager/integration/pytest.ini
@@ -17,3 +17,4 @@ markers =
   system_backup_restore
   cluster_autoscaler
   long_running
+  volume_backup_restore


### PR DESCRIPTION
```
/usr/local/lib/python3.9/site-packages/_pytest/mark/structures.py:323
  /usr/local/lib/python3.9/site-packages/_pytest/mark/structures.py:323: PytestUnknownMarkWarning: Unknown pytest.mark.volume_backup_restore - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    warnings.warn(
```