### PR TITLE
fix(backupbackingimage): cleanup backup backing image in the backupstore_cleanup function

### DIFF
--- a/manager/integration/tests/backupstore.py
+++ b/manager/integration/tests/backupstore.py
@@ -19,6 +19,7 @@ from common import is_backupTarget_s3
 from common import is_backupTarget_nfs
 from common import get_longhorn_api_client
 from common import delete_backup_volume
+from common import delete_backup_backing_image
 from common import get_backupstore_url
 from common import get_backupstore_poll_interval
 from common import get_backupstores
@@ -172,13 +173,19 @@ def backup_cleanup():
 
 def backupstore_cleanup(client):
     backup_volumes = client.list_backup_volume()
-
     # we delete the whole backup volume, which skips block gc
     for backup_volume in backup_volumes:
         delete_backup_volume(client, backup_volume.name)
 
     backup_volumes = client.list_backup_volume()
     assert backup_volumes.data == []
+
+    backup_backing_images = client.list_backup_backing_image()
+    for backup_backing_image in backup_backing_images:
+        delete_backup_backing_image(client, backup_backing_image.name)
+
+    backup_backing_images = client.list_backup_backing_image()
+    assert backup_backing_images.data == []
 
 
 def minio_get_api_client(client, core_api, minio_secret_name):

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -517,6 +517,12 @@ def delete_backup_volume(client, volume_name):
     wait_for_backup_volume_delete(client, volume_name)
 
 
+def delete_backup_backing_image(client, backing_image_name):
+    bbi = client.by_id_backupBackingImage(backing_image_name)
+    client.delete(bbi)
+    wait_for_backup_backing_image_delete(client, backing_image_name)
+
+
 def create_and_check_volume(client, volume_name,
                             num_of_replicas=3, size=SIZE, backing_image="",
                             frontend=VOLUME_FRONTEND_BLOCKDEV,
@@ -2057,6 +2063,20 @@ def wait_for_backup_volume_delete(client, name):
         if not found:
             break
         time.sleep(RETRY_BACKUP_INTERVAL)
+    assert not found
+
+
+def wait_for_backup_backing_image_delete(client, name):
+    for _ in range(RETRY_COUNTS):
+        bbis = client.list_backupBackingImage()
+        found = False
+        for bbi in bbis:
+            if bbi.name == name:
+                found = True
+                break
+        if not found:
+            break
+        time.sleep(RETRY_INTERVAL)
     assert not found
 
 

--- a/manager/integration/tests/test_system_backup_restore.py
+++ b/manager/integration/tests/test_system_backup_restore.py
@@ -123,6 +123,7 @@ def test_system_backup_and_restore_volume_with_data(client, volume_name, set_ran
 
     check_volume_data(restored_volume, data)
 
+
 @pytest.mark.system_backup_restore   # NOQA
 def test_system_backup_and_restore_volume_with_backingimage(client, core_api, volume_name, set_random_backupstore):  # NOQA
     """


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9041

The issue is caused by the backup backing image left over from the previous test.
We should clean up the backup backing image in the backupstore_cleanup function