### PR TITLE
fix(integration): test_drain_with_block_for_eviction

### DIFF
--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -2732,9 +2732,15 @@ def check_replica_evict_state(client, volume_name, node, expect_state): # NOQA
         if replica.hostId == node.id:
             replica_name = replica.name
             break
+    assert replica_name, f"Can not find {volume_name} replica on {node}"
 
-    replica_info = get_replica_detail(replica_name)
-    eviction_requested = replica_info["spec"]["evictionRequested"]
+    for i in range(RETRY_COUNTS):
+        replica_info = get_replica_detail(replica_name)
+        eviction_requested = replica_info["spec"]["evictionRequested"]
+        if eviction_requested is expect_state:
+            return
+        time.sleep(RETRY_INTERVAL)
+
     assert eviction_requested is expect_state
 
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Add retry in `check_replica_evict_state` 

#### What this PR does / why we need it:

`test_drain_with_block_for_eviction` related test cases failed on Ubuntu 24.04 due to `check_replica_evict_state`  did not have wait mechanism

#### Special notes for your reviewer:

Origin failed test on [Ubuntu](https://ci.longhorn.io/job/public/job/master/job/ubuntu/job/amd64/job/longhorn-tests-ubuntu-amd64/597/testReport/junit/tests/test_node/)

This PR tested pass on [Ubuntu 24.04](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7229/testReport/tests/test_node/) and [SLES 15 SP6](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7231/)

#### Additional documentation or context
