### PR TITLE
test: fix flaky test case test_engine_image_daemonset_restart

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2220,10 +2220,10 @@ def wait_for_engine_image_condition(client, image_name, state):
     # This helps to prevent the flaky test case in which the ENGINE_NAME
     # is flapping between ready and not ready a few times before settling
     # down to the ready state
-    # https://github.com/longhorn/longhorn-tests/pull/1638
+    # https://github.com/longhorn/longhorn/issues/7438
     state_count = 1
     if state == "True":
-        state_count = 5
+        state_count = 60
 
     c = 0
     for i in range(RETRY_COUNTS):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/7438

#### What this PR does / why we need it:

Test case `test_engine_image_daemonset_restart` is still flaky after https://github.com/longhorn/longhorn-tests/pull/1642: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6300/, so increase `state_count` to wait longer.
 
#### Special notes for your reviewer:

#### Additional documentation or context
