### PR TITLE
ci: use longhornctl to handle prerequisite installations and perform environment checks

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -351,6 +351,17 @@ create_aws_secret(){
 }
 
 
+longhornctl_check(){
+  curl -L https://github.com/longhorn/cli/releases/download/v1.7.0-rc2/longhornctl-linux-amd64 -o longhornctl
+  chmod +x longhornctl
+  ./longhornctl install preflight
+  ./longhornctl check preflight
+  if [[ -n $(./longhornctl check preflight 2>&1 | grep error) ]]; then
+    exit 1
+  fi
+}
+
+
 run_longhorn_upgrade_test(){
   LONGHORN_TESTS_CUSTOM_IMAGE=${LONGHORN_TESTS_CUSTOM_IMAGE:-"longhornio/longhorn-manager-test:master-head"}
 
@@ -508,6 +519,12 @@ main(){
   if [[ "${TF_VAR_enable_mtls}" == true ]]; then
     enable_mtls
   fi
+
+  # msg="failed to get package manager" error="operating system (amzn) is not supported"
+  if [[ "${TF_VAR_k8s_distro_name}" != "eks" ]]; then
+    longhornctl_check
+  fi
+
   if [[ "${AIR_GAP_INSTALLATION}" == true ]]; then
     if [[ "${LONGHORN_INSTALL_METHOD}" == "manifest-file" ]]; then
       create_registry_secret


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

use longhornctl to handle prerequisite installations and perform environment checks

#### Special notes for your reviewer:

#### Additional documentation or context
