### PR TITLE
ci: delete upgrade test pod

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -341,6 +341,9 @@ run_longhorn_upgrade_test(){
 
   # get upgrade test junit xml report
   kubectl cp ${LONGHORN_UPGRADE_TEST_POD_NAME}:${LONGHORN_JUNIT_REPORT_PATH} "${TF_VAR_tf_workspace}/${LONGHORN_UPGRADE_TEST_POD_NAME}-junit-report.xml" -c longhorn-test-report
+
+  # delete upgrade test pod
+  kubectl delete -f ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
 }
 
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #7521

#### What this PR does / why we need it:

Delete upgrade test pod after receving test report. Otherwise the pod will affect drain test cases because the upgrade test pod does not have a controller to drain normally.

#### Special notes for your reviewer:

```
+ kubectl delete -f /src/longhorn-tests/manager/integration/deploy/upgrade_test.yaml
serviceaccount "longhorn-test-service-account" deleted
clusterrolebinding.rbac.authorization.k8s.io "longhorn-test-bind" deleted
pod "longhorn-test-upgrade-from-stable" deleted
+ LONGHORN_UPGRADE_TYPE=from_transient
+ LONGHORN_UPGRADE_TEST_POD_NAME=longhorn-test-upgrade-from-transient
```
![image](https://github.com/longhorn/longhorn-tests/assets/73337386/8010ce71-278d-4288-b0ab-63936ec44e6b)

#### Additional documentation or context

N/A