### PR TITLE
test(integration/manual): support GKE Container-Optimized OS

### DIFF
--- a/docs/content/manual/release-specific/v1.7.0/test-gke-container-optimized-os-dependency-setup.md
+++ b/docs/content/manual/release-specific/v1.7.0/test-gke-container-optimized-os-dependency-setup.md
@@ -1,0 +1,16 @@
+---
+title: Dependency setup for GKE cluster using Container-Optimized OS as base image
+---
+
+## Related issues
+
+- https://github.com/longhorn/longhorn/issues/6165
+
+## Test step
+
+**Given** GKE cluster using Continer-Optimized OS (`COS_CONTAINER`) as the base image.
+
+**When** Follow [instruction](https://github.com/longhorn/website/pull/884) to deploy the Longhorn GKE COS node agent.
+
+**Then** Follow the [instruction](https://github.com/longhorn/website/pull/884) to verify dependency configuration/setup.  
+**And** Integration tests should pass.

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -273,6 +273,9 @@ DEPRECATED_K8S_ZONE_LABEL = "failure-domain.beta.kubernetes.io/zone"
 
 K8S_ZONE_LABEL = "topology.kubernetes.io/zone"
 
+K8S_GKE_OS_DISTRO_LABEL = "cloud.google.com/gke-os-distribution"
+K8S_GKE_OS_DISTRO_COS = "cos"
+
 K8S_CLUSTER_AUTOSCALER_EVICT_KEY = \
     "cluster-autoscaler.kubernetes.io/safe-to-evict"
 K8S_CLUSTER_AUTOSCALER_SCALE_DOWN_DISABLED_KEY = \
@@ -3365,10 +3368,54 @@ def set_k8s_node_label(core_api, node_name, key, value):
     core_api.patch_node(node_name, body=payload)
 
 
+def is_k8s_node_label(core_api, label_key, label_value, node_name):
+    node = core_api.read_node(node_name)
+
+    if label_key in node.metadata.labels:
+        if node.metadata.labels[label_key] == label_value:
+            return True
+    return False
+
+
 def set_k8s_node_zone_label(core_api, node_name, zone_name):
+    if is_k8s_node_label(core_api, K8S_ZONE_LABEL, zone_name, node_name):
+        return
+
     k8s_zone_label = get_k8s_zone_label()
 
     set_k8s_node_label(core_api, node_name, k8s_zone_label, zone_name)
+
+
+def set_and_wait_k8s_nodes_zone_label(core_api, node_zone_map):
+    k8s_zone_label = get_k8s_zone_label()
+
+    for _ in range(RETRY_COUNTS):
+        for node_name, zone_name in node_zone_map.items():
+            set_k8s_node_label(core_api, node_name, k8s_zone_label, zone_name)
+
+        is_updated = False
+        for node_name, zone_name in node_zone_map.items():
+            is_updated = \
+                is_k8s_node_label(core_api,
+                                  k8s_zone_label, zone_name, node_name)
+            if not is_updated:
+                break
+
+        if is_updated:
+            break
+
+        time.sleep(RETRY_INTERVAL)
+
+    assert is_updated, \
+        f"Timeout while waiting for nodes zone label to be updated\n" \
+        f"Expected: {node_zone_map}"
+
+
+def is_k8s_node_gke_cos(core_api):
+    return is_k8s_node_label(core_api,
+                             K8S_GKE_OS_DISTRO_LABEL,
+                             K8S_GKE_OS_DISTRO_COS,
+                             get_self_host_id())
 
 
 def get_k8s_zone_label():


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#6165

#### What this PR does / why we need it:

- Integration: The `replica_auto_balance_zone` test cases failed when Kubernetes is running on GKE with COS_CONTAINERD. This is because the node zone label is periodically updated with the actual GCP zone. To address this, implement a workaround by refreshing the zone label with each retry iteration to maintain the expected zone label.
- Manual: test dependencies configure/setup.

#### Alternative

Skip zone-related tests when the cluster is running on COS.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
