### PR TITLE
ci: fix go tool cover error: go.mod requires go >= 1.22.2

### DIFF
--- a/test_framework/Dockerfile.setup
+++ b/test_framework/Dockerfile.setup
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.19
+FROM golang:1.22-alpine3.19
 
 ARG KUBECTL_VERSION=v1.20.2
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/7166

#### What this PR does / why we need it:

fix go tool cover error: go.mod requires go >= 1.22.2

#### Special notes for your reviewer:

#### Additional documentation or context
