### PR TITLE
Revert "chore(deps): update docker dependencies"

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/python:3.12
+FROM registry.suse.com/bci/python:3.11
 
 ARG TARGETPLATFORM
 RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
@@ -10,9 +10,8 @@ ENV ARCH ${TARGETPLATFORM#linux/}
 ARG KUBECTL_VERSION=v1.17.0
 ARG YQ_VERSION=v4.24.2
 
-RUN zypper addrepo https://download.opensuse.org/repositories/Java:/Factory/SLE_15_SP6/Java:Factory.repo
-RUN zypper --gpg-auto-import-keys ref -f
-RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python312-devel gawk java-11-openjdk tar awk gzip wget && \
+RUN zypper ref -f
+RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python311-devel gawk java-11-openjdk tar awk gzip wget && \
     rm -rf /var/cache/zypp/*
 
 RUN curl -sO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/${ARCH}/kubectl && \

--- a/manager/integration/Dockerfile
+++ b/manager/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/python:3.12
+FROM registry.suse.com/bci/python:3.11
 
 ARG TARGETPLATFORM
 RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
@@ -11,9 +11,8 @@ ARG KUBECTL_VERSION=v1.28.4
 ARG YQ_VERSION=v4.24.2
 ARG TERRAFORM_VERSION=1.3.5
 
-RUN zypper addrepo https://download.opensuse.org/repositories/Java:/Factory/SLE_15_SP6/Java:Factory.repo
-RUN zypper --gpg-auto-import-keys ref -f
-RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python312-devel gawk java-11-openjdk tar awk gzip wget unzip && \
+RUN zypper ref -f
+RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python311-devel gawk java-11-openjdk tar awk gzip wget unzip && \
     rm -rf /var/cache/zypp/*
 
 RUN curl -sO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/${ARCH}/kubectl && \

--- a/manager/integration/tests/requirements.txt
+++ b/manager/integration/tests/requirements.txt
@@ -9,6 +9,6 @@ pytest-repeat==0.9.1
 pytest-order==1.0.1
 six==1.12.0
 minio==5.0.10
-pyyaml==6.0.1
+pyyaml==6.0
 pandas
 prometheus_client

--- a/mirror_csi_images/Dockerfile.setup
+++ b/mirror_csi_images/Dockerfile.setup
@@ -6,6 +6,6 @@ WORKDIR $WORKSPACE
 
 RUN apk add --no-cache skopeo docker jq bash grep
 
-COPY --from=docker/buildx-bin:v0.14 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --from=docker/buildx-bin:v0.13 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 COPY [".", "$WORKSPACE"]


### PR DESCRIPTION
This reverts commit 5a5759b5abf7263b47cd57930503b7efa613d159.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

Revert python version from 3.12 back to 3.11. Because kubernetes python client doesn't officially support python 3.12.

#### Special notes for your reviewer:

#### Additional documentation or context
