### PR TITLE
Add test_provisioner_generic_ephemeral skeleton

### DIFF
--- a/manager/integration/tests/test_provisioner.py
+++ b/manager/integration/tests/test_provisioner.py
@@ -63,6 +63,24 @@ def test_provisioner_mount(client, core_api, storage_class, pvc, pod):  # NOQA
     assert volumes.data[0].state == "attached"
 
 
+@pytest.mark.skip(reason="TODO")
+def test_provisioner_generic_ephemeral():
+    """
+    Test that a Longhorn generic ephemeral volume can be created, mounted,
+    unmounted, and deleted properly on the Kubernetes cluster.
+
+    1. Create a StorageClass and Pod with a generic ephemeral volume spec:
+       https://kubernetes.io/docs/concepts/storage/ephemeral-volumes
+    2. Verify:
+       - The Pod is running.
+       - The volume parameters match the StorageClass parameters.
+       - The volume.status.kubernetesStatus.workloadStatus reflects the
+         running Pod.
+    3. Write data to the volume using the Pod, read it back, and verify it.
+    """
+    pass
+
+
 def test_provisioner_params(client, core_api, storage_class, pvc, pod):  # NOQA
     """
     Test that substituting different StorageClass parameters is reflected in


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8198

#### What this PR does / why we need it:

longhorn/longhorn#8198 uncovered the fact that a change had unknowingly broken Longhorn generic ephemeral volumes. We need an automated test to ensure this can't happen in the future.

#### Special notes for your reviewer:

I wasn't really sure if this skeleton fit best in `test_provisioner.py` (since we want to test the ability to provision generic ephemeral volumes) or `test_kubernetes.py`, since the actual change I made in https://github.com/longhorn/longhorn-manager/pull/2701 ensures `volume.status.kubernetesStatus.workloadStatus` was correctly populated by the Longhorn Kuberntes PV controller. I went with my gut, but I'm fine with moving it if QA thinks it makes better sense elsewhere.