### PR TITLE
test: refine test_backuptarget_invalid

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -5700,7 +5700,7 @@ def test_backuptarget_invalid(apps_api, # NOQA
                                                     "longhorn-system",
                                                     "backups")
 
-        if backups["items"][0]["status"]["state"] != "":
+        if backups["items"][0]["status"]["state"] == "Error":
             break
         time.sleep(RETRY_INTERVAL)
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Refine [test_backuptarget_invalid](https://ci.longhorn.io/job/public/job/master/job/sles/job/amd64/job/longhorn-tests-sles-amd64/944/testReport/junit/tests/test_basic/test_backuptarget_invalid/)

Modify the loop break logic because a backup will in `Penging` state for a while when backup target is invalid on master-head images
```
NAMESPACE         NAME                      SNAPSHOTNAME   SNAPSHOTSIZE   SNAPSHOTCREATEDAT      STATE     LASTSYNCEDAT
longhorn-system   backup-85313580390a48f9                                 2024-06-14T07:13:13Z   Pending   <no value>
longhorn-system   backup-85313580390a48f9                                 2024-06-14T07:13:13Z   Error     2024-06-14T07:13:35Z
longhorn-system   backup-85313580390a48f9                                 2024-06-14T07:13:13Z   Error     2024-06-14T07:13:35Z
longhorn-system   backup-85313580390a48f9                                 2024-06-14T07:13:13Z   Error     2024-06-14T07:13:35Z
```

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
