### PR TITLE
Add skeleton for test_engine_crash_during_live_upgrade

### DIFF
--- a/manager/integration/tests/test_engine_upgrade.py
+++ b/manager/integration/tests/test_engine_upgrade.py
@@ -1196,3 +1196,19 @@ def test_engine_live_upgrade_while_replica_concurrent_rebuild(client, # NOQA
     for replica in volume2.replicas:
         assert replica.image == engine_upgrade_image
         assert replica.currentImage == engine_upgrade_image
+
+@pytest.mark.skip(reason="TODO")  # NOQA
+def test_engine_crash_during_live_upgrade():
+    """
+    1. Create and attach a volume to a workload, then write data into the
+       volume.
+    2. Deploy an extra engine image.
+    3. Send live upgrade request then immediately delete the related engine
+       manager pod/engine process (The new replicas are not in active in this
+       case).
+    4. Verify the workload will be restarted and the volume will be reattached
+       automatically.
+    5. Verify the upgrade is done during the reattachment.
+       (It actually becomes offline upgrade.)
+    6. Verify volume healthy and the data is correct.
+    """


### PR DESCRIPTION
Add skeleton for test_engine_crash_during_live_upgrade

ref: [7859](https://github.com/longhorn/longhorn/issues/7859)

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7859

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
