### PR TITLE
Script to generate longhorn.yaml with version replacement

### DIFF
--- a/test_tools/update_LH_ver_with_download.sh
+++ b/test_tools/update_LH_ver_with_download.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Check if the correct number of arguments are provided
+if [ "$#" -ne 3 ]; then
+    echo ""
+    echo "Usage: $0 <old_version> <new_version> <longhorn_version>"
+    echo ""
+    echo "Arguments:"
+    echo "  <old_version>       The version of Longhorn images to be replaced (e.g., v1.7.x-head, v1.8.x-head, v1.9.x-head, master)."
+    echo "  <new_version>       The new version of Longhorn images to use (e.g., v1.9.1-dev-20250810, master-head)."
+    echo "  <longhorn_version>  The branch or tag from which to download the Longhorn YAML file."
+    echo ""
+    echo "  Examples:"
+    echo ""
+    echo "    # For downloading longhorn.yaml from the v1.7.x branch"
+    echo "    $0 v1.7.x-head v1.7.4-dev-20250810 v1.7.x"
+    echo ""
+    echo "    # For downloading longhorn.yaml from the v1.8.x branch"
+    echo "    $0 v1.8.x-head v1.8.3-dev-20250810 v1.8.x"
+    echo ""
+    echo "    # For downloading longhorn.yaml from the v1.9.x branch"
+    echo "    $0 v1.9.x-head v1.9.1-dev-20250810 v1.9.x"
+    echo ""
+    echo "    # For downloading longhorn.yaml from the master branch"
+    echo "    $0 master-head v1.10.0-dev-20250810 master"
+    echo ""
+    exit 1
+fi
+
+# Capture the input arguments
+OLD_VERSION=$1
+NEW_VERSION=$2
+LONGHORN_VERSION=$3
+
+# Define the file path for the downloaded longhorn.yaml
+FILE_PATH="longhorn.yaml"
+
+# Print the URL to be downloaded
+echo "Downloading: https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml"
+
+# Download the specified version of the longhorn.yaml file
+if ! wget -O "$FILE_PATH" "https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_VERSION}/deploy/longhorn.yaml"; then
+    echo "Error downloading longhorn.yaml. Please check the Longhorn version."
+    exit 1
+fi
+
+# Define the list of Longhorn image names
+IMAGES=(
+    "longhornio/longhorn-ui"
+    "longhornio/longhorn-manager"
+    "longhornio/longhorn-engine"
+    "longhornio/longhorn-instance-manager"
+    "longhornio/longhorn-share-manager"
+    "longhornio/backing-image-manager"
+)
+
+# Loop through each image and perform the find/replace
+for IMAGE in "${IMAGES[@]}"; do
+    # Use sed to replace old version with new version
+    sed -i "s|${IMAGE}:${OLD_VERSION}|${IMAGE}:${NEW_VERSION}|g" "$FILE_PATH"
+done
+
+# Define the new filename based on the new version
+NEW_FILE_PATH="longhorn-${NEW_VERSION}.yaml"
+
+# Move the modified file to the new file name
+mv "$FILE_PATH" "$NEW_FILE_PATH"
+
+echo "Replacement complete. Updated file saved as $NEW_FILE_PATH."


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#9512

#### What this PR does / why we need it:
The script is provided that can:
- Take arguments for the `old version`, `new version`, and `Longhorn version`.
- Download the corresponding longhorn.yaml file.
- Perform a search-and-replace operation to update all relevant image tags.
- Save the final file with a filename based on the major version number.

```console
> ./update_LH_ver_with_download.sh 

Usage: ./update_LH_ver_with_download.sh <old_version> <new_version> <longhorn_version>

Arguments:
  <old_version>       The version of Longhorn images to be replaced (e.g., v1.6.3, v1.7.1).
  <new_version>       The new version of Longhorn images to use (e.g., v1.6.3-dev-20240922, v1.7.x-head).
  <longhorn_version>  The branch or tag from which to download the Longhorn YAML file.

  Examples:

    # For downloading longhorn.yaml from the v1.6.x branch
    ./update_LH_ver_with_download.sh v1.6.3 v1.6.3-dev-20240922 v1.6.x

    # For downloading longhorn.yaml from the v1.7.x branch
    ./update_LH_ver_with_download.sh v1.7.1 v1.7.x-head v1.7.x

    # For downloading longhorn.yaml from the master branch
    ./update_LH_ver_with_download.sh master-head v1.8.0-dev-20240922 master

```

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Bash script that simplifies updating version numbers within a downloaded YAML configuration file.
	- The script validates input parameters, automatically downloads the necessary configuration file, and updates version strings across relevant images.
	- It provides clear feedback on the operation's success or failure, ensuring a streamlined update process for Longhorn deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->