### PR TITLE
test(robot): add storageclass for different replica count

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -12,6 +12,7 @@ Library             ../libs/keywords/workload_keywords.py
 Library             ../libs/keywords/persistentvolumeclaim_keywords.py
 Library             ../libs/keywords/network_keywords.py
 Library             ../libs/keywords/backupstore_keywords.py
+Library             ../libs/keywords/storageclass_keywords.py
 
 *** Keywords ***
 Set test environment

--- a/e2e/keywords/storageclass.resource
+++ b/e2e/keywords/storageclass.resource
@@ -1,0 +1,12 @@
+*** Settings ***
+Documentation    Storageclass Keywords
+
+Library    Collections
+Library    ../libs/keywords/common_keywords.py
+Library    ../libs/keywords/storageclass_keywords.py
+
+*** Keywords ***
+Create storageclass ${storageclass_id} with
+    [Arguments]    &{config}
+    ${storageclass_name} =    generate_name_with_suffix    storageclass    ${storageclass_id}
+    create_storageclass   ${storageclass_name}    &{config}

--- a/e2e/libs/keywords/storageclass_keywords.py
+++ b/e2e/libs/keywords/storageclass_keywords.py
@@ -1,0 +1,23 @@
+from utility.utility import logging
+from storageclass.storageclass import create
+from storageclass.storageclass import delete
+from storageclass.storageclass import delete_all
+
+class storageclass_keywords:
+
+    def __init__(self):
+        pass
+
+    def init_storageclasses(self):
+        create('longhorn-test')
+        create('longhorn-test-strict-local', replica_count="1", data_locality='strict-local')
+
+    def create_storageclass(self, name, replica_count="", migratable="", data_locality="", from_backup=""):
+        logging(f'Creating storageclass {name}')
+        create(name, replica_count, migratable, data_locality, from_backup)
+
+    def delete_storageclass(self, name):
+        delete(name)
+
+    def cleanup_storageclasses(self):
+        delete_all()

--- a/e2e/libs/keywords/workload_keywords.py
+++ b/e2e/libs/keywords/workload_keywords.py
@@ -8,8 +8,6 @@ from persistentvolumeclaim import PersistentVolumeClaim
 
 from workload.pod import get_volume_name_by_pod
 from workload.workload import check_pod_data_checksum
-from workload.workload import create_storageclass
-from workload.workload import delete_storageclass
 from workload.workload import get_workload_pod_names
 from workload.workload import get_workload_persistent_volume_claim_name
 from workload.workload import get_workload_volume_name
@@ -35,14 +33,6 @@ class workload_keywords:
 
         self.persistentvolumeclaim = PersistentVolumeClaim()
         self.volume = Volume()
-
-    def init_storageclasses(self):
-        create_storageclass('longhorn-test')
-        create_storageclass('longhorn-test-strict-local')
-
-    def cleanup_storageclasses(self):
-        delete_storageclass('longhorn-test')
-        delete_storageclass('longhorn-test-strict-local')
 
     def check_pod_data_checksum(self, expected_checksum, pod_name, file_name):
         logging(f'Checking checksum for file {file_name} in pod {pod_name}')

--- a/e2e/libs/storageclass/__init__.py
+++ b/e2e/libs/storageclass/__init__.py
@@ -1,0 +1,1 @@
+from storageclass import storageclass

--- a/e2e/libs/storageclass/storageclass.py
+++ b/e2e/libs/storageclass/storageclass.py
@@ -1,0 +1,42 @@
+import yaml
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+from kubernetes.stream import stream
+
+
+def create(name, replica_count="", migratable="", data_locality="", from_backup=""):
+    filepath = "./templates/workload/storageclass.yaml"
+
+    with open(filepath, 'r') as f:
+        manifest_dict = yaml.safe_load(f)
+        manifest_dict['metadata']['name'] = name
+        
+        if replica_count != "":
+             manifest_dict['parameters']['numberOfReplicas'] = replica_count
+        if migratable != "":
+            manifest_dict['parameters']['migratable'] = migratable
+        if data_locality != "":
+            manifest_dict['parameters']['dataLocality'] = data_locality
+        if from_backup != "":
+            manifest_dict['parameters']['fromBackup'] = from_backup
+        
+        api = client.StorageV1Api()
+        api.create_storage_class(body=manifest_dict)
+
+
+def delete(name):
+    api = client.StorageV1Api()
+    try:
+        api.delete_storage_class(name, grace_period_seconds=0)
+    except ApiException as e:
+        assert e.status == 404
+
+
+def delete_all():
+    api = client.StorageV1Api()
+    storage_classes = api.list_storage_class()
+
+    for item in storage_classes.items:
+        if "longhorn-test" in item.metadata.name:
+            delete(item.metadata.name)

--- a/e2e/libs/utility/constant.py
+++ b/e2e/libs/utility/constant.py
@@ -8,6 +8,7 @@ ANNOT_CHECKSUM = f'{LABEL_TEST}/last-recorded-checksum'
 ANNOT_EXPANDED_SIZE = f'{LABEL_TEST}/last-recorded-expanded-size'
 
 NAME_PREFIX = 'e2e-test'
+STORAGECLASS_NAME_PREFIX = 'longhorn-test'
 
 STREAM_EXEC_TIMEOUT = 300
 

--- a/e2e/libs/utility/utility.py
+++ b/e2e/libs/utility/utility.py
@@ -18,6 +18,7 @@ from kubernetes.client.rest import ApiException
 
 from utility.constant import NAME_PREFIX
 from utility.constant import STREAM_EXEC_TIMEOUT
+from utility.constant import STORAGECLASS_NAME_PREFIX
 
 
 class timeout:
@@ -57,7 +58,10 @@ def generate_name_random(name_prefix="test-"):
 
 
 def generate_name_with_suffix(kind, suffix):
-    return f"{NAME_PREFIX}-{kind}-{suffix}"
+    if kind == "storageclass":
+        return f"{STORAGECLASS_NAME_PREFIX}-{suffix}"
+    else:
+        return f"{NAME_PREFIX}-{kind}-{suffix}"
 
 
 def init_k8s_api_client():

--- a/e2e/libs/workload/workload.py
+++ b/e2e/libs/workload/workload.py
@@ -1,34 +1,12 @@
 import time
-import yaml
 
 from kubernetes import client
-from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream
 
 from utility.utility import get_retry_count_and_interval
 from utility.utility import logging
 
 from workload.constant import WAIT_FOR_POD_STABLE_MAX_RETRY
-
-
-def create_storageclass(name):
-    if name == 'longhorn-test-strict-local':
-        filepath = "./templates/workload/strict_local_storageclass.yaml"
-    else:
-        filepath = "./templates/workload/storageclass.yaml"
-
-    with open(filepath, 'r') as f:
-        manifest_dict = yaml.safe_load(f)
-        api = client.StorageV1Api()
-        api.create_storage_class(body=manifest_dict)
-
-
-def delete_storageclass(name):
-    api = client.StorageV1Api()
-    try:
-        api.delete_storage_class(name, grace_period_seconds=0)
-    except ApiException as e:
-        assert e.status == 404
 
 
 def get_workload_pod_names(workload_name):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#8440

#### What this PR does / why we need it:

Create 1 replica storageclass `longhorn-test-1-replica` and 2 replicas storageclass `longhorn-test-2-replicas` at test step for PVC use

#### Special notes for your reviewer:

Local test code

```robot 
*** Test Cases ***
Replica Test
    Given Create persistentvolumeclaim 0 using RWO volume
    And Create persistentvolumeclaim 1 using RWO volume with 1-replica storageclass
    And Create persistentvolumeclaim 2 using RWO volume with 2-replicas storageclass

    And Create deployment 0 with persistentvolumeclaim 0
    And Create deployment 1 with persistentvolumeclaim 1
    And Create deployment 2 with persistentvolumeclaim 2
```

#### Additional documentation or context

[report.zip](https://github.com/longhorn/longhorn-tests/files/15127237/report.zip)
