### PR TITLE
fix: find backup should also wait until backup volume is synced

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3738,7 +3738,7 @@ def find_backup(client, vol_name, snap_name):
     def find_backup_volume():
         bvs = client.list_backupVolume()
         for bv in bvs:
-            if bv.name == vol_name:
+            if bv.name == vol_name and bv.created != "":
                 return bv
         return None
 


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7543

BackupVolume is not synced, so the BackingImage field is empty
This leads to the failure when creating Volume. Admission-webhook will denied the request because the BackupVolume.BackingImage is not the same as Volume.BackingImage

