### PR TITLE
ci: Update livenessProbe.repository value in Rancher chart

### DIFF
--- a/pipelines/utilities/rancher/terraform_install/main.tf
+++ b/pipelines/utilities/rancher/terraform_install/main.tf
@@ -53,6 +53,8 @@ image:
       repository: ${var.longhorn_repo == "rancher" ? "${var.longhorn_repo}/mirrored-longhornio-" : "${var.longhorn_repo}/"}csi-resizer
     snapshotter:
       repository: ${var.longhorn_repo == "rancher" ? "${var.longhorn_repo}/mirrored-longhornio-" : "${var.longhorn_repo}/"}csi-snapshotter
+    livenessProbe:
+      repository: ${var.longhorn_repo == "rancher" ? "${var.longhorn_repo}/mirrored-longhornio-" : "${var.longhorn_repo}/"}livenessprobe
   longhorn:
     backingImageManager:
       repository: ${var.longhorn_repo == "rancher" ? "${var.longhorn_repo}/mirrored-longhornio-" : "${var.longhorn_repo}/"}backing-image-manager

--- a/pipelines/utilities/rancher/terraform_upgrade/main.tf
+++ b/pipelines/utilities/rancher/terraform_upgrade/main.tf
@@ -41,6 +41,8 @@ image:
       repository: ${var.longhorn_repo == "rancher" ? "${var.longhorn_repo}/mirrored-longhornio-" : "${var.longhorn_repo}/"}csi-resizer
     snapshotter:
       repository: ${var.longhorn_repo == "rancher" ? "${var.longhorn_repo}/mirrored-longhornio-" : "${var.longhorn_repo}/"}csi-snapshotter
+    livenessProbe:
+      repository: ${var.longhorn_repo == "rancher" ? "${var.longhorn_repo}/mirrored-longhornio-" : "${var.longhorn_repo}/"}livenessprobe
   longhorn:
     backingImageManager:
       repository: ${var.longhorn_repo == "rancher" ? "${var.longhorn_repo}/mirrored-longhornio-" : "${var.longhorn_repo}/"}backing-image-manager


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#8095

#### What this PR does / why we need it:
When the `LONGHORN_REPO` is set to `longhornio`, we need to update the `livenessProbe.repository` value to `longhornio/livenessprobe` in the Rancher chart.

#### Special notes for your reviewer:

#### Additional documentation or context
https://github.com/longhorn/longhorn/issues/8095#issuecomment-1977976920