### PR TITLE
test(robot): correct the downtime unit in host_keywords

### DIFF
--- a/e2e/libs/keywords/host_keywords.py
+++ b/e2e/libs/keywords/host_keywords.py
@@ -30,23 +30,23 @@ class host_keywords:
 
     def reboot_node_by_index(self, idx, power_off_time_in_min=1):
         node_name = self.node.get_node_by_index(idx)
-        reboot_down_time_min = int(power_off_time_in_min) * 60
+        reboot_down_time_sec = int(power_off_time_in_min) * 60
 
-        logging(f'Rebooting node {node_name} with downtime {reboot_down_time_min} minutes')
-        self.host.reboot_node(node_name, reboot_down_time_min)
+        logging(f'Rebooting node {node_name} with downtime {power_off_time_in_min} minutes')
+        self.host.reboot_node(node_name, reboot_down_time_sec)
 
     def reboot_all_worker_nodes(self, power_off_time_in_min=1):
-        reboot_down_time_min = int(power_off_time_in_min) * 60
+        reboot_down_time_sec = int(power_off_time_in_min) * 60
 
-        logging(f'Rebooting all worker nodes with downtime {reboot_down_time_min} minutes')
-        self.host.reboot_all_worker_nodes(reboot_down_time_min)
+        logging(f'Rebooting all worker nodes with downtime {power_off_time_in_min} minutes')
+        self.host.reboot_all_worker_nodes(reboot_down_time_sec)
 
     def reboot_all_nodes(self):
         logging(f'Rebooting all nodes with downtime {NODE_REBOOT_DOWN_TIME_SECOND} seconds')
         self.host.reboot_all_nodes()
 
     def reboot_node_by_name(self, node_name, downtime_in_min=1):
-        reboot_down_time_min = int(downtime_in_min) * 60
+        reboot_down_time_sec = int(downtime_in_min) * 60
 
-        logging(f'Rebooting node {node_name} with downtime {reboot_down_time_min} minutes')
-        self.host.reboot_node(node_name, reboot_down_time_min)
+        logging(f'Rebooting node {node_name} with downtime {downtime_in_min} minutes')
+        self.host.reboot_node(node_name, reboot_down_time_sec)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

More precisely to show node down time, currenly the minute of downtime in log is not accurate.

#### What this PR does / why we need it:

N/A

#### Special notes for your reviewer:

N/A

#### Additional documentation or context

N/A