### PR TITLE
test: fix flaky test case `test_replica_rebuild_per_volume_limit`

### DIFF
--- a/manager/integration/tests/test_scheduling.py
+++ b/manager/integration/tests/test_scheduling.py
@@ -463,6 +463,7 @@ def test_replica_rebuild_per_volume_limit(client, core_api, storage_class, sts_n
 
     vol = common.wait_for_volume_replicas_mode(client, vol_name, 'RW',
                                                replica_count=r_count)
+    wait_for_volume_healthy(client, vol_name)
 
     # Delete 4 volume replicas
     del vol.replicas[0]


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#8011

#### What this PR does / why we need it:
https://github.com/longhorn/longhorn-tests/blob/master/manager/integration/tests/test_scheduling.py#L443C8-L443C51

Add `wait_for_volume_healthy` before deleting replicas to wait for volume rebuilding to complete, and avoid the error `failed to remove replica: no other healthy replica available`.

#### Special notes for your reviewer:

#### Additional documentation or context
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6439/consoleText

jenkins test result: 
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6442/
![Screenshot_20240229_181942](https://github.com/longhorn/longhorn-tests/assets/104337648/8d913037-cf18-4b7a-8dd0-a52de3a9e569)
 