### PR TITLE
test(robot): add test case Shutdown Volume Node And Test Auto Reattach To A New Node

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation       Common keywords
 
+Library             Collections
 Library             OperatingSystem
 Library             ../libs/keywords/common_keywords.py
 Library             ../libs/keywords/deployment_keywords.py
@@ -38,7 +39,10 @@ Set test environment
     END
 
 Cleanup test resources
-    Run keyword And Ignore Error    power_on_node_by_name    ${powered_off_node}
+    FOR    ${powered_off_node}    IN    @{powered_off_nodes}
+        Run keyword And Ignore Error    power_on_node_by_name    ${powered_off_node}
+        Remove Values From List    ${powered_off_nodes}    ${powered_off_node}
+    END
     uncordon_all_nodes
     cleanup_control_plane_network_latency
     reset_node_schedule

--- a/e2e/keywords/host.resource
+++ b/e2e/keywords/host.resource
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation       Physical Node Keywords
 
+Library             Collections
 Library             ../libs/keywords/common_keywords.py
 Library             ../libs/keywords/host_keywords.py
 Library             ../libs/keywords/network_keywords.py
@@ -34,11 +35,13 @@ Restart cluster
     reboot_all_nodes
     setup_control_plane_network_latency
 
-Power on off node
-    Run keyword And Ignore Error
-    ...    power_on_node_by_name    ${powered_off_node}
+Power on off nodes
+    FOR    ${powered_off_node}    IN    @{powered_off_nodes}
+        Run keyword And Ignore Error    power_on_node_by_name    ${powered_off_node}
+        Remove Values From List    ${powered_off_nodes}    ${powered_off_node}
+    END
 
 Power off node ${node_id}
     ${powered_off_node} =     get_node_by_index    ${node_id}
+    Append to list      ${powered_off_nodes}     ${powered_off_node}
     power_off_node_by_name    ${powered_off_node}
-    Set Test Variable    ${powered_off_node}

--- a/e2e/keywords/sharemanager.resource
+++ b/e2e/keywords/sharemanager.resource
@@ -26,6 +26,11 @@ Delete sharemanager pod of deployment ${deployment_id} and wait for recreation
     ${volume_name} =    get_workload_volume_name    ${deployment_name}
     delete_sharemanager_pod_and_wait_for_recreation    ${volume_name}
 
+Wait for sharemanager pod of deployment ${deployment_id} restart
+    ${deployment_name} =   generate_name_with_suffix    deployment    ${deployment_id}
+    ${volume_name} =    get_workload_volume_name    ${deployment_name}
+    wait_for_sharemanager_pod_restart    ${volume_name}
+
 Wait for sharemanager pod of deployment ${deployment_id} running
     ${deployment_name} =   generate_name_with_suffix    deployment    ${deployment_id}
     ${volume_name} =    get_workload_volume_name    ${deployment_name}

--- a/e2e/keywords/variables.resource
+++ b/e2e/keywords/variables.resource
@@ -1,0 +1,13 @@
+*** Settings ***
+Documentation       Global Variables
+
+*** Variables ***
+${LOOP_COUNT}    1
+${RETRY_COUNT}    300
+${RETRY_INTERVAL}    1
+${VOLUME_TYPE}    RWO
+${CONTROL_PLANE_NODE_NETWORK_LATENCY_IN_MS}    0
+${RWX_VOLUME_FAST_FAILOVER}    false
+${DATA_ENGINE}    v1
+
+@{powered_off_nodes}=

--- a/e2e/keywords/workload.resource
+++ b/e2e/keywords/workload.resource
@@ -46,9 +46,18 @@ Power off volume node of ${workload_kind} ${workload_id}
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${volume_name} =    get_workload_volume_name    ${workload_name}
     ${powered_off_node} =    get_volume_node    ${volume_name}
+    Append to list      ${powered_off_nodes}     ${powered_off_node}
     ${last_volume_node} =    get_volume_node    ${volume_name}
     power_off_volume_node    ${volume_name}
-    Set Test Variable    ${powered_off_node}
+    Set Test Variable    ${last_volume_node}
+
+Power off volume node of ${workload_kind} ${workload_id} without waiting
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    ${powered_off_node} =    get_volume_node    ${volume_name}
+    Append to list      ${powered_off_nodes}     ${powered_off_node}
+    ${last_volume_node} =    get_volume_node    ${volume_name}
+    power_off_volume_node    ${volume_name}    waiting=False
     Set Test Variable    ${last_volume_node}
 
 Reboot volume node of ${workload_kind} ${workload_id}

--- a/e2e/libs/host/aws.py
+++ b/e2e/libs/host/aws.py
@@ -68,14 +68,15 @@ class Aws(Base):
         waiter.wait(InstanceIds=instance_ids)
         logging(f"Started instances")
 
-    def power_off_node(self, power_off_node_name):
+    def power_off_node(self, power_off_node_name, waiting=True):
         instance_ids = [self.mapping[power_off_node_name]]
         resp = self.aws_client.stop_instances(InstanceIds=instance_ids, Force=True)
         assert resp['ResponseMetadata']['HTTPStatusCode'] == 200, f"Failed to stop instances {instance_ids} response: {resp}"
         logging(f"Stopping instances {instance_ids}")
-        waiter = self.aws_client.get_waiter('instance_stopped')
-        waiter.wait(InstanceIds=instance_ids)
-        logging(f"Stopped instances")
+        if waiting:
+            waiter = self.aws_client.get_waiter('instance_stopped')
+            waiter.wait(InstanceIds=instance_ids)
+            logging(f"Stopped instances")
 
     def power_on_node(self, power_on_node_name):
         instance_ids = [self.mapping[power_on_node_name]]

--- a/e2e/libs/host/base.py
+++ b/e2e/libs/host/base.py
@@ -23,7 +23,7 @@ class Base(ABC):
         return NotImplemented
 
     @abstractmethod
-    def power_off_node(self, node_name):
+    def power_off_node(self, node_name, waiting):
         return NotImplemented
 
     @abstractmethod

--- a/e2e/libs/host/harvester.py
+++ b/e2e/libs/host/harvester.py
@@ -53,7 +53,7 @@ class Harvester(Base):
         for node_name in node_names:
             self.power_on_node(node_name)
 
-    def power_off_node(self, node_name):
+    def power_off_node(self, node_name, waiting=True):
         vm_id = self.mapping[node_name]
 
         url = f"{self.url}/{vm_id}"
@@ -67,6 +67,9 @@ class Harvester(Base):
             except Exception as e:
                 logging(f"Stopping vm failed with error {e}")
         logging(f"Stopping vm {vm_id}")
+
+        if not waiting:
+            return
 
         stopped = False
         for i in range(self.retry_count):

--- a/e2e/libs/keywords/host_keywords.py
+++ b/e2e/libs/keywords/host_keywords.py
@@ -46,10 +46,10 @@ class host_keywords:
         logging(f'Rebooting node {node_name} with downtime {reboot_down_time_sec} seconds')
         self.host.reboot_node(node_name, reboot_down_time_sec)
 
-    def power_off_volume_node(self, volume_name):
+    def power_off_volume_node(self, volume_name, waiting=True):
         node_id = self.volume_keywords.get_node_id_by_replica_locality(volume_name, "volume node")
-        logging(f'Power off volume {volume_name} node {node_id}')
-        self.host.power_off_node(node_id)
+        logging(f'Power off volume {volume_name} node {node_id} with waiting = {waiting}')
+        self.host.power_off_node(node_id, waiting)
 
     def power_on_node_by_name(self, node_name):
         self.host.power_on_node(node_name)

--- a/e2e/tests/negative/cluster_restart.robot
+++ b/e2e/tests/negative/cluster_restart.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative    cluster
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/deployment.resource
 Resource    ../keywords/longhorn.resource
@@ -15,15 +16,6 @@ Resource    ../keywords/setting.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${CONTROL_PLANE_NODE_NETWORK_LATENCY_IN_MS}    0
-${RWX_VOLUME_FAST_FAILOVER}    false
-${DATA_ENGINE}    v1
-
 
 *** Test Cases ***
 Restart Cluster While Workload Heavy Writing

--- a/e2e/tests/negative/component_resilience.robot
+++ b/e2e/tests/negative/component_resilience.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/backing_image.resource
@@ -17,13 +18,6 @@ Resource    ../keywords/sharemanager.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${RWX_VOLUME_FAST_FAILOVER}    false
-${DATA_ENGINE}    v1
 
 *** Keywords ***
 Delete instance-manager of volume ${volume_id} and wait for recover

--- a/e2e/tests/negative/kubelet_restart.robot
+++ b/e2e/tests/negative/kubelet_restart.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/storageclass.resource
 Resource    ../keywords/persistentvolumeclaim.resource
@@ -13,13 +14,6 @@ Resource    ../keywords/setting.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${RWX_VOLUME_FAST_FAILOVER}    false
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Restart Volume Node Kubelet While Workload Heavy Writing

--- a/e2e/tests/negative/network_disconnect.robot
+++ b/e2e/tests/negative/network_disconnect.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/storageclass.resource
 Resource    ../keywords/statefulset.resource
@@ -13,14 +14,6 @@ Resource    ../keywords/setting.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${LATENCY_IN_MS}    0
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${RWX_VOLUME_FAST_FAILOVER}    false
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Disconnect Volume Node Network While Workload Heavy Writing

--- a/e2e/tests/negative/node_delete.robot
+++ b/e2e/tests/negative/node_delete.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/host.resource
 Resource    ../keywords/storageclass.resource
@@ -14,13 +15,6 @@ Resource    ../keywords/setting.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${RWX_VOLUME_FAST_FAILOVER}    false
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Delete Volume Node While Replica Rebuilding

--- a/e2e/tests/negative/node_drain.robot
+++ b/e2e/tests/negative/node_drain.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/storageclass.resource
 Resource    ../keywords/persistentvolumeclaim.resource
@@ -17,13 +18,6 @@ Resource    ../keywords/node.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${RWX_VOLUME_FAST_FAILOVER}    false
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Force Drain Volume Node While Replica Rebuilding

--- a/e2e/tests/negative/pull_backup_from_another_longhorn.robot
+++ b/e2e/tests/negative/pull_backup_from_another_longhorn.robot
@@ -3,6 +3,7 @@ Documentation    Uninstallation Checks
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/setting.resource
 Resource    ../keywords/volume.resource
@@ -17,12 +18,6 @@ Library     ../libs/keywords/setting_keywords.py
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Pull backup created by another Longhorn system

--- a/e2e/tests/negative/replica_rebuilding.robot
+++ b/e2e/tests/negative/replica_rebuilding.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/host.resource
 Resource    ../keywords/volume.resource
@@ -13,12 +14,6 @@ Resource    ../keywords/workload.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Delete Replica While Replica Rebuilding

--- a/e2e/tests/negative/stress_cpu.robot
+++ b/e2e/tests/negative/stress_cpu.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/persistentvolumeclaim.resource
 Resource    ../keywords/statefulset.resource
@@ -13,12 +14,7 @@ Resource    ../keywords/workload.resource
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
 
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
 *** Test Cases ***
-
 Stress Volume Node CPU When Replica Is Rebuilding
     Given Create volume 0 with    size=5Gi    numberOfReplicas=3
     And Attach volume 0

--- a/e2e/tests/negative/stress_filesystem.robot
+++ b/e2e/tests/negative/stress_filesystem.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/persistentvolumeclaim.resource
 Resource    ../keywords/statefulset.resource
@@ -13,13 +14,7 @@ Resource    ../keywords/workload.resource
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
 
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-
 *** Test Cases ***
-
 Stress Volume Node Filesystem When Replica Is Rebuilding
     Given Create volume 0 with    size=5Gi    numberOfReplicas=3
     And Attach volume 0

--- a/e2e/tests/negative/stress_memory.robot
+++ b/e2e/tests/negative/stress_memory.robot
@@ -3,6 +3,7 @@ Documentation    Negative Test Cases
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/persistentvolumeclaim.resource
 Resource    ../keywords/statefulset.resource
@@ -13,13 +14,7 @@ Resource    ../keywords/workload.resource
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
 
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-
 *** Test Cases ***
-
 Stress Volume Node Memory When Replica Is Rebuilding
     Given Create volume 0 with    size=5Gi    numberOfReplicas=3
     And Attach volume 0

--- a/e2e/tests/negative/test_backup_listing.robot
+++ b/e2e/tests/negative/test_backup_listing.robot
@@ -2,8 +2,9 @@
 Documentation    Test backup listing
 ...              https://longhorn.github.io/longhorn-tests/manual/pre-release/stress/backup-listing/
 
-Test Tags    manual
+Test Tags    manual    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/deployment.resource
 Resource    ../keywords/workload.resource
@@ -22,9 +23,6 @@ Test Teardown    Cleanup test resources
 
 *** Variables ***
 ${LOOP_COUNT}    1001
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Keywords ***
 Verify backup ${backup_id} count for ${workload_kind} ${workload_id} volume 
@@ -142,7 +140,7 @@ Backup listing with more than 1000 backups
     And Volume 1 data should same as deployment 0 volume
 
 Backup listing of volume bigger than 200 Gi
-    [Tags]  manual  longhorn-8355
+    [Tags]  manual  longhorn-8355  large-size
     [Documentation]    Test backup bigger than 200 Gi
     Given Create persistentvolumeclaim 0 using RWO volume
     And Create deployment 0 with persistentvolumeclaim 0
@@ -152,7 +150,8 @@ Backup listing of volume bigger than 200 Gi
     And Create deployment 1 with volume 1
     Then Get deployment 1 volume data in file data
     And Volume 1 data should same as deployment 0 volume
-    Then Create pod 2 mount 250 GB volume 2
+    Then Create volume 2 from deployment 0 volume random backup
+    And Create pod 2 mount 250 GB volume 2
     And Write 210 GB large data to file 0 in pod 2
     Then Volume 2 backup 0 should be able to create
     Then Delete pod 2 and volume 2

--- a/e2e/tests/negative/uninstallation_checks.robot
+++ b/e2e/tests/negative/uninstallation_checks.robot
@@ -3,6 +3,7 @@ Documentation    Uninstallation Checks
 
 Test Tags    negative
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/setting.resource
 Resource    ../keywords/volume.resource
@@ -17,11 +18,6 @@ Library     ../libs/keywords/setting_keywords.py
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
 
 *** Test Cases ***
 Uninstallation Checks

--- a/e2e/tests/regression/test_backing_image.robot
+++ b/e2e/tests/regression/test_backing_image.robot
@@ -3,18 +3,13 @@ Documentation    Backing Image Test Cases
 
 Test Tags    regression    backing_image
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/backing_image.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Test Backing Image Basic Operation

--- a/e2e/tests/regression/test_backup.robot
+++ b/e2e/tests/regression/test_backup.robot
@@ -3,6 +3,7 @@ Documentation    Backup Test Cases
 
 Test Tags    regression
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/setting.resource
 Resource    ../keywords/volume.resource
@@ -15,12 +16,6 @@ Resource    ../keywords/backupstore.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Keywords ***
 Snapshot PV PVC could not be created on DR volume 1

--- a/e2e/tests/regression/test_basic.robot
+++ b/e2e/tests/regression/test_basic.robot
@@ -3,6 +3,7 @@ Documentation    Basic Test Cases
 
 Test Tags    regression
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/node.resource
 Resource    ../keywords/setting.resource
@@ -18,12 +19,6 @@ Resource    ../keywords/node.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Keywords ***
 Create volume with invalid name should fail

--- a/e2e/tests/regression/test_engine_image.robot
+++ b/e2e/tests/regression/test_engine_image.robot
@@ -3,18 +3,13 @@ Documentation    Engine Image Test Cases
 
 Test Tags    regression    engine_image
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/engine_image.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Test Replica Rebuilding After Engine Upgrade

--- a/e2e/tests/regression/test_ha.robot
+++ b/e2e/tests/regression/test_ha.robot
@@ -3,6 +3,7 @@ Documentation    HA Test Cases
 
 Test Tags    regression
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/setting.resource
@@ -13,11 +14,6 @@ Resource    ../keywords/statefulset.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
 
 *** Test Cases ***
 Disrupt Data Plane Traffic For Less Than Long Engine Replica Timeout

--- a/e2e/tests/regression/test_migration.robot
+++ b/e2e/tests/regression/test_migration.robot
@@ -3,6 +3,7 @@ Documentation    Migration Test Cases
 
 Test Tags    regression
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/deployment.resource
 Resource    ../keywords/persistentvolumeclaim.resource
@@ -12,12 +13,6 @@ Resource    ../keywords/volume.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Test Migration Confirm

--- a/e2e/tests/regression/test_replica.robot
+++ b/e2e/tests/regression/test_replica.robot
@@ -3,6 +3,7 @@ Documentation    Replica Test Cases
 
 Test Tags    regression
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/setting.resource
@@ -12,12 +13,6 @@ Resource    ../keywords/workload.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Test Replica Rebuilding Per Volume Limit

--- a/e2e/tests/regression/test_scheduling.robot
+++ b/e2e/tests/regression/test_scheduling.robot
@@ -3,6 +3,7 @@ Documentation    Scheduling Test Cases
 
 Test Tags    regression
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/replica.resource
@@ -15,12 +16,6 @@ Resource    ../keywords/node.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Test Soft Anti Affinity Scheduling

--- a/e2e/tests/regression/test_settings.robot
+++ b/e2e/tests/regression/test_settings.robot
@@ -3,6 +3,7 @@ Documentation    Settings Test Cases
 
 Test Tags    regression
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/setting.resource
@@ -14,12 +15,6 @@ Resource    ../keywords/sharemanager.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Test Cases ***
 Test Setting Concurrent Rebuild Limit

--- a/e2e/tests/regression/test_v2.robot
+++ b/e2e/tests/regression/test_v2.robot
@@ -3,6 +3,7 @@ Documentation    v2 Data Engine Test Cases
 
 Test Tags    regression    v2
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/storageclass.resource
 Resource    ../keywords/persistentvolumeclaim.resource
@@ -16,11 +17,6 @@ Resource    ../keywords/longhorn.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
 
 *** Test Cases ***
 Test V2 Volume Basic

--- a/e2e/tests/regression/test_volume.robot
+++ b/e2e/tests/regression/test_volume.robot
@@ -3,6 +3,7 @@ Documentation    Volume Test Cases
 
 Test Tags    regression
 
+Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
 Resource    ../keywords/deployment.resource
 Resource    ../keywords/longhorn.resource
@@ -14,12 +15,6 @@ Resource    ../keywords/volume.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
-
-*** Variables ***
-${LOOP_COUNT}    1
-${RETRY_COUNT}    300
-${RETRY_INTERVAL}    1
-${DATA_ENGINE}    v1
 
 *** Keywords ***
 Create volume with invalid name should fail


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9858

#### What this PR does / why we need it:

add test case Shutdown Volume Node And Test Auto Reattach To A New Node

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new keyword for waiting on sharemanager pod restarts.
  - Added functionality for batch processing powered-off nodes during power operations.

- **Improvements**
  - Enhanced variable management by centralizing definitions in a new resource file.
  - Updated multiple keywords to support looping through lists for improved resource handling.

- **Bug Fixes**
  - Improved cleanup process for powered-off nodes to ensure all are addressed systematically.

- **Documentation**
  - Updated comments and documentation for clarity on new functionalities and variable management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->