### PR TITLE
fix: fix failed test_instance_manager_cpu_reservation

### DIFF
--- a/manager/integration/tests/test_settings.py
+++ b/manager/integration/tests/test_settings.py
@@ -439,7 +439,7 @@ def test_instance_manager_cpu_reservation(client, core_api):  # NOQA
 
     with pytest.raises(Exception) as e:
         client.update(im_setting, value="41")
-    assert "should be between 0 to 40" in \
+    assert "should be less than 40" in \
            str(e.value)
 
     # Create a volume to test


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8318

#### What this PR does / why we need it:

Fix failed test case [test_instance_manager_cpu_reservation](https://ci.longhorn.io/job/public/job/master/job/sles/job/amd64/job/longhorn-tests-sles-amd64/880/testReport/junit/tests/test_settings/test_instance_manager_cpu_reservation/)

#### Special notes for your reviewer:

N/A

#### Additional documentation or context
