### PR TITLE
test: fix flaky test case test_csi_block_volume_online_expansion caused by md5 calculation timeout

### DIFF
--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -552,7 +552,7 @@ def test_csi_block_volume_online_expansion(client, core_api, storage_class, pvc,
     expand_and_wait_for_pvc(core_api, pvc, (EXPANDED_VOLUME_SIZE+1)*Gi)
     wait_for_volume_expansion(client, volume_name)
 
-    thread_timeout = 60
+    thread_timeout = 120
     try:
         pod_dev_md5 = future.result(timeout=thread_timeout)
     except TimeoutError:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9451

#### What this PR does / why we need it:

fix flaky test case test_csi_block_volume_online_expansion caused by md5 calculation timeout

#### Special notes for your reviewer:

#### Additional documentation or context
