### PR TITLE
test(integration): DR volume when volume backup policy set to always

### DIFF
--- a/manager/integration/tests/test_system_backup_restore.py
+++ b/manager/integration/tests/test_system_backup_restore.py
@@ -30,8 +30,10 @@ from common import create_pvc_for_volume
 from common import check_pvc_existence
 from common import check_pv_existence
 from common import check_backing_image_disk_map_status
+from common import wait_for_backup_restore_completed
 
 from common import SETTING_BACKUPSTORE_POLL_INTERVAL
+from common import SIZE
 
 from backupstore import set_random_backupstore  # NOQA
 
@@ -261,6 +263,8 @@ def test_system_backup_with_volume_backup_policy_always(client, volume_name, set
 
     Given a volume is created.
     And volume has backup count (1).
+    And create a DR volume from backup
+    And wait for DR volume to restore from backup
 
     When system backup (system-backup) has volume backup policy (always).
     And system backup (system-backup) created.
@@ -279,7 +283,14 @@ def test_system_backup_with_volume_backup_policy_always(client, volume_name, set
     volume.attach(hostId=host_id)
     volume = wait_for_volume_healthy(client, volume_name)
 
-    create_backup(client, volume_name)
+    _, backup, _, _ = create_backup(client, volume_name)
+
+    # System backup should skip creating DR volume backup.
+    dr_volume_name = volume_name + "-dr"
+    client.create_volume(name=dr_volume_name, size=SIZE,
+                         numberOfReplicas=1, fromBackup=backup.url,
+                         frontend="", standby=True)
+    wait_for_backup_restore_completed(client, dr_volume_name, backup.name)
 
     system_backup_name = system_backup_random_name()
     client.create_system_backup(Name=system_backup_name,


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9330, longhorn/longhorn#9338

#### What this PR does / why we need it:

Add DR volume to `test_system_backup_with_volume_backup_policy_always`.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
