### PR TITLE
test(manual) update Node disconnection test

### DIFF
--- a/docs/content/manual/pre-release/node-not-ready/node-disconnection/node-disconnection.md
+++ b/docs/content/manual/pre-release/node-not-ready/node-disconnection/node-disconnection.md
@@ -4,11 +4,11 @@ title: Node disconnection test
 https://github.com/longhorn/longhorn/issues/1545
 For disconnect node : https://github.com/longhorn/longhorn/files/4864127/network_down.sh.zip
 
-If auto-salvage is disabled, the auto-reattachment behavior after the node disconnection depends on all replicas are in ERROR state or not.
+If auto-salvage is disabled, the behavior after the node disconnection depends on all replicas are in ERROR state or not.
 
 (1) If all replicas are in ERROR state, the volume would remain in detached/faulted state if auto-salvage is disabled.
 
-(2) If there is any healthy replica, the volume would be auto-reattached even though auto-salvage is disabled.
+(2) If there is any healthy replica, the volume would start the replica rebuild process(if necessary) after node back.
 
 What makes all replicas in ERROR state? When there is data writing during the disconnection:
 
@@ -20,11 +20,11 @@ So we have 2 * 2 test cases for node disconnection + disabled auto-salvage:
 
 (Case 1-1) there is no replica on the attached node + data writing during the disconnection -> all replicas become ERROR -> no auto-reattach after the disconnection
 
-(Case 1-2) there is a replica on the attached node + data writing during the disconnection -> one replica can recover to healthy -> auto-reattach after the disconnection
+(Case 1-2) there is a replica on the attached node + data writing during the disconnection -> one replica can recover to healthy -> the volume become degraded and start replica rebuilding then become healthy
 
-(Case 2-1) there is no replica on the attached node + no data writing during the disconnection -> other replicas are still healthy -> auto-reattach after the disconnection
+(Case 2-1) there is no replica on the attached node + no data writing during the disconnection -> other replicas are still healthy -> the volume in attached state, robustness changed from unknown to healthy
 
-(Case 2-2) there is a replica on the attached node + no data writing during the disconnection -> other replicas are still healthy -> auto-reattach after the disconnection
+(Case 2-2) there is a replica on the attached node + no data writing during the disconnection -> other replicas are still healthy -> the volume in attached state, robustness changed from unknown to healthy
 
 ### Case 1-1:
 1. Disable auto-salvage.
@@ -42,7 +42,8 @@ So we have 2 * 2 test cases for node disconnection + disabled auto-salvage:
 4. Keep writing data directly to the volume. (sudo dd if=/dev/urandom of=/dev/longhorn/test-1 bs=2M count=2048)
 5. Disconnect the network of the node that the volume attached to for 100 seconds during the data writing. (sudo nohup ./network_down.sh 100)
 6. Wait for the node back.
-7. The volume will be detached then reattached automatically, and replicas should still be in RUNNING state.
+7. The volume will be in degraded state and then started the replica rebuilding process.
+8. The volume become healthy.
 
 ### Case 2-1:
 1. Disable auto-salvage.
@@ -50,7 +51,7 @@ So we have 2 * 2 test cases for node disconnection + disabled auto-salvage:
 3. Attach the volume to the 3rd node.
 4. No need to write data to the volume. Directly disconnect the network of the node that the volume attached to for 100 seconds. (sudo nohup ./network_down.sh 100)
 5. Wait for the node back.
-6. The volume will be detached then reattached automatically, and replicas should still be in RUNNING state.
+6. The volume will be in an attached state with its robustness unknown at first, then the volume become healthy.
 
 ### Case 2-2:
 1. Disable auto-salvage.
@@ -58,7 +59,7 @@ So we have 2 * 2 test cases for node disconnection + disabled auto-salvage:
 3. Attach the volume to a node.
 4. No need to write data to the volume. Directly disconnect the network of the node that the volume attached to for 100 seconds. (sudo nohup ./network_down.sh 100)
 5. Wait for the node back.
-6. The volume will be detached then reattached automatically, and replicas should still be in RUNNING state.
+6. The volume will be in an attached state with its robustness unknown at first, then the volume become healthy.
 
 ### Case 3:
 1. Launch Longhorn.
@@ -66,8 +67,7 @@ So we have 2 * 2 test cases for node disconnection + disabled auto-salvage:
 3. Run command 'sync' in pod, make sure data fulshed.
 4. Disconnect the node that the volume attached to for 100 seconds.
 5. Wait for the node back and the volume reattachment.
-6. After the volume is reattached, the pod will be automatically deleted and recreate.
+6. The volume will be in an attached state with its robustness unknown at first, then the volume become healthy
 7. Verify the data and the pod still works fine.
 8. Repeat step 2~6 for 3 times.
 9. Create, Attach, and detach other volumes to the recovered node. All volumes should work fine.
-10. Remove Longhorn and repeat step 1~9 for 3 times.


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #8617

#### What this PR does / why we need it:

Update manual test case [Node disconnection test](https://longhorn.github.io/longhorn-tests/manual/pre-release/node-not-ready/node-disconnection/node-disconnection/). Because the last content updated was 2 years ago.

Tested on v1.4.4 and master-head, after volume node network back, the volume does not detach, but if data is written during the volume node network disconnect, replica rebuilding is observed..

#### Special notes for your reviewer:

#### Additional documentation or context
