### PR TITLE
test(robot): power off replica node should not rebuild new replica on same node

### DIFF
--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -250,3 +250,11 @@ Create volume ${volume_id} with ${size} GB and no replicas on the attached node
     Wait for volume ${volume_id} healthy
     Update volume ${volume_id} replica count to 2
     Delete volume ${volume_id} replica on volume node
+
+Record volume ${volume_id} replica names
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    record_volume_replica_names    ${volume_name}
+
+Check volume ${volume_id} replica names are as recorded
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    check_volume_replica_names_recorded    ${volume_name}

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -1,13 +1,18 @@
 import asyncio
 import time
+
 from node import Node
 from node.utility import check_replica_locality
 
+from replica import Replica
+
 from utility.constant import ANNOT_CHECKSUM
+from utility.constant import ANNOT_REPLICA_NAMES
 from utility.constant import LABEL_TEST
 from utility.constant import LABEL_TEST_VALUE
 from utility.utility import logging
 from utility.utility import get_retry_count_and_interval
+
 from volume import Volume
 
 
@@ -16,6 +21,7 @@ class volume_keywords:
     def __init__(self):
         self.node = Node()
         self.volume = Volume()
+        self.replica = Replica()
 
     def cleanup_volumes(self):
         volumes = self.volume.list(label_selector=f"{LABEL_TEST}={LABEL_TEST_VALUE}")
@@ -268,3 +274,28 @@ class volume_keywords:
 
     def create_persistentvolumeclaim_for_volume(self, volume_name, retry=True):
         self.volume.create_persistentvolumeclaim(volume_name, retry)
+
+    def record_volume_replica_names(self, volume_name):
+        replica_list = self.replica.get(volume_name, node_name="")
+        assert replica_list != "", f"failed to get replicas"
+
+        replica_names = [replica['metadata']['name'] for replica in replica_list['items']]
+        logging(f"Found volume {volume_name} replicas: {replica_names}")
+
+        replica_names_str = ",".join(replica_names)
+        self.volume.set_annotation(volume_name, ANNOT_REPLICA_NAMES, replica_names_str)
+
+    def check_volume_replica_names_recorded(self, volume_name):
+        replica_names_str = self.volume.get_annotation_value(volume_name, ANNOT_REPLICA_NAMES)
+        expected_replica_names = sorted(replica_names_str.split(","))
+
+        replica_list = self.replica.get(volume_name, node_name="")
+        assert replica_list != "", f"failed to get replicas"
+
+        actual_replica_names = [replica['metadata']['name'] for replica in replica_list['items']]
+        actual_replica_names = sorted(actual_replica_names)
+
+        assert actual_replica_names == expected_replica_names, \
+            f"Volume {volume_name} replica names mismatched:\n" \
+            f"Want: {expected_replica_names}\n" \
+            f"Got: {actual_replica_names}"

--- a/e2e/libs/replica/crd.py
+++ b/e2e/libs/replica/crd.py
@@ -7,18 +7,17 @@ from utility.utility import logging
 
 
 class CRD(Base):
-    def __init__(self, node_exec):
+    def __init__(self):
         self.obj_api = client.CustomObjectsApi()
-        self.node_exec = node_exec
 
-    def get_replica(self, volume_name, node_name):
+    def get(self, volume_name, node_name):
         label_selector = []
         if volume_name != "":
             label_selector.append(f"longhornvolume={volume_name}")
         if node_name != "":
             label_selector.append(f"longhornnode={node_name}")
 
-        replicas = self.cr_api.list_namespaced_custom_object(
+        replicas = self.obj_api.list_namespaced_custom_object(
             group="longhorn.io",
             version="v1beta2",
             namespace="longhorn-system",
@@ -27,14 +26,14 @@ class CRD(Base):
         )
         return replicas
 
-    def delete_replica(self, volume_name, node_name):
+    def delete(self, volume_name, node_name):
         if volume_name == "" or node_name == "":
             logging(f"Deleting all replicas")
         else:
             logging(
                 f"Deleting volume {volume_name} on node {node_name} replicas")
 
-        resp = self.get_replica(volume_name, node_name)
+        resp = self.get(volume_name, node_name)
         assert resp != "", f"failed to get replicas"
 
         replicas = resp['items']
@@ -52,8 +51,8 @@ class CRD(Base):
             )
         logging(f"Finished replicas deletion")
 
-    def wait_for_replica_rebuilding_start(self, volume_name, node_name):
-        Rest(self.node_exec).wait_for_replica_rebuilding_start(volume_name, node_name)
+    def wait_for_rebuilding_start(self, volume_name, node_name):
+        Rest().wait_for_rebuilding_start(volume_name, node_name)
 
-    def wait_for_replica_rebuilding_complete(self, volume_name, node_name):
-        Rest(self.node_exec).wait_for_replica_rebuilding_complete(volume_name, node_name)
+    def wait_for_rebuilding_complete(self, volume_name, node_name):
+        Rest().wait_for_rebuilding_complete(volume_name, node_name)

--- a/e2e/libs/replica/replica.py
+++ b/e2e/libs/replica/replica.py
@@ -8,19 +8,19 @@ class Replica(Base):
 
     _strategy = LonghornOperationStrategy.CRD
 
-    def __init__(self, node_exec):
+    def __init__(self):
         if self._strategy == LonghornOperationStrategy.CRD:
-            self.replica = CRD(node_exec)
+            self.replica = CRD()
 
     # delete replicas, if input parameters are empty then will delete all
     def delete(self, volume_name="", node_name=""):
-        return self.replica.delete_replica(volume_name, node_name)
+        return self.replica.delete(volume_name, node_name)
 
-    def get_replica(self, volume_name, node_name):
-        return self.replica.get_replica(volume_name, node_name)
+    def get(self, volume_name, node_name):
+        return self.replica.get(volume_name, node_name)
 
-    def wait_for_replica_rebuilding_start(self, volume_name, node_name):
-        return self.replica.wait_for_replica_rebuilding_start(volume_name,node_name)
+    def wait_for_rebuilding_start(self, volume_name, node_name):
+        return self.replica.wait_for_rebuilding_start(volume_name,node_name)
 
-    def wait_for_replica_rebuilding_complete(self, volume_name, node_name):
-        return self.replica.wait_for_replica_rebuilding_complete(volume_name,node_name)
+    def wait_for_rebuilding_complete(self, volume_name, node_name):
+        return self.replica.wait_for_rebuilding_complete(volume_name,node_name)

--- a/e2e/libs/replica/rest.py
+++ b/e2e/libs/replica/rest.py
@@ -9,16 +9,16 @@ from utility.utility import get_longhorn_client
 
 
 class Rest(Base):
-    def __init__(self, node_exec):
-        self.node_exec = node_exec
+    def __init__(self):
+        pass
 
-    def get_replica(self, volume_name, node_name):
+    def get(self, volume_name, node_name):
         return NotImplemented
 
-    def delete_replica(self, volume_name, node_name):
+    def delete(self, volume_name, node_name):
         return NotImplemented
 
-    def wait_for_replica_rebuilding_start(self, volume_name, node_name):
+    def wait_for_rebuilding_start(self, volume_name, node_name):
         rebuilding_replica_name = None
         for i in range(RETRY_COUNTS):
             try:
@@ -50,7 +50,7 @@ class Rest(Base):
             time.sleep(RETRY_INTERVAL)
         assert started, f'replica {rebuilding_replica_name} rebuilding starting failed'
 
-    def wait_for_replica_rebuilding_complete(self, volume_name, node_name):
+    def wait_for_rebuilding_complete(self, volume_name, node_name):
         completed = False
         for i in range(RETRY_COUNTS):
             try:

--- a/e2e/libs/utility/constant.py
+++ b/e2e/libs/utility/constant.py
@@ -6,6 +6,7 @@ LABEL_TEST_VALUE = 'e2e'
 
 ANNOT_CHECKSUM = f'{LABEL_TEST}/last-recorded-checksum'
 ANNOT_EXPANDED_SIZE = f'{LABEL_TEST}/last-recorded-expanded-size'
+ANNOT_REPLICA_NAMES = f'{LABEL_TEST}/replica-names'
 
 NAME_PREFIX = 'e2e-test'
 STORAGECLASS_NAME_PREFIX = 'longhorn-test'


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8825 , longhorn/longhorn#1992

#### What this PR does / why we need it:

Add a new case to ensure that no new replica is created and rebuilt on the same node if the node is powered off for a duration longer than the replica-replenishment-wait-interval. When the node is powered on, the existing replica should be reused.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
