### PR TITLE
Update sles distro to 15-sp5

### DIFF
--- a/test_framework/terraform/aws/sles/variables.tf
+++ b/test_framework/terraform/aws/sles/variables.tf
@@ -31,7 +31,7 @@ variable "arch" {
 
 variable "os_distro_version" {
   type        = string
-  default     = "15-sp4"
+  default     = "15-sp5"
 }
 
 variable "aws_ami_sles_account_number" {


### PR DESCRIPTION
15-sp4 is not found anymore

```
│ Error: Your query returned no results. Please change your search criteria and try again.
│ 
│   with data.aws_ami.aws_ami_sles,
│   on data.tf line 6, in data "aws_ami" "aws_ami_sles":
│    6: data "aws_ami" "aws_ami_sles" {
│ 
```