### PR TITLE
Update title test-kubelet-restart-no-pending-pod-event

### DIFF
--- a/docs/content/manual/release-specific/v1.7.0/test-kubelet-restart-no-pending-pod-event.md
+++ b/docs/content/manual/release-specific/v1.7.0/test-kubelet-restart-no-pending-pod-event.md
@@ -1,5 +1,5 @@
 ---
-Test: restarting Kubelet should not result in repeated "no Pending workload pods ..." event for the workload pod.
+title: restarting Kubelet should not result in repeated "no Pending workload pods ..." event for the workload pod.
 ---
 
 ## Related issues


### PR DESCRIPTION
Updating the title as our frontend of https://longhorn.github.io/longhorn-tests/manual/ framework depends on this text to build the page. A page with no `title` won't appear on the https://longhorn.github.io/longhorn-tests/manual/
Also, using different text breaks our automation to sync the test cases in Qase.

Ref - https://github.com/longhorn/longhorn-tests/actions/runs/8115565903
