### PR TITLE
test: refine test_drain_with_block_for_eviction_if_contains_last_replica_success

### DIFF
--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -2927,8 +2927,7 @@ def test_drain_with_block_for_eviction_if_contains_last_replica_success(client, 
     disk_volume_name = 'vol-disk'
     disk_volume = client.create_volume(name=disk_volume_name,
                                        size=str(2 * Gi),
-                                       numberOfReplicas=1,
-                                       dataLocality="strict-local")
+                                       numberOfReplicas=3)
     disk_volume = wait_for_volume_detached(client, disk_volume_name)
 
     disk_volume.attach(hostId=host_id)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#8753

#### What this PR does / why we need it:

Do not use stict-local volume for disk to avoid misunderstanding.

#### Special notes for your reviewer:

#### Additional documentation or context

Verified on local