### PR TITLE
Fix flaky test_node_metrics

### DIFF
--- a/manager/integration/tests/test_metric.py
+++ b/manager/integration/tests/test_metric.py
@@ -23,6 +23,7 @@ from common import wait_for_volume_healthy
 from common import write_volume_data
 from common import set_node_scheduling
 from common import set_node_cordon
+from common import wait_for_node_update
 from common import Mi
 from common import LONGHORN_NAMESPACE
 from common import RETRY_COUNTS
@@ -537,5 +538,6 @@ def test_node_metrics(client, core_api): # NOQA
         "node": lht_hostId
     }
     set_node_cordon(core_api, lht_hostId, True)
+    wait_for_node_update(client, lht_hostId, "allowScheduling", False)
     check_metric_with_condition(core_api, "longhorn_node_status",
                                 metric_labels, 0.0)


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix flaky [test_node_metrics](https://ci.longhorn.io/job/public/job/master/job/sles/job/amd64/job/longhorn-tests-sles-amd64/862/testReport/junit/tests/test_metric/test_node_metrics/)

```
found_metric = Sample(name='longhorn_node_status', labels={'condition': 'schedulable', 'condition_reason': '', 'node': 'ip-10-0-2-55'}, value=1.0, timestamp=None, exemplar=None)
metric_labels = {'condition': 'schedulable', 'condition_reason': 'KubernetesNodeCordoned', 'node': 'ip-10-0-2-55'}
expected_value = 0.0

    def examine_metric_value(found_metric, metric_labels, expected_value=None):
        for key, value in metric_labels.items():
>           assert found_metric.labels[key] == value
E           AssertionError: assert '' == 'KubernetesNodeCordoned'
E             - KubernetesNodeCordoned

test_metric.py:125: AssertionError
```
Add `wait_for_node_update(client, lht_hostId, "allowScheduling", False)` make sure Longhorn node cordoned before check  Longhorn metric `longhorn_node_status`.

#### Special notes for your reviewer:

200 times test result
- https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6675/testReport/tests/test_metric/
- https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6677/testReport/tests/test_metric/

#### Additional documentation or context
