### PR TITLE
fix(robot): fix flaky test case Disrupt Data Plane Traffic For Less Than Long Engine Replica Timeout

### DIFF
--- a/e2e/tests/regression/test_ha.robot
+++ b/e2e/tests/regression/test_ha.robot
@@ -21,15 +21,17 @@ ${RETRY_INTERVAL}    1
 
 *** Test Cases ***
 Disrupt Data Plane Traffic For Less Than Long Engine Replica Timeout
-    Given Set setting engine-replica-timeout to 8
+    Given Set setting engine-replica-timeout to 15
     And Set setting auto-salvage to false
     And Create storageclass longhorn-test with    dataEngine=v1
     And Create statefulset 0 using RWO volume with longhorn-test storageclass
-    And Drop instance-manager egress traffic of statefulset 0 for 10 seconds without waiting for completion
-    Then Write 1024 MB data to file data in statefulset 0
-    And Wait for volume of statefulset 0 attached and degraded
-    And Wait for volume of statefulset 0 healthy
-    And Check statefulset 0 data in file data is intact
+    FOR    ${i}    IN RANGE    ${LOOP_COUNT}
+        And Drop instance-manager egress traffic of statefulset 0 for 25 seconds without waiting for completion
+        Then Write 1024 MB data to file data in statefulset 0
+        And Wait for volume of statefulset 0 attached and degraded
+        And Wait for volume of statefulset 0 healthy
+        And Check statefulset 0 data in file data is intact
+    END
 
 Don't Orphan Processes When Node Not Ready
     [Tags]    robot:skip


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9276

#### What this PR does / why we need it:

fix flaky test case Disrupt Data Plane Traffic For Less Than Long Engine Replica Timeout

#### Special notes for your reviewer:

#### Additional documentation or context
