### PR TITLE
test: new field `Incompatible` of EngineImage

### DIFF
--- a/docs/content/manual/release-specific/v1.6.0/test-engine-version-enforcement.md
+++ b/docs/content/manual/release-specific/v1.6.0/test-engine-version-enforcement.md
@@ -4,6 +4,7 @@ title: Test engine version enforcement
 
 ## Related issue
 https://github.com/longhorn/longhorn/issues/5842
+https://github.com/longhorn/longhorn/issues/7539
 
 ## Test step
 
@@ -30,12 +31,12 @@ time="2023-08-17T03:03:20Z" level=fatal msg="Error starting manager: failed chec
 **When** upgraded v1.4.1 volume (volume-1) engine  
 And upgraded Longhorn to v1.6.0
 **Then** Longhorn components should be running  
-And v1.4.x EngineImage state should be incompatible
+And v1.4.x EngineImage state should be deployed and incompatible should be true.
 ```
-NAME          STATE          IMAGE                               REFCOUNT   BUILDDATE   AGE
-ei-74783864   deployed       longhornio/longhorn-engine:v1.5.1   10         28d         12m
-ei-7fa7c208   incompatible   longhornio/longhorn-engine:v1.4.1   0          157d        13m
-ei-ad420081   deployed       c3y1huang/research:2017-lh-ei       0          44h         24s
+NAME          INCOMPATIBLE   STATE      IMAGE                               REFCOUNT   BUILDDATE   AGE
+ei-74783864   false          deployed   longhornio/longhorn-engine:v1.5.1   10         28d         12m
+ei-7fa7c208   true           deployed   longhornio/longhorn-engine:v1.4.1   0          157d        13m
+ei-ad420081   false          deployed   c3y1huang/research:2017-lh-ei       0          44h         24s
 ```
 
 **When** update existing volume/engine/replica custom resourcs `spec.image` with `longhornio/longhorn-engine:v1.4.x`  


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#5842, longhorn/longhorn#7539

#### What this PR does / why we need it:

Modify the manual test case for engine version enforcement.

#### Special notes for your reviewer:

#### Additional documentation or context
