### PR TITLE
fix(node): cleanup node exec in test case teardown

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -42,6 +42,7 @@ Cleanup test resources
     uncordon_all_nodes
     cleanup_control_plane_network_latency
     reset_node_schedule
+    cleanup_node_exec
     cleanup_stress_helper
     cleanup_recurringjobs
     cleanup_deployments

--- a/e2e/libs/keywords/common_keywords.py
+++ b/e2e/libs/keywords/common_keywords.py
@@ -1,4 +1,5 @@
 from node import Node
+from node_exec import NodeExec
 from utility.utility import init_k8s_api_client
 from utility.utility import generate_name_with_suffix
 
@@ -19,3 +20,7 @@ class common_keywords:
 
     def get_node_by_index(self, node_id):
         return Node().get_node_by_index(node_id)
+
+    def cleanup_node_exec(self):
+        for node_name in Node().list_node_names_by_role("all"):
+            NodeExec(node_name).cleanup()

--- a/e2e/libs/node_exec/node_exec.py
+++ b/e2e/libs/node_exec/node_exec.py
@@ -17,8 +17,6 @@ class NodeExec:
     def __init__(self, node_name):
         self.node_name = node_name
         self.core_api = client.CoreV1Api()
-        self.cleanup()
-        self.pod = self.launch_pod()
 
     def cleanup(self):
         if get_pod(self.node_name):
@@ -26,6 +24,10 @@ class NodeExec:
             delete_pod(self.node_name)
 
     def issue_cmd(self, cmd):
+
+        self.cleanup()
+        self.pod = self.launch_pod()
+
         logging(f"Issuing command on {self.node_name}: {cmd}")
 
         if isinstance(cmd, list):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9649

#### What this PR does / why we need it:

cleanup node exec in test case teardown

cleanup node exec after test case complete

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new cleanup keyword, `cleanup_node_exec`, to enhance resource management during tests.
	- Added a method to dynamically manage node execution cleanup and pod launching.

- **Bug Fixes**
	- Adjusted the lifecycle management of pods to ensure proper cleanup and launching with each command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->