### PR TITLE
ci: support cifs and azurite on pytest and e2e

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -14,11 +14,14 @@ curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/master/scripts/en
 
 ### Run the test
 
-1. Deploy all backupstore servers (including `NFS` server and `Minio` as s3 server) for test purposes.
+1. Deploy all backupstore servers (including `NFS` server and `Minio` as s3 server, `CIFS` and `Azurite` server) for test purposes.
+
+   For Azurite, there are some manual steps need to be done after manifest deployed(https://github.com/longhorn/longhorn-tests/wiki/Setup-Azurite-Backupstore-For-Testing).
 ```
 kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/minio-backupstore.yaml \
                -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml \
-               -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml
+               -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml \
+               -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/azurite-backupstore.yaml
 ```
 
 1. Expose Longhorn API:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -17,7 +17,8 @@ curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/master/scripts/en
 1. Deploy all backupstore servers (including `NFS` server and `Minio` as s3 server) for test purposes.
 ```
 kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/minio-backupstore.yaml \
-               -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml
+               -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml \
+               -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml
 ```
 
 1. Expose Longhorn API:

--- a/manager/integration/README.md
+++ b/manager/integration/README.md
@@ -19,7 +19,8 @@ Run the test:
 1. Deploy all backupstore servers(including `NFS` server and `Minio` as s3 server) for test purposes.
 ```
 kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/minio-backupstore.yaml \
-               -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml
+               -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml \
+               -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml
 ```
 2. Deploy the test script to the Kubernetes cluster.
 ```

--- a/manager/integration/README.md
+++ b/manager/integration/README.md
@@ -16,11 +16,14 @@ Requirement:
 6. Make sure `nfs-common` or equivalent has been installed on the node to allow the NFS client to work.
 
 Run the test:
-1. Deploy all backupstore servers(including `NFS` server and `Minio` as s3 server) for test purposes.
+1. Deploy all backupstore servers(including `NFS` server and `Minio` as s3 server `CIFS` and `Azurite` server) for test purposes.
+   
+   For Azurite, there are some manual steps need to be done after manifest deployed(https://github.com/longhorn/longhorn-tests/wiki/Setup-Azurite-Backupstore-For-Testing).
 ```
 kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/minio-backupstore.yaml \
                -f https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml \
-               -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml
+               -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml \
+               -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/azurite-backupstore.yaml
 ```
 2. Deploy the test script to the Kubernetes cluster.
 ```

--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -42,7 +42,7 @@ spec:
     - name: LONGHORN_JUNIT_REPORT_PATH
       value: /tmp/test-report/longhorn-test-junit-report.xml
     - name: LONGHORN_BACKUPSTORES
-      value: "s3://backupbucket@us-east-1/backupstore$minio-secret, nfs://longhorn-test-nfs-svc.default:/opt/backupstore"
+      value: "s3://backupbucket@us-east-1/backupstore$minio-secret, nfs://longhorn-test-nfs-svc.default:/opt/backupstore, cifs://longhorn-test-cifs-svc.default/backupstore$cifs-secret"
     - name: LONGHORN_BACKUPSTORE_POLL_INTERVAL
       value: "30"
     - name: LONGHORN_DISK_TYPE

--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -42,7 +42,7 @@ spec:
     - name: LONGHORN_JUNIT_REPORT_PATH
       value: /tmp/test-report/longhorn-test-junit-report.xml
     - name: LONGHORN_BACKUPSTORES
-      value: "s3://backupbucket@us-east-1/backupstore$minio-secret, nfs://longhorn-test-nfs-svc.default:/opt/backupstore, cifs://longhorn-test-cifs-svc.default/backupstore$cifs-secret"
+      value: "s3://backupbucket@us-east-1/backupstore$minio-secret, nfs://longhorn-test-nfs-svc.default:/opt/backupstore, cifs://longhorn-test-cifs-svc.default/backupstore$cifs-secret, azblob://longhorn-test-azurite@core.windows.net/$azblob-secret"
     - name: LONGHORN_BACKUPSTORE_POLL_INTERVAL
       value: "30"
     - name: LONGHORN_DISK_TYPE

--- a/manager/integration/tests/backupstore.py
+++ b/manager/integration/tests/backupstore.py
@@ -17,6 +17,7 @@ from common import LONGHORN_NAMESPACE
 from common import cleanup_all_volumes
 from common import is_backupTarget_s3
 from common import is_backupTarget_nfs
+from common import is_backupTarget_cifs
 from common import get_longhorn_api_client
 from common import delete_backup_volume
 from common import delete_backup_backing_image
@@ -64,6 +65,8 @@ def set_random_backupstore(request, client):
     elif request.param == "nfs":
         set_backupstore_nfs(client)
         mount_nfs_backupstore(client)
+    elif request.param == "cifs":
+        set_backupstore_cifs(client)
 
     yield
     cleanup_all_volumes(client)
@@ -112,6 +115,18 @@ def set_backupstore_nfs(client):
         if is_backupTarget_nfs(backupstore):
             set_backupstore_url(client, backupstore)
             set_backupstore_credential_secret(client, "")
+            set_backupstore_poll_interval(client, poll_interval)
+            break
+
+
+def set_backupstore_cifs(client):
+    backupstores = get_backupstore_url()
+    poll_interval = get_backupstore_poll_interval()
+    for backupstore in backupstores:
+        if is_backupTarget_cifs(backupstore):
+            backupsettings = backupstore.split("$")
+            set_backupstore_url(client, backupsettings[0])
+            set_backupstore_credential_secret(client, backupsettings[1])
             set_backupstore_poll_interval(client, poll_interval)
             break
 

--- a/manager/integration/tests/backupstore.py
+++ b/manager/integration/tests/backupstore.py
@@ -18,6 +18,7 @@ from common import cleanup_all_volumes
 from common import is_backupTarget_s3
 from common import is_backupTarget_nfs
 from common import is_backupTarget_cifs
+from common import is_backupTarget_azurite
 from common import get_longhorn_api_client
 from common import delete_backup_volume
 from common import delete_backup_backing_image
@@ -67,8 +68,10 @@ def set_random_backupstore(request, client):
         mount_nfs_backupstore(client)
     elif request.param == "cifs":
         set_backupstore_cifs(client)
+    elif request.param == "azblob":
+        set_backupstore_azurite(client)
 
-    yield
+    yield request.param
     cleanup_all_volumes(client)
     backupstore_cleanup(client)
     system_backups_cleanup(client)
@@ -124,6 +127,18 @@ def set_backupstore_cifs(client):
     poll_interval = get_backupstore_poll_interval()
     for backupstore in backupstores:
         if is_backupTarget_cifs(backupstore):
+            backupsettings = backupstore.split("$")
+            set_backupstore_url(client, backupsettings[0])
+            set_backupstore_credential_secret(client, backupsettings[1])
+            set_backupstore_poll_interval(client, poll_interval)
+            break
+
+
+def set_backupstore_azurite(client):
+    backupstores = get_backupstore_url()
+    poll_interval = get_backupstore_poll_interval()
+    for backupstore in backupstores:
+        if is_backupTarget_azurite(backupstore):
             backupsettings = backupstore.split("$")
             set_backupstore_url(client, backupsettings[0])
             set_backupstore_credential_secret(client, backupsettings[1])
@@ -289,7 +304,7 @@ def backupstore_get_backup_volume_prefix(client, volume_name):
         return nfs_get_backup_volume_prefix(client, volume_name)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def minio_get_backup_volume_prefix(volume_name):
@@ -326,7 +341,7 @@ def backupstore_get_backup_cfg_file_path(client, volume_name, backup_name):
         return nfs_get_backup_cfg_file_path(client, volume_name, backup_name)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def minio_get_backup_cfg_file_path(volume_name, backup_name):
@@ -349,7 +364,7 @@ def backupstore_get_volume_cfg_file_path(client, volume_name):
         return nfs_get_volume_cfg_file_path(client, volume_name)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def nfs_get_volume_cfg_file_path(client, volume_name):
@@ -372,7 +387,7 @@ def backupstore_get_backup_blocks_dir(client, volume_name):
         return nfs_get_backup_blocks_dir(client, volume_name)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def minio_get_backup_blocks_dir(volume_name):
@@ -398,7 +413,7 @@ def backupstore_create_file(client, core_api, file_path, data={}):
         return nfs_create_file_in_backupstore(file_path, data={})
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def mino_create_file_in_backupstore(client, core_api, file_path, data={}): # NOQA
@@ -448,7 +463,7 @@ def backupstore_write_backup_cfg_file(client, core_api, volume_name, backup_name
                                   data)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def nfs_write_backup_cfg_file(client, volume_name, backup_name, data):
@@ -496,7 +511,7 @@ def backupstore_delete_file(client, core_api, file_path):
         return nfs_delete_file_in_backupstore(file_path)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def mino_delete_file_in_backupstore(client, core_api, file_path):
@@ -536,7 +551,7 @@ def backupstore_delete_backup_cfg_file(client, core_api, volume_name, backup_nam
         nfs_delete_backup_cfg_file(client, volume_name, backup_name)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def nfs_delete_backup_cfg_file(client, volume_name, backup_name):
@@ -578,7 +593,7 @@ def backupstore_delete_volume_cfg_file(client, core_api, volume_name):  # NOQA
         nfs_delete_volume_cfg_file(client, volume_name)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def nfs_delete_volume_cfg_file(client, volume_name):
@@ -647,7 +662,7 @@ def backupstore_delete_random_backup_block(client, core_api, volume_name):
         nfs_delete_random_backup_block(client, volume_name)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def nfs_delete_random_backup_block(client, volume_name):
@@ -696,7 +711,7 @@ def backupstore_count_backup_block_files(client, core_api, volume_name):
         return nfs_count_backup_block_files(client, volume_name)
 
     else:
-        raise NotImplementedError
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
 
 def nfs_count_backup_block_files(client, volume_name):

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3900,6 +3900,10 @@ def is_backupTarget_nfs(s):
     return s.startswith("nfs://")
 
 
+def is_backupTarget_cifs(s):
+    return s.startswith("cifs://")
+
+
 def wait_for_backup_volume(client, vol_name, backing_image=""):
     for _ in range(RETRY_BACKUP_COUNTS):
         bv = client.by_id_backupVolume(vol_name)

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3904,6 +3904,10 @@ def is_backupTarget_cifs(s):
     return s.startswith("cifs://")
 
 
+def is_backupTarget_azurite(s):
+    return s.startswith("azblob://")
+
+
 def wait_for_backup_volume(client, vol_name, backing_image=""):
     for _ in range(RETRY_BACKUP_COUNTS):
         bv = client.by_id_backupVolume(vol_name)

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -673,6 +673,10 @@ def test_backup_block_deletion(set_random_backupstore, client, core_api, volume_
     17. Delete the backup volume
     18. Cleanup the volume
     """
+    backup_store_type = set_random_backupstore
+    if backup_store_type not in ["nfs", "s3"]:
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
+
     backupstore_cleanup(client)
 
     volume = create_and_check_volume(client, volume_name)
@@ -1106,6 +1110,10 @@ def test_backup_volume_list(set_random_backupstore, client, core_api):  # NOQA
     11. delete backup volumes(1 & 2)
     12. cleanup
     """
+    backup_store_type = set_random_backupstore
+    if backup_store_type not in ["nfs", "s3"]:
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
+
     backupstore_cleanup(client)
 
     # create 2 volumes.
@@ -1200,6 +1208,10 @@ def test_backup_metadata_deletion(set_random_backupstore, client, core_api, volu
     18. verify that volume(1) has been deleted in the backupstore.
     19. cleanup
     """
+    backup_store_type = set_random_backupstore
+    if backup_store_type not in ["nfs", "s3"]:
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
+
     backupstore_cleanup(client)
 
     volume1_name = volume_name + "-1"
@@ -4392,7 +4404,7 @@ def test_backuptarget_available_during_engine_image_not_ready(client, apps_api):
             url = backupstore
             cred_secret = ""
         else:
-            raise NotImplementedError
+            pytest.skip("Skip test case because the backup store type is not supported") # NOQA
 
         poll_intervals = ["0", "300"]
         for poll_interval in poll_intervals:

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -1409,6 +1409,10 @@ def test_all_replica_restore_failure(set_random_backupstore, client, core_api, v
     15. Verify the faulted volume cannot be attached to a node.
     16. Verify this faulted volume can be deleted.
     """
+    backup_store_type = set_random_backupstore
+    if backup_store_type not in ["nfs", "s3"]:
+        pytest.skip("Skip test case because the backup store type is not supported") # NOQA
+
     auto_salvage_setting = client.by_id_setting(SETTING_AUTO_SALVAGE)
     assert auto_salvage_setting.name == SETTING_AUTO_SALVAGE
     assert auto_salvage_setting.value == "true"

--- a/pipelines/gke/scripts/longhorn-setup.sh
+++ b/pipelines/gke/scripts/longhorn-setup.sh
@@ -141,8 +141,10 @@ create_longhorn_namespace(){
 install_backupstores(){
   MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml"
   NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/nfs-backupstore.yaml"
+  CIFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml"
   kubectl create -f ${MINIO_BACKUPSTORE_URL} \
-               -f ${NFS_BACKUPSTORE_URL}
+               -f ${NFS_BACKUPSTORE_URL} \
+               -f ${CIFS_BACKUPSTORE_URL}
 }
 
 
@@ -177,6 +179,9 @@ run_longhorn_upgrade_test(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   fi
 
@@ -225,6 +230,9 @@ run_longhorn_tests(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 

--- a/pipelines/gke/scripts/longhorn-setup.sh
+++ b/pipelines/gke/scripts/longhorn-setup.sh
@@ -141,10 +141,8 @@ create_longhorn_namespace(){
 install_backupstores(){
   MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml"
   NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/nfs-backupstore.yaml"
-  CIFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml"
   kubectl create -f ${MINIO_BACKUPSTORE_URL} \
-               -f ${NFS_BACKUPSTORE_URL} \
-               -f ${CIFS_BACKUPSTORE_URL}
+               -f ${NFS_BACKUPSTORE_URL}
 }
 
 
@@ -179,9 +177,6 @@ run_longhorn_upgrade_test(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
-    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
-    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   fi
 
@@ -230,9 +225,6 @@ run_longhorn_tests(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
-    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
-  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
-    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 

--- a/pipelines/utilities/install_backupstores.sh
+++ b/pipelines/utilities/install_backupstores.sh
@@ -2,7 +2,33 @@ install_backupstores(){
   MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/minio-backupstore.yaml"
   NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml"
   CIFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml"
+  AZURITE_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/azurite-backupstore.yaml"
   kubectl create -f ${MINIO_BACKUPSTORE_URL} \
                  -f ${NFS_BACKUPSTORE_URL} \
-                 -f ${CIFS_BACKUPSTORE_URL}
+                 -f ${CIFS_BACKUPSTORE_URL} \
+                 -f ${AZURITE_BACKUPSTORE_URL}
+  setup_azuitize_backup_store
+}
+
+setup_azuitize_backup_store(){
+  RETRY=0
+  MAX_RETRY=60
+  until (kubectl get pods | grep 'longhorn-test-azblob' | grep 'Running'); do
+    echo 'Waiting azurite pod running'
+    sleep 5
+    if [ $RETRY -eq $MAX_RETRY ]; then
+      break
+    fi
+    RETRY=$((RETRY+1))
+  done
+
+  AZBLOB_ENDPOINT=$(echo -n "http://$(kubectl get svc azblob-service -o jsonpath='{.spec.clusterIP}'):10000/" | base64)
+  kubectl -n longhorn-system patch secret azblob-secret \
+    --type=json \
+    -p="[{'op': 'replace', 'path': '/data/AZBLOB_ENDPOINT', 'value': \"${AZBLOB_ENDPOINT}\"}]"
+
+  CONTROL_PLANE_PUBLIC_IP=$(cat /tmp/controlplane_public_ip)
+  # port forward and az container create need to be run on control node
+  ssh ec2-user@${CONTROL_PLANE_PUBLIC_IP} "nohup kubectl port-forward --address 0.0.0.0 service/azblob-service 20001:10000 > /dev/null 2>&1 &"
+  ssh ec2-user@${CONTROL_PLANE_PUBLIC_IP} "az storage container create -n longhorn-test-azurite --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://0.0.0.0:20001/devstoreaccount1;'"
 }

--- a/pipelines/utilities/install_backupstores.sh
+++ b/pipelines/utilities/install_backupstores.sh
@@ -1,6 +1,8 @@
 install_backupstores(){
   MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/minio-backupstore.yaml"
   NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml"
+  CIFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml"
   kubectl create -f ${MINIO_BACKUPSTORE_URL} \
-                 -f ${NFS_BACKUPSTORE_URL}
+                 -f ${NFS_BACKUPSTORE_URL} \
+                 -f ${CIFS_BACKUPSTORE_URL}
 }

--- a/pipelines/utilities/run_longhorn_e2e_test.sh
+++ b/pipelines/utilities/run_longhorn_e2e_test.sh
@@ -1,6 +1,7 @@
 S3_BACKUP_STORE='s3://backupbucket@us-east-1/backupstore$minio-secret'
 NFS_BACKUP_STORE='nfs://longhorn-test-nfs-svc.default:/opt/backupstore'
 CIFS_BACKUP_STORE='cifs://longhorn-test-cifs-svc.default/backupstore$cifs-secret'
+AZURITE_BACKUP_STORE='azblob://longhorn-test-azurite@core.windows.net/$azblob-secret'
 
 run_longhorn_e2e_test(){
 
@@ -25,6 +26,8 @@ run_longhorn_e2e_test(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${NFS_BACKUP_STORE}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${CIFS_BACKUP_STORE}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "azurite" ]]; then
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${AZURITE_BACKUP_STORE}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 
   if [[ "${TF_VAR_use_hdd}" == true ]]; then
@@ -81,6 +84,8 @@ run_longhorn_e2e_test_out_of_cluster(){
     LONGHORN_BACKUPSTORES=${NFS_BACKUP_STORE}
   elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
     LONGHORN_BACKUPSTORES=${CIFS_BACKUP_STORE}
+  elif [[ $BACKUP_STORE_TYPE = "azurite" ]]; then
+    LONGHORN_BACKUPSTORES=${AZURITE_BACKUP_STORE}
   fi
   LONGHORN_BACKUPSTORE_POLL_INTERVAL="30"
 

--- a/pipelines/utilities/run_longhorn_e2e_test.sh
+++ b/pipelines/utilities/run_longhorn_e2e_test.sh
@@ -1,5 +1,6 @@
 S3_BACKUP_STORE='s3://backupbucket@us-east-1/backupstore$minio-secret'
 NFS_BACKUP_STORE='nfs://longhorn-test-nfs-svc.default:/opt/backupstore'
+CIFS_BACKUP_STORE='cifs://longhorn-test-cifs-svc.default/backupstore$cifs-secret'
 
 run_longhorn_e2e_test(){
 
@@ -22,6 +23,8 @@ run_longhorn_e2e_test(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${S3_BACKUP_STORE}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then    
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${NFS_BACKUP_STORE}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${CIFS_BACKUP_STORE}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 
   if [[ "${TF_VAR_use_hdd}" == true ]]; then
@@ -76,6 +79,8 @@ run_longhorn_e2e_test_out_of_cluster(){
     LONGHORN_BACKUPSTORES=${S3_BACKUP_STORE}
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
     LONGHORN_BACKUPSTORES=${NFS_BACKUP_STORE}
+  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
+    LONGHORN_BACKUPSTORES=${CIFS_BACKUP_STORE}
   fi
   LONGHORN_BACKUPSTORE_POLL_INTERVAL="30"
 

--- a/pipelines/utilities/run_longhorn_test.sh
+++ b/pipelines/utilities/run_longhorn_test.sh
@@ -24,6 +24,9 @@ run_longhorn_test(){
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 
   if [[ "${TF_VAR_use_hdd}" == true ]]; then
@@ -106,6 +109,9 @@ run_longhorn_upgrade_test(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   fi
 

--- a/pipelines/utilities/run_longhorn_test.sh
+++ b/pipelines/utilities/run_longhorn_test.sh
@@ -27,6 +27,9 @@ run_longhorn_test(){
   elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "azurite" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $4}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 
   if [[ "${TF_VAR_use_hdd}" == true ]]; then
@@ -112,6 +115,9 @@ run_longhorn_upgrade_test(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "azurite" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $4}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   fi
 

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -333,8 +333,10 @@ create_longhorn_namespace(){
 install_backupstores(){
   MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/minio-backupstore.yaml"
   NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml"
+  CIFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml"
   kubectl create -f ${MINIO_BACKUPSTORE_URL} \
-               -f ${NFS_BACKUPSTORE_URL}
+               -f ${NFS_BACKUPSTORE_URL} \
+               -f ${CIFS_BACKUPSTORE_URL}
 }
 
 
@@ -396,6 +398,9 @@ run_longhorn_upgrade_test(){
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   fi
 
   yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[4].value="'${LONGHORN_UPGRADE_TYPE}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
@@ -449,6 +454,9 @@ run_longhorn_tests(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -334,11 +334,36 @@ install_backupstores(){
   MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/minio-backupstore.yaml"
   NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml"
   CIFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml"
+  AZURITE_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/azurite-backupstore.yaml"
   kubectl create -f ${MINIO_BACKUPSTORE_URL} \
                -f ${NFS_BACKUPSTORE_URL} \
-               -f ${CIFS_BACKUPSTORE_URL}
+               -f ${CIFS_BACKUPSTORE_URL} \
+               -f ${AZURITE_BACKUPSTORE_URL}
+  setup_azuitize_backup_store
 }
 
+setup_azuitize_backup_store(){
+  RETRY=0
+  MAX_RETRY=60
+  until (kubectl get pods | grep 'longhorn-test-azblob' | grep 'Running'); do
+    echo 'Waiting azurite pod running'
+    sleep 5
+    if [ $RETRY -eq $MAX_RETRY ]; then
+      break
+    fi
+    RETRY=$((RETRY+1))
+  done
+
+  AZBLOB_ENDPOINT=$(echo -n "http://$(kubectl get svc azblob-service -o jsonpath='{.spec.clusterIP}'):10000/" | base64)
+  kubectl -n longhorn-system patch secret azblob-secret \
+    --type=json \
+    -p="[{'op': 'replace', 'path': '/data/AZBLOB_ENDPOINT', 'value': \"${AZBLOB_ENDPOINT}\"}]"
+
+  CONTROL_PLANE_PUBLIC_IP=$(cat /tmp/controlplane_public_ip)  
+  # port forward and az container create need to be run on control node
+  ssh ec2-user@${CONTROL_PLANE_PUBLIC_IP} "nohup kubectl port-forward --address 0.0.0.0 service/azblob-service 20001:10000 > /dev/null 2>&1 &"  
+  ssh ec2-user@${CONTROL_PLANE_PUBLIC_IP} "az storage container create -n longhorn-test-azurite --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://0.0.0.0:20001/devstoreaccount1;'"
+}
 
 create_aws_secret(){
   AWS_ACCESS_KEY_ID_BASE64=`echo -n "${TF_VAR_lh_aws_access_key}" | base64`
@@ -401,6 +426,9 @@ run_longhorn_upgrade_test(){
   elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "azurite" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $4}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   fi
 
   yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[4].value="'${LONGHORN_UPGRADE_TYPE}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
@@ -457,6 +485,9 @@ run_longhorn_tests(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   elif [[ $BACKUP_STORE_TYPE = "cifs" ]]; then
     BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $3}' | sed 's/ *//'`
+    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  elif [[ $BACKUP_STORE_TYPE = "azurite" ]]; then
+    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $4}' | sed 's/ *//'`
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 

--- a/test_framework/terraform/aws/centos/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/centos/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -14,7 +14,7 @@ sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /
 
 sudo yum update -y
 sudo yum group install -y "Development Tools"
-sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools
+sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 

--- a/test_framework/terraform/aws/centos/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/centos/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -14,7 +14,7 @@ sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /
 
 sudo yum update -y
 sudo yum group install -y "Development Tools"
-sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools nc
+sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools nc samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 

--- a/test_framework/terraform/aws/oracle/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/oracle/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -2,7 +2,7 @@
 
 sudo yum update -y
 sudo yum group install -y "Development Tools"
-sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper
+sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 # disable nm-cloud-setup otherwise k3s-agent service won’t start.

--- a/test_framework/terraform/aws/oracle/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/oracle/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -2,7 +2,7 @@
 
 sudo yum update -y
 sudo yum group install -y "Development Tools"
-sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper nc
+sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper nc samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -10,7 +10,7 @@ fi
 
 sudo yum update -y
 sudo yum group install -y "Development Tools"
-sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper
+sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer

--- a/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/rhel/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -10,7 +10,7 @@ fi
 
 sudo yum update -y
 sudo yum group install -y "Development Tools"
-sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper nc
+sudo yum install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper nc samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 sudo systemctl disable nm-cloud-setup.service nm-cloud-setup.timer

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -10,7 +10,7 @@ fi
 
 # Do not arbitrarily run "dnf update", as this will effectively move us up to the latest minor release.
 sudo dnf group install -y "Development Tools"
-sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper
+sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 

--- a/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/rockylinux/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -10,7 +10,7 @@ fi
 
 # Do not arbitrarily run "dnf update", as this will effectively move us up to the latest minor release.
 sudo dnf group install -y "Development Tools"
-sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper jq nmap-ncat
+sudo dnf install -y iscsi-initiator-utils nfs-utils nfs4-acl-tools cryptsetup device-mapper jq nmap-ncat samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -5,7 +5,7 @@ set -e
 sudo systemctl restart guestregister # Sometimes registration fails on first boot.
 sudo zypper ref
 sudo zypper install -y -t pattern devel_basis
-sudo zypper install -y open-iscsi nfs-client cryptsetup device-mapper
+sudo zypper install -y open-iscsi nfs-client cryptsetup device-mapper samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_server.sh.tpl
@@ -5,7 +5,7 @@ set -e
 sudo systemctl restart guestregister # Sometimes registration fails on first boot.
 sudo zypper ref
 sudo zypper install -y -t pattern devel_basis
-sudo zypper install -y open-iscsi nfs-client jq
+sudo zypper install -y open-iscsi nfs-client jq azure-cli
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -5,7 +5,7 @@ set -e
 sudo systemctl restart guestregister # Sometimes registration fails on first boot.
 sudo zypper ref
 sudo zypper install -y -t pattern devel_basis
-sudo zypper install -y open-iscsi nfs-client cryptsetup device-mapper
+sudo zypper install -y open-iscsi nfs-client cryptsetup device-mapper samba
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_server.sh.tpl
@@ -5,7 +5,7 @@ set -e
 sudo systemctl restart guestregister # Sometimes registration fails on first boot.
 sudo zypper ref
 sudo zypper install -y -t pattern devel_basis 
-sudo zypper install -y open-iscsi nfs-client jq
+sudo zypper install -y open-iscsi nfs-client jq azure-cli
 sudo systemctl -q enable iscsid
 sudo systemctl start iscsid
 

--- a/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 apt-get update
-apt-get install -y nfs-common cryptsetup dmsetup linux-modules-extra-`uname -r`
+apt-get install -y nfs-common cryptsetup dmsetup samba linux-modules-extra-`uname -r`
 
 modprobe uio
 modprobe uio_pci_generic

--- a/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 apt-get update
-apt-get install -y nfs-common cryptsetup dmsetup linux-modules-extra-`uname -r`
+apt-get install -y nfs-common cryptsetup dmsetup samba linux-modules-extra-`uname -r`
 
 modprobe uio
 modprobe uio_pci_generic

--- a/test_framework/terraform/equinix/ubuntu/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/equinix/ubuntu/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -4,7 +4,7 @@ set -e
 set -x
 
 apt-get update
-apt-get install -y nfs-common cryptsetup dmsetup linux-modules-extra-`uname -r`
+apt-get install -y nfs-common cryptsetup dmsetup samba linux-modules-extra-`uname -r`
 
 modprobe uio
 modprobe uio_pci_generic

--- a/test_framework/terraform/equinix/ubuntu/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/equinix/ubuntu/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -4,7 +4,7 @@ set -e
 set -x
 
 apt-get update
-apt-get install -y nfs-common cryptsetup dmsetup linux-modules-extra-`uname -r`
+apt-get install -y nfs-common cryptsetup dmsetup samba linux-modules-extra-`uname -r`
 
 modprobe uio
 modprobe uio_pci_generic


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #[9699](https://github.com/longhorn/longhorn/issues/9699)

#### What this PR does / why we need it:

ci: support cifs and azurite on pytest and e2e, set `BACKUP_STORE_TYPE` on jenkins to cifs or azurite

#### Special notes for your reviewer:

Currently azurite only support on sles pipeline, for other distro, need to more time for implement

Verified on local jenkins

![image](https://github.com/user-attachments/assets/476dfde3-3bc2-4813-8591-1e13ed6043c8)

![image](https://github.com/user-attachments/assets/8cf31a78-ae12-4480-b6bd-becdc0b191ad)

#### Additional documentation or context

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added support for CIFS and Azure Blob Storage backup stores in deployment instructions and scripts.
	- Enhanced backup store management functionality to include new types and improved validation processes.
	- Introduced new test cases for high availability scenarios and backup status checks.

- **Documentation**
	- Updated README files with instructions for deploying CIFS and Azurite backup stores.
	- Added notes on manual setup steps for Azurite after deployment.

- **Chores**
	- Included the `samba` package in various provisioning scripts to support CIFS functionality.
	- Updated scripts for RKE2 and K3s agents to include `samba` installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->