### PR TITLE
fix: attach volumes to eliminate duplicated replicas

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -6494,3 +6494,14 @@ def check_backing_image_eviction_failed(name): # NOQA
         time.sleep(RETRY_INTERVAL)
 
     assert check
+
+
+def wait_for_replica_count(client, volume_name, replica_count):
+    for i in range(RETRY_COUNTS):
+        volume = client.by_id_volume(volume_name)
+        if len(volume.replicas) == replica_count:
+            break
+        time.sleep(RETRY_INTERVAL)
+
+    volume = client.by_id_volume(volume_name)
+    assert len(volume.replicas) == replica_count

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -83,6 +83,7 @@ from common import DEFAULT_BACKUP_COMPRESSION_METHOD
 from common import wait_scheduling_failure
 from common import set_tags_for_node_and_its_disks
 from common import wait_for_tainted_node_engine_image_undeployed
+from common import wait_for_replica_count
 
 from backupstore import set_random_backupstore # NOQA
 from backupstore import backupstore_cleanup
@@ -2877,11 +2878,13 @@ def test_engine_image_not_fully_deployed_perform_auto_upgrade_engine(client, cor
     tainted node and not fully deployed engine.
 
     1. Create 2 volumes vol-1 and vol-2 with 2 replicas
-    2. Deploy a new engine image, new-ei
-    3. Upgrade vol-1 and vol-2 to the new-ei
-    4. Attach vol-2 to current-node
-    5. Set `Concurrent Automatic Engine Upgrade Per Node Limit` setting to 3
-    6. In a 2-min retry, verify that Longhorn upgrades the engine image of
+    2. Attach both volumes to make sure they are healthy and have 2 replicas
+    4. Detach both volumes
+    5. Deploy a new engine image, new-ei
+    6. Upgrade vol-1 and vol-2 to the new-ei
+    7. Attach vol-2 to current-node
+    8. Set `Concurrent Automatic Engine Upgrade Per Node Limit` setting to 3
+    9. In a 2-min retry, verify that Longhorn upgrades the engine image of
        vol-1 and vol-2.
     """
     tainted_node_id = \
@@ -2894,6 +2897,18 @@ def test_engine_image_not_fully_deployed_perform_auto_upgrade_engine(client, cor
     volume2 = create_and_check_volume(client, "vol-2",
                                       num_of_replicas=2,
                                       size=str(3 * Gi))
+
+    volume1.attach(hostId=get_self_host_id())
+    volume2.attach(hostId=get_self_host_id())
+    volume1 = wait_for_volume_healthy(client, volume1.name)
+    volume2 = wait_for_volume_healthy(client, volume2.name)
+    wait_for_replica_count(client, volume1.name, 2)
+    wait_for_replica_count(client, volume2.name, 2)
+
+    volume1.detach()
+    volume2.detach()
+    volume1 = wait_for_volume_detached(client, volume1.name)
+    volume2 = wait_for_volume_detached(client, volume2.name)
 
     default_img = common.get_default_engine_image(client)
     # engine reference =


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8573

https://github.com/longhorn/longhorn/issues/8573#issuecomment-2348405896
When the engine image is not stable, there is a chance that the volume changes the owner and creates duplicated replicas.
This might fail this e2e test because it checks the number of replicas before the volume is attached.

We should attach the volume and let Longhorn deletes duplicated replicas before starting the test.
