### PR TITLE
fix: check for timeout in wait_deployment_replica_ready and fail if so.

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4783,6 +4783,7 @@ def make_deployment_cpu_request(request):
 
 def wait_deployment_replica_ready(apps_api, deployment_name,
                                   desired_replica_count, namespace='default'):  # NOQA
+    ok = False
     for i in range(DEFAULT_DEPLOYMENT_TIMEOUT):
         deployment = apps_api.read_namespaced_deployment(
             name=deployment_name,
@@ -4791,9 +4792,11 @@ def wait_deployment_replica_ready(apps_api, deployment_name,
         # deployment is none if deployment is not yet created
         if deployment is not None and \
            deployment.status.ready_replicas == desired_replica_count:
+            ok = True
             break
 
         time.sleep(DEFAULT_DEPLOYMENT_INTERVAL)
+    assert ok
 
 
 def create_and_wait_deployment(apps_api, deployment_manifest):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/8183

#### What this PR does / why we need it:

Adds a check for timeout when waiting for deployment to create successfully.

#### Special notes for your reviewer:

#### Additional documentation or context
