### PR TITLE
Fix test_csi_block_volume_online_expansion

### DIFF
--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -546,6 +546,7 @@ def test_csi_block_volume_online_expansion(client, core_api, storage_class, pvc,
         write_data_complete = False
     assert write_data_complete
 
+    subprocess.check_call(["sync"])
     executor = ThreadPoolExecutor(max_workers=5)
     future = executor.submit(md5sum_thread, pod_name, pod_dev_volume_path)
 
@@ -615,6 +616,7 @@ def test_csi_mount_volume_online_expansion(client, core_api, storage_class, pvc,
         write_data_complete = False
     assert write_data_complete
 
+    subprocess.check_call(["sync"])
     command = 'md5sum {}'.format(volume_data_path)
     md5_before_expanding = \
         exec_command_in_pod(core_api, command, pod_name, 'default').\


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Fix `test_csi_block_volume_online_expansion`

#### What this PR does / why we need it:

`test_csi_block_volume_online_expansion` is flaky on [rhel 9.3.0](https://ci.longhorn.io/job/public/job/master/job/rhel/job/amd64/job/longhorn-tests-rhel-amd64/175/)
 
#### Special notes for your reviewer:

This PR tested by perform 50 times of `test_csi_block_volume_online_expansion` and `test_csi_mount_volume_online_expansion` on rhel all [passed](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7240/testReport/tests/test_csi/)

#### Additional documentation or context

N/A
