### PR TITLE
Fix flaky test_exporting_backing_image_from_volume on sle-micro arm64

### DIFF
--- a/manager/integration/tests/test_backing_image.py
+++ b/manager/integration/tests/test_backing_image.py
@@ -515,7 +515,7 @@ def test_exporting_backing_image_from_volume(client, volume_name):  # NOQA
         client, volume_name=volume3_name, size=str(1 * Gi),
         backing_image=backing_img2["name"])
     volume3 = volume3.attach(hostId=hostId)
-    volume3 = wait_for_volume_healthy(client, volume3_name, 300)
+    volume3 = wait_for_volume_healthy(client, volume3_name, 450)
 
     # Step10
     check_volume_data(volume3, data2)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#9254

#### What this PR does / why we need it:
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7486/
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7487/

After executing the test case 20 times, I found that `volume3 = wait_for_volume_healthy` takes 350 to 450 seconds. 

![Screenshot_20240820_124311](https://github.com/user-attachments/assets/6f44e680-d25f-410f-bb03-b35d008252b5)


#### Special notes for your reviewer:

#### Additional documentation or context
