### PR TITLE
fix: flaky test_volume_metircs

### DIFF
--- a/manager/integration/tests/test_metric.py
+++ b/manager/integration/tests/test_metric.py
@@ -29,6 +29,7 @@ from common import LONGHORN_NAMESPACE
 from common import RETRY_COUNTS
 from common import RETRY_INTERVAL
 from common import DEFAULT_DISK_PATH
+from common import Gi
 
 # The dictionaries use float type of value because the value obtained from
 # prometheus_client is in float type.
@@ -194,9 +195,11 @@ def check_metric_sum_on_all_nodes(client, core_api, metric_name, expected_labels
         assert total_metrics["value"] >= 0.0
 
 
-def wait_for_metric_volume_actual_size(core_api, metric_name, metric_labels, actual_size): # NOQA
+def wait_for_metric_volume_actual_size(client, core_api, metric_name, metric_labels, volume_name): # NOQA
     for _ in range(RETRY_COUNTS):
         time.sleep(RETRY_INTERVAL)
+        volume = client.by_id_volume(volume_name)
+        actual_size = int(volume.controllers[0].actualSize)
 
         try:
             check_metric(core_api, metric_name,
@@ -273,7 +276,7 @@ def test_volume_metrics(client, core_api, volume_name, pvc_namespace): # NOQA
     lht_hostId = get_self_host_id()
     pv_name = volume_name + "-pv"
     pvc_name = volume_name + "-pvc"
-    volume_size = str(500 * Mi)
+    volume_size = str(1 * Gi)
     volume = create_and_check_volume(client,
                                      volume_name,
                                      num_of_replicas=3,
@@ -286,7 +289,7 @@ def test_volume_metrics(client, core_api, volume_name, pvc_namespace): # NOQA
     volume = client.by_id_volume(volume_name)
     volume.attach(hostId=lht_hostId)
     volume = wait_for_volume_healthy(client, volume_name)
-    data_size = 1 * Mi
+    data_size = 100 * Mi
     data = {'pos': 0,
             'len': data_size,
             'content': generate_random_data(data_size)}
@@ -302,9 +305,9 @@ def test_volume_metrics(client, core_api, volume_name, pvc_namespace): # NOQA
     }
 
     # check volume metric basic
-    wait_for_metric_volume_actual_size(core_api,
+    wait_for_metric_volume_actual_size(client, core_api,
                                        "longhorn_volume_actual_size_bytes",
-                                       metric_labels, data_size)
+                                       metric_labels, volume_name)
     check_metric(core_api, "longhorn_volume_capacity_bytes",
                  metric_labels, capacity_size)
     check_metric(core_api, "longhorn_volume_read_throughput",


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8268

#### What this PR does / why we need it:

Test case flaky due to sometimes `delete_replica_processes` not make volume faulted. Add retry to make sure volume faulted before check Longhorn metric.

#### Special notes for your reviewer:

100 times test result on [master](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6687/ ) and [v1.6.x](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6689/)

#### Additional documentation or context

N/A