### PR TITLE
fix(robot): Single Replica Node Down Deletion Policy do-nothing With RWO Volume Replica Locate On Volume Node

### DIFF
--- a/e2e/tests/negative/node_reboot.robot
+++ b/e2e/tests/negative/node_reboot.robot
@@ -305,12 +305,10 @@ Single Replica Node Down Deletion Policy do-nothing With RWO Volume Replica Loca
     And Update volume of deployment 0 replica count to 1
     And Delete replica of deployment 0 volume on all replica node
     And Power off volume node of deployment 0
-    Then Wait for volume of deployment 0 faulted
     And Wait for deployment 0 pod stuck in Terminating on the original node
 
     When Power on off node
     And Wait for deployment 0 pods stable
-    And Check deployment 0 pod is Running on the original node
     Then Check deployment 0 data in file data is intact
 
 Single Replica Node Down Deletion Policy delete-deployment-pod With RWO Volume Replica Locate On Replica Node


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9622

#### What this PR does / why we need it:

Remove redundant intermediate check as when node down deletion policy is set to `do-nothing`, the workload pod deletion isn't handled by Longhorn.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`Name`
