### PR TITLE
test(robot): fix syntax in node.py

### DIFF
--- a/e2e/libs/node/node.py
+++ b/e2e/libs/node/node.py
@@ -35,9 +35,9 @@ class Node:
                 all_updated = True
                 disks = node.disks
                 for d in disks:
-                    if disks[d]["diskUUID"] == "" or
-                        not disks[d]["conditions"] or
-                        disks[d]["conditions"]["Ready"]["status"] != "True" or
+                    if disks[d]["diskUUID"] == "" or \
+                        not disks[d]["conditions"] or \
+                        disks[d]["conditions"]["Ready"]["status"] != "True" or \
                         disks[d]["conditions"]["Schedulable"]["status"] != "True":
                         all_updated = False
                         break


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

When run self built test image I encountered below error, fix it by this PR
```
==============================================================================
Tests                                                                         
==============================================================================
[ ERROR ] Error in file '/e2e/keywords/common.resource' on line 4: Importing library '/e2e/libs/keywords/common_keywords.py' failed: SyntaxError: invalid syntax (node.py, line 38)
Traceback (most recent call last):
  File "/e2e/libs/keywords/common_keywords.py", line 2, in <module>
    from node import Node
  File "/e2e/libs/node/__init__.py", line 1, in <module>
    from node.node import Node
```
#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
