### PR TITLE
Fix flaky test_volume_metrics

### DIFF
--- a/manager/integration/tests/test_metric.py
+++ b/manager/integration/tests/test_metric.py
@@ -8,6 +8,7 @@ from prometheus_client.parser import text_string_to_metric_families
 from common import client, core_api, volume_name  # NOQA
 
 from common import delete_replica_processes
+from common import check_volume_data
 from common import create_pv_for_volume
 from common import create_pvc_for_volume
 from common import create_snapshot
@@ -194,6 +195,21 @@ def check_metric_sum_on_all_nodes(client, core_api, metric_name, expected_labels
         assert total_metrics["value"] >= 0.0
 
 
+def wait_for_metric_volume_actual_size(core_api, metric_name, metric_labels, actual_size): # NOQA
+    for _ in range(RETRY_COUNTS):
+        time.sleep(RETRY_INTERVAL)
+
+        try:
+            check_metric(core_api, metric_name,
+                         metric_labels, actual_size)
+            return
+        except AssertionError:
+            continue
+
+    check_metric(core_api, metric_name,
+                 metric_labels, actual_size)
+
+
 def wait_for_metric_count_all_nodes(client, core_api, metric_name, metric_labels, expected_count): # NOQA
     for _ in range(RETRY_COUNTS):
         time.sleep(RETRY_INTERVAL)
@@ -271,7 +287,8 @@ def test_volume_metrics(client, core_api, volume_name, pvc_namespace): # NOQA
     volume = client.by_id_volume(volume_name)
     volume.attach(hostId=lht_hostId)
     volume = wait_for_volume_healthy(client, volume_name)
-    write_volume_random_data(volume)
+    data = write_volume_random_data(volume)
+    check_volume_data(volume, data)
     volume = client.by_id_volume(volume_name)
     actual_size = float(volume.controllers[0].actualSize)
     capacity_size = float(volume.size)
@@ -284,8 +301,9 @@ def test_volume_metrics(client, core_api, volume_name, pvc_namespace): # NOQA
     }
 
     # check volume metric basic
-    check_metric(core_api, "longhorn_volume_actual_size_bytes",
-                 metric_labels, actual_size)
+    wait_for_metric_volume_actual_size(core_api,
+                                       "longhorn_volume_actual_size_bytes",
+                                       metric_labels, actual_size)
     check_metric(core_api, "longhorn_volume_capacity_bytes",
                  metric_labels, capacity_size)
     check_metric(core_api, "longhorn_volume_read_throughput",


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue  longhorn/longhorn#7626

#### What this PR does / why we need it:

According to the [fail](https://github.com/longhorn/longhorn/issues/7626#issuecomment-1965757650) scenario on v1.5.x, add loop to check metric `longhorn_volume_actual_size_bytes` value.

#### Special notes for your reviewer:

60 times test result
- [master](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6512/testReport/tests/test_metric/)
- [v1.6.x](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6513/testReport/tests/test_metric/)
- [v1.5.x](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6526/testReport/tests/test_metric/)

#### Additional documentation or context

N/A
