### PR TITLE
fix(negative): wait_for_workload_pods_stable

### DIFF
--- a/e2e/libs/workload/workload.py
+++ b/e2e/libs/workload/workload.py
@@ -174,7 +174,7 @@ def wait_for_workload_pods_stable(workload_name, namespace="default"):
                 continue
 
             pod_name = pod.metadata.name
-            if wait_for_stable_retry[pod_name] != WAIT_FOR_POD_STABLE_MAX_RETRY:
+            if wait_for_stable_retry[pod_name] < WAIT_FOR_POD_STABLE_MAX_RETRY:
                 wait_for_stable_pod.append(pod_name)
 
         if len(wait_for_stable_pod) == 0:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8193

#### What this PR does / why we need it:

Check whether the retry count exceeds the `WAIT_FOR_POD_STABLE_MAX_RETRY` instead of verifying the exact match to avoid the loop.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

https://github.com/longhorn/longhorn/issues/8193#issuecomment-2006061894