### PR TITLE
fix(robot): Single Replica Node Down Deletion Policy do-nothing With RWO Volume Replica Locate On Replica Node

### DIFF
--- a/e2e/libs/workload/pod.py
+++ b/e2e/libs/workload/pod.py
@@ -122,7 +122,7 @@ def create_pod(manifest, is_wait_for_pod_running=False):
 def delete_pod(name, namespace='default'):
     core_api = client.CoreV1Api()
     try:
-        core_api.delete_namespaced_pod(name=name, namespace=namespace, delete_namespaced_pod=0)
+        core_api.delete_namespaced_pod(name=name, namespace=namespace, grace_period_seconds=0)
         wait_delete_pod(name)
     except rest.ApiException as e:
         assert e.status == 404

--- a/e2e/tests/negative/node_reboot.robot
+++ b/e2e/tests/negative/node_reboot.robot
@@ -287,12 +287,10 @@ Single Replica Node Down Deletion Policy do-nothing With RWO Volume Replica Loca
     And Delete replica of deployment 0 volume on replica node
     And Delete replica of deployment 0 volume on volume node
     And Power off volume node of deployment 0
-    Then Wait for volume of deployment 0 stuck in state attaching
     And Wait for deployment 0 pod stuck in Terminating on the original node
 
     When Power on off node
     And Wait for deployment 0 pods stable
-    And Check deployment 0 pod is Running on another node
     Then Check deployment 0 data in file data is intact
 
 Single Replica Node Down Deletion Policy do-nothing With RWO Volume Replica Locate On Volume Node


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9498

#### What this PR does / why we need it:

When the `node-down-pod-deletion-policy` is set to `do-nothing`, Longhorn doesn't actively delete the workload pod. In this case, reattaching may not happen, as this behavior will depend on Kubernetes' response. We should remove the check of the volume's attaching state and just ensure that the workload pod is in a terminating state, which is expected.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
