### PR TITLE
test(robot): replace "Cleanup test resources include off nodes" with "Cleanup test resources"

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -35,10 +35,7 @@ Set test environment
     END
 
 Cleanup test resources
-    ${variables}=     Get Variables
-    IF    "\${powered_off_node}" in "$variables"
-        power_on_node_by_name    ${powered_off_node}
-    END
+    Power on off node
     uncordon_all_nodes
     cleanup_control_plane_network_latency
     reset_node_schedule

--- a/e2e/tests/negative/node_drain.robot
+++ b/e2e/tests/negative/node_drain.robot
@@ -176,7 +176,6 @@ Stopped replicas on deleted nodes should not be counted as healthy replicas when
     ...    And All pods on Node_2 are evicted except the replica instance manager pod.
     ...        kubectl get pods --field-selector spec.nodeName=<Node_2 name> -o wide -n longhorn-system
     ...    And The last healthy replica exists on the Node_2.
-    [Teardown]    Cleanup test resources include off nodes
     Given Disable node 0 scheduling
     And Set setting node-drain-policy to block-if-contains-last-replica
     And Given Create volume 0 with    size=5Gi    numberOfReplicas=2    dataEngine=${DATA_ENGINE}
@@ -209,7 +208,6 @@ Setting Allow Node Drain with the Last Healthy Replica protects the last healthy
     ...        kubectl get pods --field-selector spec.nodeName=<Node_2 name> -o wide -n longhorn-system
     ...    And The PDB will be deleted and can be verified with the following command:
     ...        kubectl get pdb <replica name, e.g., instance-manager-r-xxxxxxxx> -n longhorn-system
-    [Teardown]    Cleanup test resources include off nodes
     Given Disable node 0 scheduling
     And Set setting node-drain-policy to block-if-contains-last-replica
     And Given Create volume 0 with    size=5Gi    numberOfReplicas=2        dataEngine=${DATA_ENGINE}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

replace "Cleanup test resources include off nodes" with "Cleanup test resources"

#### Special notes for your reviewer:

#### Additional documentation or context
