### PR TITLE
fix(engineimage): check if engine image is deployed correctly

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3738,20 +3738,42 @@ def scale_up_engine_image_daemonset(client):
     wait_for_deployed_engine_image_count(client, default_img.name, 3)
 
 
-def wait_for_deployed_engine_image_count(client, image_name, expected_cnt):
+def wait_for_deployed_engine_image_count(client, image_name, expected_cnt,
+                                         exclude_nodes=[]):
     for i in range(RETRY_COUNTS):
+        time.sleep(RETRY_INTERVAL)
         image = client.by_id_engine_image(image_name)
         deployed_cnt = 0
         if image.nodeDeploymentMap is None:
             continue
-        for item in image.nodeDeploymentMap:
-            if image.nodeDeploymentMap[item] is True:
+        for node_name in image.nodeDeploymentMap:
+            if node_name in exclude_nodes:
+                continue
+            if image.nodeDeploymentMap[node_name] is True:
                 deployed_cnt = deployed_cnt + 1
         if deployed_cnt == expected_cnt:
             break
-        time.sleep(RETRY_INTERVAL)
 
     assert deployed_cnt == expected_cnt, f"image = {image}"
+
+
+def wait_for_tainted_node_engine_image_undeployed(client,
+                                                  img_name, tainted_node):
+    for _ in range(RETRY_COUNTS):
+        time.sleep(RETRY_INTERVAL)
+        tainted_node_excluded = False
+        img = client.by_id_engine_image(img_name)
+        if img.nodeDeploymentMap is None:
+            continue
+        for node_name in img.nodeDeploymentMap:
+            if node_name != tainted_node:
+                continue
+            if img.nodeDeploymentMap[node_name] is False:
+                tainted_node_excluded = True
+                break
+        if tainted_node_excluded:
+            break
+    assert img.nodeDeploymentMap[tainted_node] is False
 
 
 def wait_for_running_engine_image_count(image_name, engine_cnt):

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -82,6 +82,7 @@ from common import wait_for_snapshot_count
 from common import DEFAULT_BACKUP_COMPRESSION_METHOD
 from common import wait_scheduling_failure
 from common import set_tags_for_node_and_its_disks
+from common import wait_for_tainted_node_engine_image_undeployed
 
 from backupstore import set_random_backupstore # NOQA
 from backupstore import backupstore_cleanup
@@ -2506,7 +2507,7 @@ def test_replica_failure_during_attaching(settings_reset, client, core_api, volu
     common.wait_for_disk_update(client, node.name, 1)
 
 
-def prepare_upgrade_image_not_fully_deployed_environment(client): # NOQA
+def prepare_upgrade_image_not_fully_deployed_environment(client, excluded_nodes=[]): # NOQA
     # deploy upgrade image, wait until 2 running pods because 1 node tainted
     default_img = common.get_default_engine_image(client)
     default_img = client.by_id_engine_image(default_img.name)
@@ -2523,7 +2524,8 @@ def prepare_upgrade_image_not_fully_deployed_environment(client): # NOQA
                                                          data_v, data_minv)
 
     new_img = client.create_engine_image(image=engine_upgrade_image)
-    wait_for_deployed_engine_image_count(client, new_img.name, 2)
+    wait_for_deployed_engine_image_count(client, new_img.name, 2,
+                                         excluded_nodes)
     new_img = client.by_id_engine_image(new_img.name)
 
     return engine_upgrade_image, new_img
@@ -2542,7 +2544,15 @@ def prepare_engine_not_fully_deployed_environment(client, core_api): # NOQA
 
     restart_and_wait_ready_engine_count(client, 2)
     default_img = common.get_default_engine_image(client)
-    wait_for_deployed_engine_image_count(client, default_img.name, 2)
+    default_img_name = default_img.name
+
+    # check if tainted node is marked as not deployed in `nodeDeploymentMap`.
+    wait_for_tainted_node_engine_image_undeployed(client,
+                                                  default_img_name,
+                                                  taint_node_id)
+
+    wait_for_deployed_engine_image_count(client, default_img_name, 2,
+                                         [taint_node_id])
 
     return taint_node_id
 
@@ -2757,7 +2767,8 @@ def test_engine_image_not_fully_deployed_perform_engine_upgrade(client, core_api
     volume1 = wait_for_volume_detached(client, volume1.name)
 
     engine_upgrade_image, new_img = \
-        prepare_upgrade_image_not_fully_deployed_environment(client)
+        prepare_upgrade_image_not_fully_deployed_environment(client,
+                                                             [tainted_node_id])
 
     # expected refCount: 1 for volume + 1 for engine and number of replicas(2)
     expect_ref_count = 4
@@ -2869,7 +2880,8 @@ def test_engine_image_not_fully_deployed_perform_auto_upgrade_engine(client, cor
     6. In a 2-min retry, verify that Longhorn upgrades the engine image of
        vol-1 and vol-2.
     """
-    prepare_engine_not_fully_deployed_environment(client, core_api)
+    tainted_node_id = \
+        prepare_engine_not_fully_deployed_environment(client, core_api)
 
     volume1 = create_and_check_volume(client, "vol-1",
                                       num_of_replicas=2,
@@ -2885,7 +2897,8 @@ def test_engine_image_not_fully_deployed_perform_auto_upgrade_engine(client, cor
     wait_for_engine_image_ref_count(client, default_img.name, 8)
 
     engine_upgrade_image, new_img = \
-        prepare_upgrade_image_not_fully_deployed_environment(client)
+        prepare_upgrade_image_not_fully_deployed_environment(client,
+                                                             [tainted_node_id])
 
     volume1.engineUpgrade(image=engine_upgrade_image)
     volume2.engineUpgrade(image=engine_upgrade_image)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#9038

#### What this PR does / why we need it:

After we tainted a node as `NoSchedule` and delete the EngineImage DaemonSet, `nodeDeploymentMap` will be unstable for a period and it is not enough only to check if the `nodeDeploymentMap` has the expected count for deloyed node.

#### Special notes for your reviewer:

#### Additional documentation or context
