### PR TITLE
fix(engineimage): new status `incompatible`.

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2191,6 +2191,17 @@ def wait_for_engine_image_state(client, image_name, state):
     return image
 
 
+def wait_for_engine_image_incompatible(client, image_name):
+    wait_for_engine_image_creation(client, image_name)
+    for i in range(RETRY_COUNTS):
+        image = client.by_id_engine_image(image_name)
+        if image.incompatible:
+            break
+        time.sleep(RETRY_INTERVAL)
+    assert image.incompatible
+    return image
+
+
 def wait_for_engine_image_condition(client, image_name, state):
     """
     state: "True", "False"

--- a/manager/integration/tests/test_engine_upgrade.py
+++ b/manager/integration/tests/test_engine_upgrade.py
@@ -9,6 +9,7 @@ from common import wait_for_volume_current_image, wait_for_volume_delete
 from common import wait_for_volume_detached
 from common import wait_for_engine_image_deletion
 from common import wait_for_engine_image_ref_count, wait_for_engine_image_state
+from common import wait_for_engine_image_incompatible
 from common import get_volume_engine, write_volume_random_data
 from common import check_volume_endpoint
 from common import wait_for_volume_replicas_mode
@@ -450,8 +451,8 @@ def test_engine_image_incompatible(client, core_api, volume_name):  # NOQA
         ctl_v, ctl_minv,
         data_v, data_minv)
     img = client.create_engine_image(image=fail_cli_v_image)
-    img = wait_for_engine_image_state(client, img.name, "incompatible")
-    assert img.state == "incompatible"
+    img = wait_for_engine_image_incompatible(client, img.name)
+    assert img.incompatible
     assert img.cliAPIVersion == cli_minv - 1
     assert img.cliAPIMinVersion == cli_minv - 1
     client.delete(img)
@@ -462,8 +463,8 @@ def test_engine_image_incompatible(client, core_api, volume_name):  # NOQA
             ctl_v, ctl_minv,
             data_v, data_minv)
     img = client.create_engine_image(image=fail_cli_minv_image)
-    img = wait_for_engine_image_state(client, img.name, "incompatible")
-    assert img.state == "incompatible"
+    img = wait_for_engine_image_incompatible(client, img.name)
+    assert img.incompatible
     assert img.cliAPIVersion == cli_v + 1
     assert img.cliAPIMinVersion == cli_v + 1
     client.delete(img)


### PR DESCRIPTION
Modified the test case `test_engine_image_incompatible` by new introduced status field `incompatible`.

Ref: longhorn/longhorn#7683, longhorn/longhorn#7539