### PR TITLE
Revert "ci: check if new engine test images need to be published"

### DIFF
--- a/build_engine_test_images/Dockerfile.setup
+++ b/build_engine_test_images/Dockerfile.setup
@@ -15,7 +15,7 @@ RUN wget -q https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
     wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" && \
     mv yq_linux_amd64 /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq && \
-    apk add openssh-client ca-certificates git rsync bash curl jq docker && \
+    apk add openssh-client ca-certificates git rsync bash curl jq && \
     ssh-keygen -t rsa -b 4096 -N "" -f ~/.ssh/id_rsa
 
 COPY [".", "$WORKSPACE"]

--- a/build_engine_test_images/Jenkinsfile
+++ b/build_engine_test_images/Jenkinsfile
@@ -15,12 +15,11 @@ node {
     usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME'),
     usernamePassword(credentialsId: 'AWS_CREDS', passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY')
   ]) {
-        stage('build') {
+        stage('build') {      
             
             sh "build_engine_test_images/scripts/build.sh"
 
-            sh """ docker run -itd --privileged -v /var/run/docker.sock:/var/run/docker.sock \
-                                   --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
+            sh """ docker run -itd --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
                                    --env TF_VAR_build_engine_aws_access_key=${AWS_ACCESS_KEY} \
                                    --env TF_VAR_build_engine_aws_secret_key=${AWS_SECRET_KEY} \
                                    --env TF_VAR_docker_id=${DOCKER_USERNAME} \

--- a/build_engine_test_images/run.sh
+++ b/build_engine_test_images/run.sh
@@ -26,30 +26,6 @@ if [[ -z "$TF_VAR_docker_repo" ]]; then
     exit 1
 fi
 
-# if commit_id is empty, we can directly check longhorn-engine:master-head's api version
-if [[ -z "${TF_VAR_commit_id}" ]]; then
-
-  docker login -u="${TF_VAR_docker_id}" -p="${TF_VAR_docker_password}"
-  docker pull longhornio/longhorn-engine:master-head
-  version=`docker run longhornio/longhorn-engine:master-head longhorn version --client-only`
-  CLIAPIVersion=`echo $version | jq -r ".clientVersion.cliAPIVersion"`
-  CLIAPIMinVersion=`echo $version | jq -r ".clientVersion.cliAPIMinVersion"`
-  ControllerAPIVersion=`echo $version | jq -r ".clientVersion.controllerAPIVersion"`
-  ControllerAPIMinVersion=`echo $version | jq -r ".clientVersion.controllerAPIMinVersion"`
-  DataFormatVersion=`echo $version | jq -r ".clientVersion.dataFormatVersion"`
-  DataFormatMinVersion=`echo $version | jq -r ".clientVersion.dataFormatMinVersion"`
-  echo "latest engine version: ${version}"
-
-  upgrade_image="${TF_VAR_docker_repo}:upgrade-test.$CLIAPIVersion-$CLIAPIMinVersion"\
-".$ControllerAPIVersion-$ControllerAPIMinVersion"\
-".$DataFormatVersion-$DataFormatMinVersion"
-
-  if [[ $(docker manifest inspect "${upgrade_image}") != "" ]]; then
-    echo "latest engine test images have already published"
-    exit 0
-  fi
-fi
-
 trap ./scripts/cleanup.sh EXIT
 
 # Build amd64 images


### PR DESCRIPTION
Revert "ci: check if new engine test images need to be published"

This reverts commit d4b540af193895682716638e2a7a3cb290998c6e.

Signed-off-by: Yang Chiu <yang.chiu@suse.com>

