### PR TITLE
test(manual): cordoned node controller renders the backup target unusable

### DIFF
--- a/docs/content/manual/release-specific/v1.6.0/test-list-backup-when-cluster-has-node-cordoned-before-longhorn-installation.md
+++ b/docs/content/manual/release-specific/v1.6.0/test-list-backup-when-cluster-has-node-cordoned-before-longhorn-installation.md
@@ -1,0 +1,18 @@
+---
+title: Test list backup when cluster has node cordoned before Longhorn installation
+---
+
+## Related issue
+https://github.com/longhorn/longhorn/issues/7619
+
+## Test step
+
+**Given** a cluster has 3 worker nodes.  
+**And** 2 worker nodes are cordoned.  
+**And** Longhorn is installed.  
+
+**When** Setting up a backup target.  
+
+**Then** no error is observed on the UI Backup page.  
+**And** Backup custom resources are created if the backup target has existing backups.  
+


### PR DESCRIPTION
longhorn/longhorn#7619