### PR TITLE
fix: indent of create_deployment_and_write_data

### DIFF
--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -2952,24 +2952,22 @@ def test_drain_with_block_for_eviction_if_contains_last_replica_success(client, 
     # Step 2, 3
     volume1_name = "vol-1"
     volume2_name = "vol-2"
-    volume1, pod1, checksum1, _ = create_deployment_and_write_data(
-                                                                client,
-                                                                core_api,
-                                                                make_deployment_with_pvc, # NOQA
-                                                                volume1_name,
-                                                                str(1 * Gi),
-                                                                3,
-                                                                DATA_SIZE_IN_MB_3, # NOQA
-                                                                host_id) # NOQA
-    volume2, pod2, checksum2, _ = create_deployment_and_write_data(
-                                                                client,
-                                                                core_api,
-                                                                make_deployment_with_pvc,  # NOQA
-                                                                volume2_name,
-                                                                str(1 * Gi),
-                                                                3,
-                                                                DATA_SIZE_IN_MB_3, # NOQA
-                                                                host_id) # NOQA
+    volume1, pod1, checksum1, _ = create_deployment_and_write_data(client,
+                                                                   core_api,
+                                                                   make_deployment_with_pvc, # NOQA
+                                                                   volume1_name, # NOQA
+                                                                   str(1 * Gi),
+                                                                   3,
+                                                                   DATA_SIZE_IN_MB_3, # NOQA
+                                                                   host_id) # NOQA
+    volume2, pod2, checksum2, _ = create_deployment_and_write_data(client,
+                                                                   core_api,
+                                                                   make_deployment_with_pvc,  # NOQA
+                                                                   volume2_name, # NOQA
+                                                                   str(1 * Gi),
+                                                                   3,
+                                                                   DATA_SIZE_IN_MB_3, # NOQA
+                                                                   host_id) # NOQA
     # Make volume 1 replica only located on evict_source_node
     make_replica_on_specific_node(client, volume1_name, evict_source_node)
     volume2_replicas = get_all_replica_name(client, volume2_name)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7859

#### What this PR does / why we need it:

Correct the indent in test case `test_drain_with_block_for_eviction_if_contains_last_replica_success`

#### Special notes for your reviewer:
 
N/A

#### Additional documentation or context

https://github.com/longhorn/longhorn-tests/pull/1823#discussion_r1533532611
