### PR TITLE
ci: prevent overwriting the desired size of eks node group

### DIFF
--- a/test_framework/terraform/aws/eks/main.tf
+++ b/test_framework/terraform/aws/eks/main.tf
@@ -127,6 +127,9 @@ resource "aws_eks_node_group" "node_group" {
     max_size     = 6
     min_size     = 1
   }
+  lifecycle {
+    ignore_changes = [scaling_config[0].desired_size]
+  }
   update_config {
     max_unavailable = 1
   }


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

prevent overwriting the desired size of eks node group

#### Special notes for your reviewer:

#### Additional documentation or context
