### PR TITLE
chore(robot): remove duplicated call of reset_backupstore

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -55,5 +55,4 @@ Cleanup test resources
     cleanup_backing_images
     cleanup_engine_images
     reset_backupstore
-    reset_backupstore
     reset_settings


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue `None`

#### What this PR does / why we need it:

The `reset_backupstore` task is being called twice. Should either remove the duplicated call or add a comment to explain why.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

https://github.com/longhorn/longhorn-tests/pull/2080/files#diff-84cbf5801bda0fa4be66cfbfdc6b0b4ff977edc0485718924095d3947c2c0529R54-R55
