### PR TITLE
test: update test_backup_with_backing_image

### DIFF
--- a/manager/integration/tests/test_backing_image.py
+++ b/manager/integration/tests/test_backing_image.py
@@ -32,7 +32,7 @@ from common import cleanup_all_recurring_jobs
 from common import BACKING_IMAGE_NAME, BACKING_IMAGE_QCOW2_URL, \
     BACKING_IMAGE_RAW_URL, BACKING_IMAGE_EXT4_SIZE, \
     DIRECTORY_PATH, BACKING_IMAGE_SOURCE_TYPE_DOWNLOAD, \
-    BACKING_IMAGE_SOURCE_TYPE_FROM_VOLUME, Gi
+    BACKING_IMAGE_SOURCE_TYPE_FROM_VOLUME, Gi, SIZE
 
 from common import wait_for_volume_detached
 from common import wait_for_backing_image_status
@@ -264,11 +264,12 @@ def test_snapshot_prune_and_coalesce_simultaneously_with_backing_image(client, v
 
 @pytest.mark.coretest   # NOQA
 @pytest.mark.backing_image  # NOQA
-def test_backup_with_backing_image(set_random_backupstore, client, volume_name):  # NOQA
+@pytest.mark.parametrize("volume_size", [str(BACKING_IMAGE_EXT4_SIZE), SIZE]) # NOQA
+def test_backup_with_backing_image(set_random_backupstore, client, volume_name, volume_size):  # NOQA
     for bi_url in (BACKING_IMAGE_QCOW2_URL, BACKING_IMAGE_RAW_URL):
         create_backing_image_with_matching_url(
             client, BACKING_IMAGE_NAME, bi_url)
-        backup_test(client, volume_name, str(BACKING_IMAGE_EXT4_SIZE),
+        backup_test(client, volume_name, volume_size,
                     BACKING_IMAGE_NAME)
         cleanup_all_volumes(client)
         cleanup_all_backing_images(client)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#9227

#### What this PR does / why we need it:

Add scenario for backing image size larger than volume size then backup volume.

Currently this scenario only included in `test_system_backup_and_restore_volume_with_backingimage` but v1.6.x does not support system backup with backing image so the scenario not tested in v1.6,x.

#### Special notes for your reviewer:

test result
- [amd](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7480/)
- [arm](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7477/)
- [sle-micro arm](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7478/)

#### Additional documentation or context
