### PR TITLE
ci: fix unable to specify custom longhorn repo

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -155,7 +155,7 @@ get_longhorn_manifest(){
 get_longhorn_chart(){
   git clone --single-branch \
             --branch "${LONGHORN_REPO_BRANCH}" \
-            "${LONGHORN_REPO_URL}" \
+            "${LONGHORN_REPO_URI}" \
             "${LONGHORN_REPO_DIR}"
 }
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix unable to specify custom longhorn repo

#### Special notes for your reviewer:

#### Additional documentation or context
