### PR TITLE
fix(robot): skip kubelet terminated pod in get_workload_pods

### DIFF
--- a/e2e/libs/workload/pod.py
+++ b/e2e/libs/workload/pod.py
@@ -168,3 +168,15 @@ def get_volume_name_by_pod(name, namespace='default'):
     api = client.CoreV1Api()
     claim = api.read_namespaced_persistent_volume_claim(name=claim_name, namespace='default')
     return claim.spec.volume_name
+
+
+def is_pod_terminated_by_kubelet(pod):
+    if not pod.status.conditions:
+        return False
+
+    for condition in pod.status.conditions:
+        if condition.type == "DisruptionTarget" and \
+            condition.reason == "TerminationByKubelet" and \
+            condition.status == "True":
+            return True
+    return False


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8550

#### What this PR does / why we need it:

https://github.com/longhorn/longhorn/issues/8550#issuecomment-2109276522

#### Special notes for your reviewer:

#### Additional documentation or context
