### PR TITLE
fix(supportbundle): wait for changed support bundle size updated

### DIFF
--- a/manager/integration/tests/test_support_bundle.py
+++ b/manager/integration/tests/test_support_bundle.py
@@ -398,6 +398,21 @@ def test_support_bundle_should_not_timeout(client, core_api):  # NOQA
         body=support_bundle
     )
 
+    # Wait for the SupportBundle size to be updated
+    for _ in range(RETRY_COUNTS):
+        support_bundle = custom_obj_api.get_namespaced_custom_object(
+            group=group,
+            version=version,
+            namespace=LONGHORN_NAMESPACE,
+            plural=plural,
+            name=support_bundle_name
+        )
+        if support_bundle["status"]["filesize"] == int(zip_size):
+            break
+        time.sleep(RETRY_INTERVAL)
+    assert support_bundle["status"]["filesize"] == int(zip_size), \
+        f"Expected size={zip_size}, got {support_bundle['status']['filesize']}"
+
     download_support_bundle(node_id, support_bundle_name, client)
     wait_for_support_bundle_cleanup(client)
     check_all_support_bundle_managers_deleted()


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#9055

#### What this PR does / why we need it:

In the test case `test_support_bundle_should_not_timeout`, we change the support bundle size manually, and we should wait for the changed size to be updated before we start to do the download action.

#### Special notes for your reviewer:

#### Additional documentation or context

Local testing 30 times: **PASSED**

```shell
master:~# k logs longhorn-test -c longhorn-test -f
============================= test session starts ==============================
platform linux -- Python 3.11.9, pytest-6.2.4, py-1.11.0, pluggy-0.13.1 -- /usr/bin/python3.11
cachedir: .pytest_cache
rootdir: /integration, configfile: pytest.ini
plugins: order-1.0.1, repeat-0.9.1
collecting ... collected 30 items

+test_support_bundle.py::test_support_bundle_should_not_timeout[1-30] PASSED [  3%]
test_support_bundle.py::test_support_bundle_should_not_timeout[2-30] PASSED [  6%]
test_support_bundle.py::test_support_bundle_should_not_timeout[3-30] PASSED [ 10%]
test_support_bundle.py::test_support_bundle_should_not_timeout[4-30] PASSED [ 13%]
test_support_bundle.py::test_support_bundle_should_not_timeout[5-30] PASSED [ 16%]
test_support_bundle.py::test_support_bundle_should_not_timeout[6-30] PASSED [ 20%]
test_support_bundle.py::test_support_bundle_should_not_timeout[7-30] PASSED [ 23%]
test_support_bundle.py::test_support_bundle_should_not_timeout[8-30] PASSED [ 26%]
test_support_bundle.py::test_support_bundle_should_not_timeout[9-30] PASSED [ 30%]
test_support_bundle.py::test_support_bundle_should_not_timeout[10-30] PASSED [ 33%]
test_support_bundle.py::test_support_bundle_should_not_timeout[11-30] PASSED [ 36%]
test_support_bundle.py::test_support_bundle_should_not_timeout[12-30] PASSED [ 40%]
test_support_bundle.py::test_support_bundle_should_not_timeout[13-30] PASSED [ 43%]
test_support_bundle.py::test_support_bundle_should_not_timeout[14-30] PASSED [ 46%]
test_support_bundle.py::test_support_bundle_should_not_timeout[15-30] PASSED [ 50%]
test_support_bundle.py::test_support_bundle_should_not_timeout[16-30] PASSED [ 53%]
test_support_bundle.py::test_support_bundle_should_not_timeout[17-30] PASSED [ 56%]
test_support_bundle.py::test_support_bundle_should_not_timeout[18-30] PASSED [ 60%]
test_support_bundle.py::test_support_bundle_should_not_timeout[19-30] PASSED [ 63%]
test_support_bundle.py::test_support_bundle_should_not_timeout[20-30] PASSED [ 66%]
test_support_bundle.py::test_support_bundle_should_not_timeout[21-30] PASSED [ 70%]
test_support_bundle.py::test_support_bundle_should_not_timeout[22-30] PASSED [ 73%]
test_support_bundle.py::test_support_bundle_should_not_timeout[23-30] PASSED [ 76%]
test_support_bundle.py::test_support_bundle_should_not_timeout[24-30] PASSED [ 80%]
test_support_bundle.py::test_support_bundle_should_not_timeout[25-30] PASSED [ 83%]
test_support_bundle.py::test_support_bundle_should_not_timeout[26-30] PASSED [ 86%]
test_support_bundle.py::test_support_bundle_should_not_timeout[27-30] PASSED [ 90%]
test_support_bundle.py::test_support_bundle_should_not_timeout[28-30] PASSED [ 93%]
test_support_bundle.py::test_support_bundle_should_not_timeout[29-30] PASSED [ 96%]
test_support_bundle.py::test_support_bundle_should_not_timeout[30-30] PASSED [100%]

=============================== warnings summary ===============================
common.py:1648
  /integration/tests/common.py:1648: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================== 30 passed, 1 warning in 4342.24s (1:12:22) ==================
```

Testing 100 times is running:
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7323/