### PR TITLE
test(robot): v2 volume should block trim when volume is degraded

### DIFF
--- a/e2e/keywords/workload.resource
+++ b/e2e/keywords/workload.resource
@@ -189,3 +189,14 @@ Check ${workload_kind} ${workload_id} pod is ${expect_state} on another node
 Delete Longhorn ${workload_kind} ${workload_name} pod on node ${node_id}
     ${node_name} =    get_node_by_index    ${node_id}
     delete_workload_pod_on_node    ${workload_name}    ${node_name}    longhorn-system
+
+Trim ${workload_kind} ${workload_id} volume should ${condition}
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+
+    IF    $condition == "fail"
+        trim_workload_volume_filesystem    ${workload_name}    is_expect_fail=True
+    ELSE IF    $condition == "pass"
+        trim_workload_volume_filesystem    ${workload_name}    is_expect_fail=False
+    ELSE
+        Fail    "Invalid condition value: ${condition}"
+    END

--- a/e2e/libs/keywords/workload_keywords.py
+++ b/e2e/libs/keywords/workload_keywords.py
@@ -192,3 +192,7 @@ class workload_keywords:
             if not is_workload_pods_has_annotations(workload_name, annotation_key, namespace=namespace, label_selector=label_selector):
                 return False
         return True
+
+    def trim_workload_volume_filesystem(self, workload_name, is_expect_fail=False):
+        volume_name = get_workload_volume_name(workload_name)
+        self.volume.trim_filesystem(volume_name, is_expect_fail=is_expect_fail)

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -511,3 +511,6 @@ class CRD(Base):
         volume = self.get(volume_name)
         assert str(volume["spec"][setting_name]) == value, \
             f"Expected volume {volume_name} setting {setting_name} is {value}, but it's {str(volume['spec'][setting_name])}"
+
+    def trim_filesystem(self, volume_name, is_expect_fail=False):
+        return Rest(self).trim_filesystem(volume_name, is_expect_fail=is_expect_fail)

--- a/e2e/libs/volume/rest.py
+++ b/e2e/libs/volume/rest.py
@@ -370,3 +370,20 @@ class Rest(Base):
                 break
             time.sleep(self.retry_interval)
         assert ready, f"Failed to get volume {volume_name} replicas ready: {replicas}"
+
+    def trim_filesystem(self, volume_name, is_expect_fail=False):
+        is_unexpected_pass = False
+        try:
+            self.get(volume_name).trimFilesystem(name=volume_name)
+
+            if is_expect_fail:
+                is_unexpected_pass = True
+
+        except Exception as e:
+            if is_expect_fail:
+                logging(f"Failed to trim filesystem: {e}")
+            else:
+                raise e
+
+        if is_unexpected_pass:
+            raise Exception(f"Expected volume {volume_name} trim filesystem to fail")

--- a/e2e/libs/volume/volume.py
+++ b/e2e/libs/volume/volume.py
@@ -154,3 +154,6 @@ class Volume(Base):
 
     def validate_volume_setting(self, volume_name, setting_name, value):
         return self.volume.validate_volume_setting(volume_name, setting_name, value)
+
+    def trim_filesystem(self, volume_name, is_expect_fail=False):
+        return self.volume.trim_filesystem(volume_name, is_expect_fail=is_expect_fail)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8430

#### What this PR does / why we need it:

Propose a new robot case to test v2 volume should block trim when the volume is degraded.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new keyword for trimming workload volumes based on specified conditions.
	- Added methods to handle filesystem trimming operations with expected outcomes.
  
- **Bug Fixes**
	- Enhanced error handling for filesystem trimming to differentiate between expected and unexpected failures.

- **Tests**
	- Added a comprehensive test case to ensure trimming fails when a volume is in a degraded state and succeeds when it is not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->