### PR TITLE
test(manual): Update PVC provisioning with insufficient storage

### DIFF
--- a/docs/content/manual/pre-release/resiliency/pvc_provisioning_with_insufficient_storage.md
+++ b/docs/content/manual/pre-release/resiliency/pvc_provisioning_with_insufficient_storage.md
@@ -5,17 +5,22 @@ title: "PVC provisioning with insufficient storage"
 #### Related Issue:
 - https://github.com/longhorn/longhorn/issues/4654
 - https://github.com/longhorn/longhorn/issues/3529
+- https://github.com/longhorn/longhorn/issues/6461
 
 #### Root Cause Analysis
 - https://github.com/longhorn/longhorn/issues/4654#issuecomment-1264870672
 
 This case need to be tested on both RWO/RWX volumes
 
-1. Create a PVC with size larger than 8589934591 GiB.
+1. Create a PVC with size larger than `8589934591` GiB.
     - Deployment keep in pending status, RWO/RWX volume will keep in a create -> delete loop.
-2. Create a PVC with size <= 8589934591 GiB, but greater than the actual available space size.
-    - RWO/RWX volume will be created, and volume will have annotation "longhorn.io/volume-scheduling-error": "insufficient storage volume scheduling failure" in it.
-3. Create a PVC with size < the actual available space size，Resize the PVC to a not schedulable size
+1. Create a PVC with size <= `8589934591` GiB, but greater than the actual available space size.
+    - RWO/RWX volume will be created, and the associated PV for this volume will have annotation "**longhorn.io/volume-scheduling-error**": "**insufficient storage**" in it.
+    - We can observe "**Scheduling Failure**" and "**Replica Scheduling Failure**" error messages on the Longhorn UI with the following details
+        - **Scheduling Failure**
+        - Replica Scheduling Failure
+        - Error Message: insufficient storage
+1. Create a PVC with size < the actual available space size，Resize the PVC to a not schedulable size
     - After resize PVC to a not schedulable size, both RWO/RWX were still in scheduling status.
 
 We can modify/use https://raw.githubusercontent.com/longhorn/longhorn/master/examples/rwx/rwx-nginx-deployment.yaml to deploy RWO/RWX PVC for this test 


### PR DESCRIPTION
longhorn/longhorn#7650

#### Which issue(s) this PR fixes:

longhorn/longhorn#7650

#### What this PR does / why we need it:

We have the ticket  longhorn/longhorn#6461 `[IMPROVEMENT] Provide more information for volume scheduling failure`. Our test case requires an update to ensure improved clarity and coverage.

#### Special notes for your reviewer:
@derekbit @jillian-maroket 

#### Additional documentation or context
- longhorn/longhorn#6461