### PR TITLE
Don't test with XFS volumes smaller than 300 MiB

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -32,6 +32,8 @@ Mi = (1024 * 1024)
 Gi = (1024 * Mi)
 
 SIZE = str(16 * Mi)
+# See https://github.com/longhorn/longhorn/issues/8488.
+XFS_MIN_SIZE = str(300 * Mi)
 EXPAND_SIZE = str(32 * Mi)
 VOLUME_NAME = "longhorn-testvol"
 ATTACHMENT_TICKET_ID_PREFIX = "test-attachment-ticket"
@@ -5127,7 +5129,7 @@ def crash_engine_process_with_sigkill(client, core_api, volume_name):
 
     kill_command = [
             '/bin/sh', '-c',
-            "kill `pgrep -f \"controller " + volume_name + "\"`",]
+            "kill `pgrep -f \"controller " + volume_name + "\"`"]
 
     with timeout(seconds=STREAM_EXEC_TIMEOUT,
                  error_message='Timeout on executing stream read'):

--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -16,6 +16,7 @@ from common import VOLUME_CONDITION_SCHEDULED
 from common import SETTING_REPLICA_NODE_SOFT_ANTI_AFFINITY
 from common import SETTING_REPLICA_REPLENISHMENT_WAIT_INTERVAL
 from common import LONGHORN_NAMESPACE
+from common import XFS_MIN_SIZE
 from common import create_and_wait_pod, create_pvc_spec, delete_and_wait_pod
 from common import size_to_string, create_storage_class, create_pvc
 from common import create_crypto_secret
@@ -610,7 +611,7 @@ def test_xfs_pv(client, core_api, pod_manifest):  # NOQA
     """
     volume_name = generate_volume_name()
 
-    volume = create_and_check_volume(client, volume_name)
+    volume = create_and_check_volume(client, volume_name, size=XFS_MIN_SIZE)
 
     create_pv_for_volume(client, core_api, volume, volume_name, "xfs")
 
@@ -648,7 +649,7 @@ def test_xfs_pv_existing_volume(client, core_api, pod_manifest):  # NOQA
     """
     volume_name = generate_volume_name()
 
-    volume = create_and_check_volume(client, volume_name)
+    volume = create_and_check_volume(client, volume_name, size=XFS_MIN_SIZE)
 
     create_pv_for_volume(client, core_api, volume, volume_name, "xfs")
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8488

#### What this PR does / why we need it:

Don't attempt to create XFS file systems that are smaller than 300 MiB.

#### Additional documentation or context

- Without this PR, test_xfs_pv fails: https://ci.longhorn.io/job/public/job/master/job/sles/job/amd64/job/longhorn-tests-sles-amd64/906/testReport/.
- With this PR, text_xfs_pv passes: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/6782/testReport/tests/test_csi/.
