### PR TITLE
docs(storage-network): clarify source/destination check step

### DIFF
--- a/docs/content/manual/release-specific/v1.3.0/test-storage-network.md
+++ b/docs/content/manual/release-specific/v1.3.0/test-storage-network.md
@@ -28,7 +28,9 @@ https://github.com/longhorn/longhorn/issues/2285
 - Use subnet-2 for network interface 2
 - Disable `Auto-assign public IP`
 - Add security group inbound rule to allow `All traffic` from `Anywhere-IPv4`
-- Stop `Source/destination check`
+- Stop `Source/destination check`. There does not appear to be a way to do this from `Launch instances` in the console,
+  so be sure to do it from `Instances`, `Actions`, `Networking`, `Change source/destination check` after creation.
+  Failure to do so will cause traffic on the 192.168.0.0/16 (between `lhnet1` interfaces) to be blocked.
 
 *And* Create 3 elastic IPs.
 

--- a/docs/content/manual/release-specific/v1.6.0/test-storage-network.md
+++ b/docs/content/manual/release-specific/v1.6.0/test-storage-network.md
@@ -28,7 +28,9 @@ https://github.com/longhorn/longhorn/issues/6953
 - Use subnet-2 for network interface 2
 - Disable `Auto-assign public IP`
 - Add security group inbound rule to allow `All traffic` from `Anywhere-IPv4`
-- Stop `Source/destination check`
+- Stop `Source/destination check`. There does not appear to be a way to do this from `Launch instances` in the console,
+  so be sure to do it from `Instances`, `Actions`, `Networking`, `Change source/destination check` after creation.
+  Failure to do so will cause traffic on the 192.168.0.0/16 (between `lhnet1` interfaces) to be blocked.
 
 *And* Create 3 elastic IPs.
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

I decided to create this PR while setting up a storage network to test https://github.com/longhorn/longhorn-manager/pull/2970 for https://github.com/longhorn/longhorn/issues/9000.

#### What this PR does / why we need it:

There are two locations in the manual tests where we document how to set up an AWS environment capable of supporting the Longhorn storage network feature. While the existing documentation makes it clear that `Source/destination check` should be stopped on all involved instances, I couldn't find the option in the console `Launch instances` dialogue, so I ignored the step. Later, I spend a few hours debugging routing on the storage network before realizing that the instances and/or VPC was/were dropping traffic on the 192.168.0.0/16 network due to the setting being enabled.

This PR makes it clear that the check must be disabled after launching instances if using the console (and explains why it is necessary). Hopefully this will help me (and potentially others) in the future