### PR TITLE
test(manual): Sync up with backup target during DR volume activation

### DIFF
--- a/docs/content/manual/pre-release/backup-and-restore/sync-up-with-backup-target-during-dr-volume-activation.md
+++ b/docs/content/manual/pre-release/backup-and-restore/sync-up-with-backup-target-during-dr-volume-activation.md
@@ -1,0 +1,16 @@
+---
+title: "Sync up with backup target during DR volume activation"
+---
+
+#### Related Issue:
+- https://github.com/longhorn/longhorn/issues/5292
+- https://github.com/longhorn/longhorn/issues/7945
+
+1. Launch 2 clusters and both have Longhorn installed
+1. Set up a backup target.
+1. Create a volume and write data in the `1st cluster`. Then create `1st backup`.
+1. Restore the backup as a DR volume in the `2nd cluster`.
+1. Modify the backup poll interval to a large value.
+1. Write more data for the volume in the `1st cluster`, and create the `2nd backup`.
+1. Activate the DR volume in the `2nd cluster`. Then verify the data
+1. The activated DR volume should contain the latest data.


### PR DESCRIPTION
longhorn/longhorn#5292
longhorn/longhorn#7945

#### Which issue(s) this PR fixes:
longhorn/longhorn#5292
longhorn/longhorn#7945

#### What this PR does / why we need it:
Add the manual test case to check synchronization with the backup target during DR volume activation.

#### Special notes for your reviewer:
@shuo-wu 
@jillian-maroket 

#### Additional documentation or context
