### PR TITLE
test: fix 2 stage upgrade failed due to duplicated system backup name

### DIFF
--- a/manager/integration/tests/test_upgrade.py
+++ b/manager/integration/tests/test_upgrade.py
@@ -53,6 +53,7 @@ from common import monitor_restore_progress
 from common import wait_for_volume_recurring_job_update
 from common import get_volume_name
 from common import system_backup_feature_supported
+from common import system_backups_cleanup
 from test_orphan import create_orphaned_directories_on_host
 from test_orphan import delete_orphans
 from backupstore import set_backupstore_s3
@@ -336,6 +337,10 @@ def test_upgrade(longhorn_upgrade_type,
 
     # delete orphan
     delete_orphans(client)
+
+    # delete system backup
+    if system_backup_feature_supported(client):
+        system_backups_cleanup(client)
 
     # Check Pod and StatefulSet didn't restart after upgrade
     pod = core_api.read_namespaced_pod(name=pod_name,


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

2 stage upgrade test fails in v1.5.x because a system backup with the same name already exists which is created in the 1st round of upgrade.

#### Special notes for your reviewer:

#### Additional documentation or context

Backport form https://github.com/longhorn/longhorn-tests/pull/1474.
