### PR TITLE
ci: Update data.tf to support ubuntu 24.04

### DIFF
--- a/test_framework/terraform/aws/ubuntu/data.tf
+++ b/test_framework/terraform/aws/ubuntu/data.tf
@@ -5,7 +5,7 @@ data "aws_ami" "aws_ami_ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu*${var.os_distro_version}-${var.arch}-server-*"]
+    values = ["ubuntu/images/hvm-ssd*/ubuntu-*${var.os_distro_version}-${var.arch}-server-*"]
   }
 }
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8696

#### What this PR does / why we need it:

If `var.os_distro_version` is Ubuntu 22.04, it would be:

```
ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-202*****
or
ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-202*****
```

For Ubuntu 24.04, it would be:

```
ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-202*****
or
ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-202*****
```
So we need to update [data.tf](https://github.com/longhorn/longhorn-tests/blob/master/test_framework/terraform/aws/ubuntu/data.tf#L8) to filter Ubuntu 24.04 AMI.
#### Special notes for your reviewer:

#### Additional documentation or context
