### PR TITLE
Fix automated mirroring of livenessprobe

### DIFF
--- a/mirror_csi_images/scripts/publish.sh
+++ b/mirror_csi_images/scripts/publish.sh
@@ -9,7 +9,7 @@ if [[ -n "${LONGHORN_IMAGES_FILE_URL}" ]]; then
   wget "${LONGHORN_IMAGES_FILE_URL}" -O "${LONGHORN_IMAGES_FILE}"
 
   while read -r LINE; do
-    if [[ "${LINE}" =~ "csi-" ]]; then
+    if [[ "${LINE}" =~ csi-|livenessprobe ]]; then
       CSI_IMAGE=$(echo "${LINE}" | sed -e "s/longhornio\///g")
       IFS=: read -ra IMAGE_TAG_PAIR <<< "${CSI_IMAGE}"
       echo "registry.k8s.io/sig-storage/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
@@ -23,7 +23,7 @@ else
   IFS=, read -ra CSI_IMAGES_ARR <<< "${CSI_IMAGES}"
   for CSI_IMAGE in "${CSI_IMAGES_ARR[@]}"; do
     IFS=: read -ra IMAGE_TAG_PAIR <<< "$CSI_IMAGE"
-    if [[ "${CSI_IMAGE}" =~ "csi-" ]]; then
+    if [[ "${CSI_IMAGE}" =~ csi-|livenessprobe ]]; then
       echo "registry.k8s.io/sig-storage/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"
     elif [[ "${CSI_IMAGE}" =~ "support-bundle-kit" ]]; then
       echo "rancher/${IMAGE_TAG_PAIR[0]}" "longhornio/${IMAGE_TAG_PAIR[0]}" "${IMAGE_TAG_PAIR[1]}" >> "${INFILE}"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

N/A

I discovered the issue while working on longhorn/longhorn#7428

#### What this PR does / why we need it:

The CSI mirroring scripts ignore images that aren't prefixed with `csi-` or `support-bundle-kit`. However, we need to mirror `registry.k8s.io/sig-storage/livenessprobe` in the same way as `registry.k8s.io/sig-storage/csi...` images. My attempt to mirror a new version of livenessprobe (https://ci.longhorn.io/job/private/job/mirror-csi-images/16/) failed.

#### Special notes for your reviewer:

I was surprised by the need to leave `csi-|livenessprobe` unquoted, but according to both ShellCheck and my testing it is correct when pattern matching (https://www.shellcheck.net/wiki/SC2076).

#### Additional documentation or context

It looks like this used to work in the environment variable case, but changes in https://github.com/longhorn/longhorn-tests/pull/1625 broke it.