### PR TITLE
test: skip test case test_backup_lock_creation_during_deletion

### DIFF
--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3305,6 +3305,8 @@ def test_backup_lock_deletion_during_backup(set_random_backupstore, client, core
     assert std_md5sum2 == md5sum2
 
 
+@pytest.mark.skip(reason="In the current Longhorn implementation, \
+it's almost impossible to catch the moment when the lock is held")
 def test_backup_lock_creation_during_deletion(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     Test backup locks


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/8269

#### What this PR does / why we need it:

skip test case test_backup_lock_creation_during_deletion since in the current Longhorn implementation, it's almost impossible to catch the moment when the lock is held and the test case always fails.

#### Special notes for your reviewer:

#### Additional documentation or context
