### PR TITLE
ci: update disabling pre-upgrade checker setting for argocd

### DIFF
--- a/pipelines/utilities/argocd.sh
+++ b/pipelines/utilities/argocd.sh
@@ -48,8 +48,8 @@ spec:
       targetRevision: ${REVISION}
       helm:
         values: |
-          helmPreUpgradeCheckerJob:
-            enabled: false
+          preUpgradeChecker:
+            jobEnabled: false
   destination:
     server: https://kubernetes.default.svc
     namespace: ${LONGHORN_NAMESPACE}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
PR https://github.com/longhorn/website/pull/866

#### What this PR does / why we need it:

The pre-upgrade checker job is actually `preUpgradeChecker.jobEnabled: false` when using the Helm chart for `v1.6.0`.

#### Special notes for your reviewer:

#### Additional documentation or context
