### PR TITLE
test(robot): add single replica node down cases

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -37,3 +37,7 @@ Cleanup test resources
     cleanup_backupstore
     cleanup_disks
     cleanup_backing_images
+
+Cleanup test resources include off nodes
+    Power on off node
+    Cleanup test resources

--- a/e2e/keywords/host.resource
+++ b/e2e/keywords/host.resource
@@ -33,3 +33,7 @@ Power off all worker nodes for ${power_off_time_in_min} mins
 Restart cluster
     reboot_all_nodes
     setup_control_plane_network_latency
+
+Power on off node
+    Run keyword And Continue On Failure
+    ...    power_on_node_by_name    ${powered_off_node}

--- a/e2e/keywords/persistentvolumeclaim.resource
+++ b/e2e/keywords/persistentvolumeclaim.resource
@@ -4,6 +4,7 @@ Documentation    PersistentVolumeClaim Keywords
 Library    Collections
 Library    ../libs/keywords/common_keywords.py
 Library    ../libs/keywords/persistentvolumeclaim_keywords.py
+Library    ../libs/keywords/volume_keywords.py
 
 *** Keywords ***
 Create persistentvolumeclaim ${claim_id} using ${volume_type} volume

--- a/e2e/keywords/statefulset.resource
+++ b/e2e/keywords/statefulset.resource
@@ -4,6 +4,7 @@ Documentation    StatefulSet Keywords
 Library    Collections
 Library    ../libs/keywords/common_keywords.py
 Library    ../libs/keywords/statefulset_keywords.py
+Library    ../libs/keywords/volume_keywords.py
 
 *** Keywords ***
 Create statefulset ${statefulset_id} using ${volume_type} volume

--- a/e2e/keywords/workload.resource
+++ b/e2e/keywords/workload.resource
@@ -20,6 +20,15 @@ Power off volume node of ${workload_kind} ${workload_id} for ${duration} minutes
     ${node_name} =    get_volume_node    ${volume_name}
     reboot_node_by_name    ${node_name}    ${duration}
 
+Power off volume node of ${workload_kind} ${workload_id}
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    ${powered_off_node} =    get_volume_node    ${volume_name}
+    ${last_volume_node} =    get_volume_node    ${volume_name}
+    power_off_volume_node    ${volume_name}
+    Set Test Variable    ${powered_off_node}
+    Set Test Variable    ${last_volume_node}
+
 Reboot volume node of ${workload_kind} ${workload_id}
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${volume_name} =    get_workload_volume_name    ${workload_name}
@@ -57,6 +66,21 @@ Wait for volume of ${workload_kind} ${workload_id} attached and unknown
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${volume_name} =    get_workload_volume_name    ${workload_name}
     wait_for_volume_unknown    ${volume_name}
+
+Wait for volume of ${workload_kind} ${workload_id} faulted
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    wait_for_volume_faulted    ${volume_name}
+
+Wait for volume of ${workload_kind} ${workload_id} attaching
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    wait_for_volume_attaching    ${volume_name}
+
+Wait for volume of ${workload_kind} ${workload_id} stuck in state attaching
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    wait_for_volume_stuck_attaching    ${volume_name}
 
 Wait for volume of ${workload_kind} ${workload_id} attached and degraded
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
@@ -96,3 +120,37 @@ Wait for workloads pods stable
         Append To List    ${workload_list}    ${workload_name}
     END
     wait_for_workloads_pods_stably_running    ${workload_list}
+
+Delete replica of ${workload_kind} ${workload_id} volume on all ${replica_locality}
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    delete_replica_on_nodes    ${volume_name}    ${replica_locality}
+
+Update volume of ${workload_kind} ${workload_id} replica count to ${replica_count}
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    update_volume_spec    ${volume_name}    numberOfReplicas    ${replica_count}
+
+Wait for ${workload_kind} ${workload_id} pod stuck in ${expect_state} on the original node
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${pod} =     wait_for_pod_kept_in_state    ${workload_name}    ${expect_state}
+    ${node_name} =    get_pod_node    ${pod}
+    Should Be Equal    ${node_name}    ${last_volume_node}
+
+Wait for ${workload_kind} ${workload_id} pod stuck in ${expect_state} on another node
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${pod} =     wait_for_pod_kept_in_state    ${workload_name}    ${expect_state}
+    ${node_name} =    get_pod_node    ${pod}
+    Should Not Be Equal    ${node_name}    ${last_volume_node}
+
+Check ${workload_kind} ${workload_id} pod is ${expect_state} on the original node
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${pod} =     wait_for_pod_kept_in_state    ${workload_name}    ${expect_state}
+    ${node_name} =    get_pod_node    ${pod}
+    Should Be Equal    ${node_name}    ${last_volume_node}
+
+Check ${workload_kind} ${workload_id} pod is ${expect_state} on another node
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${pod} =     wait_for_pod_kept_in_state    ${workload_name}    ${expect_state}
+    ${node_name} =    get_pod_node    ${pod}
+    Should Not Be Equal    ${node_name}    ${last_volume_node}

--- a/e2e/libs/host/host.py
+++ b/e2e/libs/host/host.py
@@ -75,3 +75,22 @@ class Host:
         waiter = self.aws_client.get_waiter('instance_running')
         waiter.wait(InstanceIds=instance_ids)
         logging(f"Started instances")
+
+    def power_off_node(self, power_off_node_name):
+        instance_ids = [self.mapping[power_off_node_name]]
+        resp = self.aws_client.stop_instances(InstanceIds=instance_ids, Force=True)
+        assert resp['ResponseMetadata']['HTTPStatusCode'] == 200, f"Failed to stop instances {instance_ids} response: {resp}"
+        logging(f"Stopping instances {instance_ids}")
+        waiter = self.aws_client.get_waiter('instance_stopped')
+        waiter.wait(InstanceIds=instance_ids)
+        logging(f"Stopped instances")
+
+    def power_on_node(self, power_on_node_name):
+        instance_ids = [self.mapping[power_on_node_name]]
+
+        resp = self.aws_client.start_instances(InstanceIds=instance_ids)
+        logging(f"Starting instances {instance_ids} response: {resp}")
+        waiter = self.aws_client.get_waiter('instance_running')
+        waiter.wait(InstanceIds=instance_ids)
+        logging(f"Started instances")
+

--- a/e2e/libs/keywords/host_keywords.py
+++ b/e2e/libs/keywords/host_keywords.py
@@ -38,3 +38,11 @@ class host_keywords:
 
         logging(f'Rebooting node {node_name} with downtime {reboot_down_time_sec} seconds')
         self.host.reboot_node(node_name, reboot_down_time_sec)
+
+    def power_off_volume_node(self, volume_name):
+        node_id = self.volume_keywords.get_node_id_by_replica_locality(volume_name, "volume node")
+        logging(f'Power off volume {volume_name} node {node_id}')
+        self.host.power_off_node(node_id)
+
+    def power_on_node_by_name(self, node_name):
+        self.host.power_on_node(node_name)

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -108,6 +108,14 @@ class volume_keywords:
         logging(f"Deleting volume {volume_name}'s replica on node {node_name}")
         self.volume.delete_replica(volume_name, node_name)
 
+    def delete_replica_on_nodes(self, volume_name, replica_locality):
+        check_replica_locality(replica_locality)
+
+        node_ids = self.get_node_ids_by_replica_locality(volume_name, replica_locality)        
+        for node_id in node_ids:
+            logging(f"Deleting volume {volume_name}'s replica on node {node_id}")
+            self.volume.delete_replica(volume_name, node_id)
+
     def set_annotation(self, volume_name, annotation_key, annotation_value):
         self.volume.set_annotation(volume_name, annotation_key, annotation_value)
 
@@ -204,6 +212,18 @@ class volume_keywords:
         logging(f'Waiting for volume {volume_name} to be healthy')
         self.volume.wait_for_volume_healthy(volume_name)
 
+    def wait_for_volume_attaching(self, volume_name):
+        logging(f'Waiting for volume {volume_name} to be in attaching')
+        self.volume.wait_for_volume_attaching(volume_name)
+
+    def wait_for_volume_stuck_attaching(self, volume_name):
+        logging(f'Waiting for volume {volume_name} to be stuck at attaching')
+        self.volume.wait_for_volume_stuck_attaching(volume_name)
+
+    def wait_for_volume_faulted(self, volume_name):
+        logging(f'Waiting for volume {volume_name} to be in faulted')
+        self.volume.wait_for_volume_faulted(volume_name)
+
     def wait_for_volume_migration_ready(self, volume_name):
         logging(f'Waiting for volume {volume_name} migration to be ready')
         self.volume.wait_for_volume_migration_ready(volume_name)
@@ -220,3 +240,6 @@ class volume_keywords:
 
     def wait_for_volume_unknown(self, volume_name):
         self.volume.wait_for_volume_unknown(volume_name)
+
+    def update_volume_spec(self, volume_name, key, value):
+        self.volume.update_volume_spec(volume_name, key, value)

--- a/e2e/libs/keywords/workload_keywords.py
+++ b/e2e/libs/keywords/workload_keywords.py
@@ -12,10 +12,14 @@ from workload.workload import keep_writing_pod_data
 from workload.workload import write_pod_random_data
 from workload.workload import wait_for_workload_pods_running
 from workload.workload import wait_for_workload_pods_stable
+from workload.workload import wait_for_workload_pod_kept_in_state
+from workload.workload import get_pod_node
 
 from utility.constant import ANNOT_CHECKSUM
 from utility.constant import ANNOT_EXPANDED_SIZE
 from utility.utility import logging
+from node.utility import check_replica_locality
+from node.node import Node
 
 from volume import Volume
 from volume.constant import MEBIBYTE
@@ -121,3 +125,10 @@ class workload_keywords:
         logging(f'Waiting for {workload_name} volume {volume_name} to expand to {expanded_size}')
         self.volume.wait_for_volume_expand_to_size(volume_name, expanded_size)
         self.volume.wait_for_volume_detached(volume_name)
+
+    def wait_for_pod_kept_in_state(self, workload_name, expect_state, namespace="default"):
+        assert expect_state in ["Terminating", "ContainerCreating", "Running"], f"Unknown expected pod state: {expect_state}: "
+        return wait_for_workload_pod_kept_in_state(workload_name, expect_state, namespace=namespace)
+
+    def get_pod_node(self, pod):
+        return get_pod_node(pod)

--- a/e2e/libs/persistentvolumeclaim/crd.py
+++ b/e2e/libs/persistentvolumeclaim/crd.py
@@ -71,3 +71,7 @@ class CRD():
             logging(f"Exception when expanding PVC: {e}")
 
         return size
+
+    def get_volume_name(self, claim_name, claim_namespace):
+        claim = self.get(claim_name, claim_namespace)        
+        return claim.spec.volume_name

--- a/e2e/libs/persistentvolumeclaim/persistentvolumeclaim.py
+++ b/e2e/libs/persistentvolumeclaim/persistentvolumeclaim.py
@@ -94,3 +94,6 @@ class PersistentVolumeClaim():
         logging(f"Expanding PVC {claim_name} from {current_size} to {target_size}")
         expanded_size = self.claim.expand(claim_name, target_size)
         self.set_annotation(claim_name, ANNOT_EXPANDED_SIZE, str(expanded_size))
+
+    def get_volume_name(self, claim_name, claim_namespace):
+        return self.claim.get_volume_name(claim_name, claim_namespace)

--- a/e2e/libs/volume/rest.py
+++ b/e2e/libs/volume/rest.py
@@ -185,3 +185,6 @@ class Rest(Base):
 
     def cleanup(self, volume_names):
         return NotImplemented
+
+    def update_volume_spec(self, volume_name, key, value):
+        return NotImplemented

--- a/e2e/libs/volume/volume.py
+++ b/e2e/libs/volume/volume.py
@@ -55,6 +55,16 @@ class Volume(Base):
     def wait_for_volume_detached(self, volume_name):
         self.volume.wait_for_volume_state(volume_name, "detached")
 
+    def wait_for_volume_attaching(self, volume_name):
+        self.volume.wait_for_volume_state(volume_name, "attaching")
+
+    def wait_for_volume_stuck_attaching(self, volume_name):
+        self.volume.wait_for_volume_keep_in_state(volume_name, "attaching")
+
+    def wait_for_volume_faulted(self, volume_name):
+        self.volume.wait_for_volume_state(volume_name, "detached")
+        self.volume.wait_for_volume_robustness(volume_name, "faulted")
+
     def wait_for_volume_healthy(self, volume_name):
         self.volume.wait_for_volume_state(volume_name, "attached")
         self.volume.wait_for_volume_robustness(volume_name, "healthy")
@@ -106,3 +116,5 @@ class Volume(Base):
     def validate_volume_replicas_anti_affinity(self, volume_name):
         return self.volume.validate_volume_replicas_anti_affinity(volume_name)
 
+    def update_volume_spec(self, volume_name, key, value):
+        return self.volume.update_volume_spec(volume_name, key, value)

--- a/e2e/libs/workload/constant.py
+++ b/e2e/libs/workload/constant.py
@@ -3,3 +3,4 @@ IMAGE_LITMUX = 'litmuschaos/go-runner:latest'
 IMAGE_UBUNTU = 'ubuntu:16.04'
 
 WAIT_FOR_POD_STABLE_MAX_RETRY = 120
+WAIT_FOR_POD_KEPT_IN_STATE_TIME = 30

--- a/e2e/libs/workload/workload.py
+++ b/e2e/libs/workload/workload.py
@@ -8,6 +8,7 @@ from utility.utility import logging
 
 from workload.pod import is_pod_terminated_by_kubelet
 from workload.constant import WAIT_FOR_POD_STABLE_MAX_RETRY
+from workload.constant import WAIT_FOR_POD_KEPT_IN_STATE_TIME
 
 
 def get_workload_pod_names(workload_name):
@@ -193,3 +194,35 @@ async def wait_for_workload_pods_stable(workload_name, namespace="default"):
         await asyncio.sleep(retry_interval)
 
     assert False, f"Timeout waiting for {workload_name} pods {wait_for_stable_pod} stable)"
+
+def wait_for_workload_pod_kept_in_state(workload_name, expect_state, namespace="default"):
+    def count_pod_in_specifc_state_duration(count_pod_in_state_duration, pods, expect_state):
+        for pod in pods:
+            pod_name = pod.metadata.name
+            if pod_name not in count_pod_in_state_duration:
+                count_pod_in_state_duration[pod_name] = 0
+            elif (expect_state == "ContainerCreating" and pod.status.phase == "Pending") or \
+                ((expect_state == "Terminating" and hasattr(pod.metadata, "deletion_timestamp") and pod.status.phase == "Running")) or \
+                (expect_state == "Running" and pod.status.phase == "Running"):
+                count_pod_in_state_duration[pod_name] += 1
+            else:
+                count_pod_in_state_duration[pod_name] = 0
+
+    retry_count, retry_interval = get_retry_count_and_interval()
+    count_pod_in_state_duration = {}
+
+    for i in range(retry_count):
+        pods = get_workload_pods(workload_name, namespace=namespace)
+        if len(pods) > 0:
+            count_pod_in_specifc_state_duration(count_pod_in_state_duration, pods, expect_state)
+            for pod in pods:
+                logging(f'Waiting for workload {workload_name} pod kept in {expect_state}')
+                if count_pod_in_state_duration[pod.metadata.name] > WAIT_FOR_POD_KEPT_IN_STATE_TIME:
+                    logging(f'Found pod {pod.metadata.name} kept in {expect_state}')
+                    return pod
+        time.sleep(retry_interval)
+
+    assert False, f"Timeout waiting for {workload_name} pod in state: {expect_state})"
+
+def get_pod_node(pod):
+    return pod.spec.node_name

--- a/e2e/templates/workload/statefulset.yaml
+++ b/e2e/templates/workload/statefulset.yaml
@@ -34,6 +34,8 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: pod-data
+      labels:
+        test.longhorn.io: e2e
     spec:
       accessModes:
       - ReadWriteOnce

--- a/e2e/tests/test_cases/single_replica_node_down.robot
+++ b/e2e/tests/test_cases/single_replica_node_down.robot
@@ -1,0 +1,135 @@
+*** Settings ***
+Documentation    Single replica node down
+...              https://longhorn.github.io/longhorn-tests/manual/pre-release/node-not-ready/node-down/single-replica-node-down/
+
+Test Tags    manual_test_case
+
+Resource    ../keywords/common.resource
+Resource    ../keywords/deployment.resource
+Resource    ../keywords/persistentvolumeclaim.resource
+Resource    ../keywords/recurringjob.resource
+Resource    ../keywords/statefulset.resource
+Resource    ../keywords/volume.resource
+Resource    ../keywords/setting.resource
+Resource    ../keywords/setting.resource
+Resource    ../keywords/workload.resource
+Resource    ../keywords/host.resource
+
+Test Setup    Set test environment
+Test Teardown    Cleanup test resources include off nodes
+
+*** Variables ***
+${LOOP_COUNT}    1
+${RETRY_COUNT}    300
+${RETRY_INTERVAL}    1
+
+*** Test Cases ***
+Single Replica Node Down Deletion Policy do-nothing With RWO Volume Replica Locate On Replica Node
+    Given Set setting node-down-pod-deletion-policy to do-nothing
+    When Create persistentvolumeclaim 0 using RWO volume
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Write 100 MB data to file data in deployment 0
+
+    # Delete replicas to have the volume with its only replica located on different nodes.
+    And Update volume of deployment 0 replica count to 1
+    And Delete replica of deployment 0 volume on replica node
+    And Delete replica of deployment 0 volume on volume node
+    And Power off volume node of deployment 0
+    Then Wait for volume of deployment 0 stuck in state attaching
+    And Wait for deployment 0 pod stuck in Terminating on the original node
+
+    When Power on off node
+    And Wait for deployment 0 pods stable
+    And Check deployment 0 pod is Running on another node
+    Then Check deployment 0 data in file data is intact
+
+Single Replica Node Down Deletion Policy do-nothing With RWO Volume Replica Locate On Volume Node
+    Given Set setting node-down-pod-deletion-policy to do-nothing
+
+    When Create persistentvolumeclaim 0 using RWO volume
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Write 100 MB data to file data in deployment 0
+
+    # Delete replicas to have the volume with its only replica located on the same node.
+    And Update volume of deployment 0 replica count to 1
+    And Delete replica of deployment 0 volume on all replica node
+    And Power off volume node of deployment 0
+    Then Wait for volume of deployment 0 faulted
+    And Wait for deployment 0 pod stuck in Terminating on the original node
+
+    When Power on off node
+    And Wait for deployment 0 pods stable
+    And Check deployment 0 pod is Running on the original node
+    Then Check deployment 0 data in file data is intact
+
+Single Replica Node Down Deletion Policy delete-deployment-pod With RWO Volume Replica Locate On Replica Node
+    Given Set setting node-down-pod-deletion-policy to delete-deployment-pod
+
+    When Create persistentvolumeclaim 0 using RWO volume
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Write 100 MB data to file data in deployment 0
+
+    # Delete replicas to have the volume with its only replica located on different nodes.
+    And Update volume of deployment 0 replica count to 1
+    And Delete replica of deployment 0 volume on replica node
+    And Delete replica of deployment 0 volume on volume node
+    And Power off volume node of deployment 0
+    Then Wait for volume of deployment 0 attaching
+
+    And Wait for deployment 0 pods stable
+    Then Check deployment 0 data in file data is intact
+    And Power on off node
+
+Single Replica Node Down Deletion Policy delete-deployment-pod With RWO Volume Replica Locate On Volume Node
+    Given Set setting node-down-pod-deletion-policy to delete-deployment-pod
+
+    When Create persistentvolumeclaim 0 using RWO volume
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Write 100 MB data to file data in deployment 0
+
+    # Delete replicas to have the volume with its only replica located on the same node
+    And Update volume of deployment 0 replica count to 1
+    And Delete replica of deployment 0 volume on all replica node
+    And Power off volume node of deployment 0
+    Then Wait for volume of deployment 0 faulted
+    And Wait for deployment 0 pod stuck in ContainerCreating on another node
+
+    When Power on off node
+    And Wait for deployment 0 pods stable
+    And Check deployment 0 pod is Running on the original node
+    Then Check deployment 0 data in file data is intact
+
+Single Replica Node Down Deletion Policy delete-both-statefulset-and-deployment-pod With RWO Volume Replica Locate On Replica Node
+    Given Set setting node-down-pod-deletion-policy to delete-both-statefulset-and-deployment-pod
+
+    When Create statefulset 0 using RWO volume
+    And Write 100 MB data to file data in statefulset 0
+
+    # Delete replicas to have the volume with its only replica located on different nodes.
+    And Update volume of statefulset 0 replica count to 1
+    And Delete replica of statefulset 0 volume on replica node
+    And Delete replica of statefulset 0 volume on volume node
+    And Power off volume node of statefulset 0
+    Then Wait for volume of statefulset 0 attaching
+
+    And Wait for statefulset 0 pods stable
+    Then Check statefulset 0 data in file data is intact
+    And Power on off node
+
+Single Replica Node Down Deletion Policy delete-both-statefulset-and-deployment-pod With RWO Volume Replica Locate On Volume Node
+    Given Set setting node-down-pod-deletion-policy to delete-both-statefulset-and-deployment-pod
+
+    When Create statefulset 0 using RWO volume
+    And Write 100 MB data to file data in statefulset 0
+
+    # Delete replicas to have the volume with its only replica located on the same.
+    And Update volume of statefulset 0 replica count to 1
+    And Delete replica of statefulset 0 volume on all replica node
+    And Power off volume node of statefulset 0
+    Then Wait for volume of statefulset 0 faulted
+    And Wait for statefulset 0 pod stuck in ContainerCreating on another node
+
+    When Power on off node
+    And Wait for statefulset 0 pods stable
+    And Check statefulset 0 pod is Running on the original node
+    Then Check statefulset 0 data in file data is intact


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8350

#### What this PR does / why we need it:

Make manual test case [Single replica node down](https://longhorn.github.io/longhorn-tests/manual/pre-release/node-not-ready/node-down/single-replica-node-down/) an automtaion test case

#### Special notes for your reviewer:

1. Create workload with `3` replicas then set the PVC replica count to `1`. After that,  delete specific replicas to make volume and the only one replica located on the same node or on diffent node. In the end power off the volume node to observe workload become ready or not by setting `node-down-pod-deletion-policy` and the only one replica locality.

2. And when volume faluted, the nodeID field is empty so it need `power_on_all_nodes` to boot up off node.

#### Additional documentation or context

[test-report.zip](https://github.com/longhorn/longhorn-tests/files/15198264/test-report.zip)

