### PR TITLE
test: fix flaky test case `test_ha_backup_deletion_recovery`

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3129,10 +3129,10 @@ def wait_for_backup_volume_backing_image_synced(
     completed = False
     for _ in range(retry_count):
         bv = find_backup_volume(client, volume_name)
-        assert bv is not None
-        if bv.backingImageName == backing_image:
-            completed = True
-            break
+        if bv is not None:
+            if bv.backingImageName == backing_image:
+                completed = True
+                break
         time.sleep(RETRY_BACKUP_INTERVAL)
     assert completed is True, f" Backup Volume = {bv}," \
                               f" Backing Image = {backing_image}," \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#8231

#### What this PR does / why we need it:
Check if the backup volume exists and has been created before proceeding with the backing image synchronization check. 
This addresses the case where the backup volume might not have been created yet.

#### Special notes for your reviewer:

#### Additional documentation or context
amd64 : https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6658/

arm64 : https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6659

![Screenshot_20240322_102156](https://github.com/longhorn/longhorn-tests/assets/104337648/2a648057-3a7d-42ad-bc58-ffca86e59e7c)
