### PR TITLE
fix(robot): delete backing images at teardown

### DIFF
--- a/e2e/libs/backing_image/backing_image.py
+++ b/e2e/libs/backing_image/backing_image.py
@@ -29,4 +29,4 @@ class BackingImage(Base):
         return self.backing_image.delete(bi_name)
 
     def cleanup_backing_images(self):
-        return self.backing_image.cleanup_backing_images
+        return self.backing_image.cleanup_backing_images()


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Let backuping images clean up been executed at test case teardown.

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
