### PR TITLE
test(integration): support v2 volume

### DIFF
--- a/manager/integration/pytest.ini
+++ b/manager/integration/pytest.ini
@@ -18,3 +18,4 @@ markers =
   cluster_autoscaler
   long_running
   volume_backup_restore
+  v2_volume_test

--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -37,6 +37,7 @@ from common import wait_for_volume_healthy
 from common import fail_replica_expansion
 from common import get_volume_name, get_volume_dev_mb_data_md5sum # NOQA
 from common import exec_command_in_pod
+from common import DATA_ENGINE
 from backupstore import set_random_backupstore  # NOQA
 from kubernetes.stream import stream
 from kubernetes import client as k8sclient
@@ -55,7 +56,8 @@ def create_pv_storage(api, cli, pv, claim, backing_image, from_backup):
         name=pv['metadata']['name'], size=pv['spec']['capacity']['storage'],
         numberOfReplicas=int(pv['spec']['csi']['volumeAttributes']
                              ['numberOfReplicas']),
-        backingImage=backing_image, fromBackup=from_backup)
+        backingImage=backing_image, fromBackup=from_backup,
+        dataEngine=DATA_ENGINE)
     if from_backup:
         common.wait_for_volume_restoration_completed(cli,
                                                      pv['metadata']['name'])
@@ -101,6 +103,7 @@ def create_and_wait_csi_pod_named_pv(pv_name, pod_name, client, core_api, csi_pv
     create_and_wait_pod(core_api, pod)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.coretest   # NOQA
 @pytest.mark.csi  # NOQA
 def test_csi_mount(client, core_api, csi_pv, pvc, pod_make):  # NOQA
@@ -141,6 +144,7 @@ def csi_mount_test(client, core_api, csi_pv, pvc, pod_make,  # NOQA
     delete_and_wait_pv(core_api, csi_pv['metadata']['name'])
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.csi  # NOQA
 def test_csi_io(client, core_api, csi_pv, pvc, pod_make):  # NOQA
     """
@@ -192,6 +196,7 @@ def csi_io_test(client, core_api, csi_pv, pvc, pod_make, backing_image=""):  # N
     delete_and_wait_pv(core_api, pv_name)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.csi  # NOQA
 def test_csi_backup(set_random_backupstore, client, core_api, csi_pv, pvc, pod_make):  # NOQA
     """
@@ -246,6 +251,7 @@ def backupstore_test(client, core_api, csi_pv, pvc, pod_make, pod_name, vol_name
     client.delete(volume2)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.csi  # NOQA
 def test_csi_block_volume(client, core_api, storage_class, pvc, pod_manifest):  # NOQA
     """
@@ -636,6 +642,7 @@ def test_csi_mount_volume_online_expansion(client, core_api, storage_class, pvc,
     assert md5_after_expanding == md5_before_expanding
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_xfs_pv(client, core_api, pod_manifest):  # NOQA
     """
     Test create PV with new XFS filesystem
@@ -674,6 +681,7 @@ def test_xfs_pv(client, core_api, pod_manifest):  # NOQA
     assert resp == test_data
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_xfs_pv_existing_volume(client, core_api, pod_manifest):  # NOQA
     """
     Test create PV with existing XFS filesystem
@@ -791,6 +799,7 @@ def test_csi_expansion_with_replica_failure(client, core_api, storage_class, pvc
     assert resp == test_data
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.coretest  # NOQA
 def test_allow_volume_creation_with_degraded_availability_csi(
         client, core_api, apps_api, make_deployment_with_pvc):  # NOQA
@@ -913,6 +922,7 @@ def test_allow_volume_creation_with_degraded_availability_csi(
                                                  data_path)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.csi  # NOQA
 def test_csi_minimal_volume_size(
     client, core_api, csi_pv, pvc, pod_make): # NOQA

--- a/manager/integration/tests/test_recurring_job.py
+++ b/manager/integration/tests/test_recurring_job.py
@@ -81,6 +81,7 @@ from common import SETTING_RECURRING_JOB_WHILE_VOLUME_DETACHED
 from common import SIZE, Mi, Gi
 from common import SETTING_RESTORE_RECURRING_JOBS
 from common import VOLUME_HEAD_NAME
+from common import DATA_ENGINE
 
 
 RECURRING_JOB_LABEL = "RecurringJob"
@@ -154,6 +155,7 @@ def wait_for_recurring_backup_to_start(client, core_api, volume_name, expected_s
     return snapshot_name
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job(set_random_backupstore, client, volume_name):  # NOQA
     """
@@ -230,7 +232,8 @@ def test_recurring_job(set_random_backupstore, client, volume_name):  # NOQA
     check_recurring_jobs(client, recurring_jobs)
 
     volume = client.create_volume(name=volume_name, size=SIZE,
-                                  numberOfReplicas=2)
+                                  numberOfReplicas=2,
+                                  dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
     volume = volume.attach(hostId=get_self_host_id())
     volume = wait_for_volume_healthy(client, volume_name)
@@ -284,6 +287,7 @@ def test_recurring_job(set_random_backupstore, client, volume_name):  # NOQA
         f"backupStatus = {client.by_id_volume(volume_name).backupStatus}"
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_in_volume_creation(client, volume_name):  # NOQA
     """
@@ -322,7 +326,8 @@ def test_recurring_job_in_volume_creation(client, volume_name):  # NOQA
     check_recurring_jobs(client, recurring_jobs)
 
     client.create_volume(name=volume_name, size=SIZE,
-                         numberOfReplicas=2)
+                         numberOfReplicas=2,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=get_self_host_id())
     volume = wait_for_volume_healthy(client, volume_name)
@@ -346,6 +351,7 @@ def test_recurring_job_in_volume_creation(client, volume_name):  # NOQA
     wait_for_snapshot_count(volume, 4)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_duplicated(client):  # NOQA
     """
@@ -373,6 +379,7 @@ def test_recurring_job_duplicated(client):  # NOQA
     assert "already exists" in str(e.value)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_in_storageclass(set_random_backupstore, client, core_api, storage_class, statefulset):  # NOQA
     """
@@ -447,6 +454,7 @@ def test_recurring_job_in_storageclass(set_random_backupstore, client, core_api,
         wait_for_snapshot_count(volume, 4)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_labels(set_random_backupstore, client, random_labels, volume_name):  # NOQA
     """
@@ -483,7 +491,8 @@ def recurring_job_labels_test(client, labels, volume_name, size=SIZE, backing_im
     check_recurring_jobs(client, recurring_jobs)
 
     client.create_volume(name=volume_name, size=size,
-                         numberOfReplicas=2, backingImage=backing_image)
+                         numberOfReplicas=2, backingImage=backing_image,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=get_self_host_id())
     volume = wait_for_volume_healthy(client, volume_name)
@@ -517,6 +526,7 @@ def recurring_job_labels_test(client, labels, volume_name, size=SIZE, backing_im
     wait_for_backup_volume(client, volume_name, backing_image)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.csi  # NOQA
 @pytest.mark.recurring_job
 def test_recurring_job_kubernetes_status(set_random_backupstore, client, core_api, volume_name):  # NOQA
@@ -535,7 +545,8 @@ def test_recurring_job_kubernetes_status(set_random_backupstore, client, core_ap
          volume have 1 backup.
     And backup have the Kubernetes Status labels.
     """
-    client.create_volume(name=volume_name, size=SIZE, numberOfReplicas=2)
+    client.create_volume(name=volume_name, size=SIZE, numberOfReplicas=2,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
 
     pv_name = "pv-" + volume_name
@@ -595,6 +606,7 @@ def test_recurring_job_kubernetes_status(set_random_backupstore, client, core_ap
     assert len(b.labels) == 3
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_recurring_jobs_maximum_retain(client, core_api, volume_name): # NOQA
     """
     Scenario: test recurring jobs' maximum retain
@@ -640,6 +652,7 @@ def test_recurring_jobs_maximum_retain(client, core_api, volume_name): # NOQA
     assert validator_error.upper() in str(e.value).upper()
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_detached_volume(client, batch_v1_api, volume_name):  # NOQA
     """
@@ -661,7 +674,8 @@ def test_recurring_job_detached_volume(client, batch_v1_api, volume_name):  # NO
     When wait for 2 minute.
     Then then volume should have only 2 snapshots.
     """
-    client.create_volume(name=volume_name, size=SIZE)
+    client.create_volume(name=volume_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
 
     self_host = get_self_host_id()
@@ -694,6 +708,7 @@ def test_recurring_job_detached_volume(client, batch_v1_api, volume_name):  # NO
     wait_for_snapshot_count(volume, 2)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_recurring_jobs_allow_detached_volume(set_random_backupstore, client, core_api, apps_api, volume_name, make_deployment_with_pvc):  # NOQA
     """
     Scenario: test recurring jobs for detached volume with
@@ -824,6 +839,7 @@ def test_recurring_jobs_allow_detached_volume(set_random_backupstore, client, co
     common.wait_for_pod_phase(core_api, pod_names[0], pod_phase="Running")
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_recurring_jobs_when_volume_detached_unexpectedly(set_random_backupstore, client, core_api, apps_api, volume_name, make_deployment_with_pvc):  # NOQA
     """
     Scenario: test recurring jobs when volume detached unexpectedly
@@ -973,6 +989,7 @@ def test_recurring_jobs_on_nodes_with_taints():  # NOQA
     pass
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_groups(set_random_backupstore, client, batch_v1_api):  # NOQA
     """
@@ -1003,8 +1020,10 @@ def test_recurring_job_groups(set_random_backupstore, client, batch_v1_api):  # 
     """
     volume1_name = "test-job-1"
     volume2_name = "test-job-2"
-    client.create_volume(name=volume1_name, size=SIZE)
-    client.create_volume(name=volume2_name, size=SIZE)
+    client.create_volume(name=volume1_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
+    client.create_volume(name=volume2_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume1 = wait_for_volume_detached(client, volume1_name)
     volume2 = wait_for_volume_detached(client, volume2_name)
 
@@ -1061,6 +1080,7 @@ def test_recurring_job_groups(set_random_backupstore, client, batch_v1_api):  # 
     assert not backup_created
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_default(client, batch_v1_api, volume_name):  # NOQA
     """
@@ -1083,7 +1103,8 @@ def test_recurring_job_default(client, batch_v1_api, volume_name):  # NOQA
     Then volume should not have `snapshot`  job   in job label.
          volume should     have `default`   group in job label.
     """
-    client.create_volume(name=volume_name, size=SIZE)
+    client.create_volume(name=volume_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=get_self_host_id())
     volume = wait_for_volume_healthy(client, volume_name)
@@ -1104,6 +1125,7 @@ def test_recurring_job_default(client, batch_v1_api, volume_name):  # NOQA
                                          jobs=[], groups=[DEFAULT])
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_delete(client, batch_v1_api, volume_name):  # NOQA
     """
@@ -1144,7 +1166,8 @@ def test_recurring_job_delete(client, batch_v1_api, volume_name):  # NOQA
          default `backup2`   cron job should not exist.
                  `backup3`   cron job should not exist.
     """
-    client.create_volume(name=volume_name, size=SIZE)
+    client.create_volume(name=volume_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=get_self_host_id())
     volume = wait_for_volume_healthy(client, volume_name)
@@ -1250,6 +1273,7 @@ def test_recurring_job_delete(client, batch_v1_api, volume_name):  # NOQA
     wait_for_cron_job_delete(batch_v1_api, JOB_LABEL+"="+back3)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_delete_should_remove_volume_label(client, batch_v1_api, volume_name):  # NOQA
     """
@@ -1296,7 +1320,8 @@ def test_recurring_job_delete_should_remove_volume_label(client, batch_v1_api, v
     When delete `back2` recurring job.
     Then should not remove `default` job-group in volume.
     """
-    client.create_volume(name=volume_name, size=SIZE)
+    client.create_volume(name=volume_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
 
     snap1 = SNAPSHOT + "1"
@@ -1396,6 +1421,7 @@ def test_recurring_job_delete_should_remove_volume_label(client, batch_v1_api, v
                                          jobs=[], groups=[DEFAULT])
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_volume_label_when_job_and_group_use_same_name(client, volume_name):  # NOQA
     """
@@ -1426,9 +1452,12 @@ def test_recurring_job_volume_label_when_job_and_group_use_same_name(client, vol
     volume1_name = volume_name + "-1"
     volume2_name = volume_name + "-2"
     volume3_name = volume_name + "-3"
-    client.create_volume(name=volume1_name, size=SIZE)
-    client.create_volume(name=volume2_name, size=SIZE)
-    client.create_volume(name=volume3_name, size=SIZE)
+    client.create_volume(name=volume1_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
+    client.create_volume(name=volume2_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
+    client.create_volume(name=volume3_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume1 = wait_for_volume_detached(client, volume1_name)
     volume2 = wait_for_volume_detached(client, volume2_name)
     volume3 = wait_for_volume_detached(client, volume3_name)
@@ -1477,6 +1506,7 @@ def test_recurring_job_volume_label_when_job_and_group_use_same_name(client, vol
                                          jobs=[], groups=[DEFAULT])
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1_api):  # NOQA
     """
@@ -1510,7 +1540,8 @@ def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1
         1 backup exist in `test-job-1` volume.
     """
     volume1_name = "test-job-1"
-    client.create_volume(name=volume1_name, size=SIZE)
+    client.create_volume(name=volume1_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume1 = wait_for_volume_detached(client, volume1_name)
     volume1.attach(hostId=get_self_host_id())
     volume1 = wait_for_volume_healthy(client, volume1_name)
@@ -1547,7 +1578,8 @@ def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1
     wait_for_backup_count(client.by_id_backupVolume(volume1_name), 1)
 
     volume2_name = "test-job-2"
-    client.create_volume(name=volume2_name, size=SIZE)
+    client.create_volume(name=volume2_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume2 = wait_for_volume_detached(client, volume2_name)
     volume2.attach(hostId=get_self_host_id())
     volume2 = wait_for_volume_healthy(client, volume2_name)
@@ -1570,6 +1602,7 @@ def test_recurring_job_multiple_volumes(set_random_backupstore, client, batch_v1
     wait_for_backup_count(client.by_id_backupVolume(volume1_name), 1)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_snapshot(client, batch_v1_api):  # NOQA
     """
@@ -1597,8 +1630,10 @@ def test_recurring_job_snapshot(client, batch_v1_api):  # NOQA
     """
     volume1_name = "test-job-1"
     volume2_name = "test-job-2"
-    client.create_volume(name=volume1_name, size=SIZE)
-    client.create_volume(name=volume2_name, size=SIZE)
+    client.create_volume(name=volume1_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
+    client.create_volume(name=volume2_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume1 = wait_for_volume_detached(client, volume1_name)
     volume2 = wait_for_volume_detached(client, volume2_name)
 
@@ -1643,6 +1678,7 @@ def test_recurring_job_snapshot(client, batch_v1_api):  # NOQA
     wait_for_snapshot_count(volume2, 3)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_snapshot_delete(set_random_backupstore, client, batch_v1_api, volume_name):  # NOQA
     """
@@ -1678,7 +1714,8 @@ def test_recurring_job_snapshot_delete(set_random_backupstore, client, batch_v1_
          - 3 snapshots retained
          - 1 volume-head
     """
-    client.create_volume(name=volume_name, size=SIZE)
+    client.create_volume(name=volume_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
 
     self_host = get_self_host_id()
@@ -1771,7 +1808,8 @@ def test_recurring_job_snapshot_delete_retain_0(set_random_backupstore, client, 
          - 0 snapshot retained
          - 1 volume-head
     """
-    client.create_volume(name=volume_name, size=SIZE)
+    client.create_volume(name=volume_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
 
     self_host = get_self_host_id()
@@ -1839,7 +1877,8 @@ def test_recurring_job_snapshot_cleanup(set_random_backupstore, client, batch_v1
          - 1 user-created
          - 1 volume-head
     """
-    client.create_volume(name=volume_name, size=SIZE)
+    client.create_volume(name=volume_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
 
     self_host = get_self_host_id()
@@ -1901,6 +1940,7 @@ def test_recurring_job_snapshot_cleanup(set_random_backupstore, client, batch_v1
     assert system_created_count == 0
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_backup(set_random_backupstore, client, batch_v1_api):  # NOQA
     """
@@ -1926,8 +1966,10 @@ def test_recurring_job_backup(set_random_backupstore, client, batch_v1_api):  # 
     """
     volume1_name = "test-job-1"
     volume2_name = "test-job-2"
-    client.create_volume(name=volume1_name, size=SIZE)
-    client.create_volume(name=volume2_name, size=SIZE)
+    client.create_volume(name=volume1_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
+    client.create_volume(name=volume2_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume1 = wait_for_volume_detached(client, volume1_name)
     volume2 = wait_for_volume_detached(client, volume2_name)
 
@@ -1966,6 +2008,7 @@ def test_recurring_job_backup(set_random_backupstore, client, batch_v1_api):  # 
     wait_for_backup_count(client.by_id_backupVolume(volume2_name), 2)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 def test_recurring_job_restored_from_backup_target(set_random_backupstore, client, batch_v1_api):  # NOQA
     """
@@ -2035,7 +2078,8 @@ def test_recurring_job_restored_from_backup_target(set_random_backupstore, clien
     check_recurring_jobs(client, recurring_jobs)
 
     volume = client.create_volume(name=volume_name1, size=SIZE,
-                                  numberOfReplicas=2)
+                                  numberOfReplicas=2,
+                                  dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name1)
     volume = volume.attach(hostId=get_self_host_id())
     volume = wait_for_volume_healthy(client, volume_name1)
@@ -2069,7 +2113,8 @@ def test_recurring_job_restored_from_backup_target(set_random_backupstore, clien
     _, backup = find_backup(client, volume_name1, restore_snapshot_name)
     client.create_volume(name=rvolume_name1,
                          size=SIZE,
-                         fromBackup=backup.url)
+                         fromBackup=backup.url,
+                         dataEngine=DATA_ENGINE)
     rvolume1 = wait_for_volume_detached(client, rvolume_name1)
     wait_for_volume_recurring_job_update(rvolume1,
                                          jobs=[snap1, back1],
@@ -2079,13 +2124,15 @@ def test_recurring_job_restored_from_backup_target(set_random_backupstore, clien
     cleanup_all_recurring_jobs(client)
     client.create_volume(name=rvolume_name2,
                          size=SIZE,
-                         fromBackup=backup.url)
+                         fromBackup=backup.url,
+                         dataEngine=DATA_ENGINE)
     rvolume2 = wait_for_volume_detached(client, rvolume_name2)
     wait_for_volume_recurring_job_update(rvolume2,
                                          jobs=[snap1, back1],
                                          groups=[DEFAULT, group1])
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job  # NOQA
 @pytest.mark.parametrize("access_mode", [ACCESS_MODE_RWO, ACCESS_MODE_RWX])  # NOQA
 def test_recurring_job_filesystem_trim(client, core_api, batch_v1_api, volume_name, csi_pv, pvc, pod_make, access_mode):  # NOQA
@@ -2163,6 +2210,7 @@ def test_recurring_job_filesystem_trim(client, core_api, batch_v1_api, volume_na
     assert size_trimmed == test_size
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job
 def test_recurring_job_label_on_pvc(client, core_api, volume_name):  # NOQA
     """
@@ -2273,6 +2321,7 @@ def test_recurring_job_label_on_pvc(client, core_api, volume_name):  # NOQA
     assert unexpected_count == 0
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.recurring_job
 def test_recurring_job_source_label(client, core_api, volume_name):  # NOQA
     """

--- a/manager/integration/tests/test_scheduling.py
+++ b/manager/integration/tests/test_scheduling.py
@@ -89,6 +89,7 @@ from common import SIZE, CONDITION_STATUS_FALSE, CONDITION_STATUS_TRUE
 from common import SETTING_REPLICA_ZONE_SOFT_ANTI_AFFINITY
 from common import SETTING_REPLICA_DISK_SOFT_ANTI_AFFINITY
 from common import SETTING_ALLOW_EMPTY_DISK_SELECTOR_VOLUME
+from common import DATA_ENGINE
 
 from time import sleep
 
@@ -146,6 +147,7 @@ def wait_new_replica_ready(client, volume_name, replica_names):  # NOQA
     assert new_replica_ready
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_soft_anti_affinity_scheduling(client, volume_name):  # NOQA
     """
     Test that volumes with Soft Anti-Affinity work as expected.
@@ -185,6 +187,7 @@ def test_soft_anti_affinity_scheduling(client, volume_name):  # NOQA
     cleanup_volume(client, volume)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_soft_anti_affinity_detach(client, volume_name):  # NOQA
     """
     Test that volumes with Soft Anti-Affinity can detach and reattach to a
@@ -230,6 +233,7 @@ def test_soft_anti_affinity_detach(client, volume_name):  # NOQA
     cleanup_volume(client, volume)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_hard_anti_affinity_scheduling(client, volume_name):  # NOQA
     """
     Test that volumes with Hard Anti-Affinity work as expected.
@@ -279,6 +283,7 @@ def test_hard_anti_affinity_scheduling(client, volume_name):  # NOQA
     cleanup_volume(client, volume)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_hard_anti_affinity_detach(client, volume_name):  # NOQA
     """
     Test that volumes with Hard Anti-Affinity are still able to detach and
@@ -332,6 +337,7 @@ def test_hard_anti_affinity_detach(client, volume_name):  # NOQA
     cleanup_volume(client, volume)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_hard_anti_affinity_live_rebuild(client, volume_name):  # NOQA
     """
     Test that volumes with Hard Anti-Affinity can build new replicas live once
@@ -380,6 +386,7 @@ def test_hard_anti_affinity_live_rebuild(client, volume_name):  # NOQA
     cleanup_volume(client, volume)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_hard_anti_affinity_offline_rebuild(client, volume_name):  # NOQA
     """
     Test that volumes with Hard Anti-Affinity can build new replicas during
@@ -430,6 +437,7 @@ def test_hard_anti_affinity_offline_rebuild(client, volume_name):  # NOQA
     cleanup_volume(client, volume)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_replica_rebuild_per_volume_limit(client, core_api, storage_class, sts_name, statefulset):  # NOQA
     """
     Test the volume always only have one replica scheduled for rebuild
@@ -477,6 +485,7 @@ def test_replica_rebuild_per_volume_limit(client, core_api, storage_class, sts_n
     assert md5sum == common.get_pod_data_md5sum(core_api, pod_name, data_path)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_replica_auto_balance_node_least_effort(client, volume_name):  # NOQA
     """
     Scenario: replica auto-balance nodes with `least_effort`.
@@ -608,6 +617,7 @@ def test_replica_auto_balance_node_least_effort(client, volume_name):  # NOQA
     check_volume_data(volume, data)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_replica_auto_balance_node_best_effort(client, volume_name):  # NOQA
     """
     Scenario: replica auto-balance nodes with `best_effort`.
@@ -1094,7 +1104,8 @@ def replica_auto_balance_with_data_locality_test(client, volume_name):  # NOQA
     volume = client.create_volume(name=volume_name,
                                   size=str(200 * Mi),
                                   numberOfReplicas=number_of_replicas,
-                                  dataLocality="best-effort")
+                                  dataLocality="best-effort",
+                                  dataEngine=DATA_ENGINE)
     volume = common.wait_for_volume_detached(client, volume_name)
 
     volume.attach(hostId=self_node)
@@ -1278,6 +1289,7 @@ def test_replica_auto_balance_disabled_volume_spec_enabled(client, volume_name):
     check_volume_data(v2, d2)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_data_locality_basic(client, core_api, volume_name, pod, settings_reset):  # NOQA
     """
     Test data locality basic feature
@@ -1512,7 +1524,8 @@ def test_data_locality_basic(client, core_api, volume_name, pod, settings_reset)
                                    size=volume2_size,
                                    numberOfReplicas=3,
                                    nodeSelector=["AVAIL"],
-                                   dataLocality="best-effort")
+                                   dataLocality="best-effort",
+                                   dataEngine=DATA_ENGINE)
 
     volume2 = wait_for_volume_detached(client, volume2_name)
     volume2 = client.by_id_volume(volume2_name)
@@ -1584,7 +1597,8 @@ def test_data_locality_basic(client, core_api, volume_name, pod, settings_reset)
 
     volume3 = client.create_volume(name=volume3_name,
                                    size=volume3_size,
-                                   numberOfReplicas=1)
+                                   numberOfReplicas=1,
+                                   dataEngine=DATA_ENGINE)
 
     volume3 = wait_for_volume_detached(client, volume3_name)
     volume3 = client.by_id_volume(volume3_name)
@@ -1670,7 +1684,8 @@ def test_data_locality_basic(client, core_api, volume_name, pod, settings_reset)
     volume4 = client.create_volume(name=volume4_name,
                                    size=volume4_size,
                                    numberOfReplicas=1,
-                                   dataLocality="best-effort")
+                                   dataLocality="best-effort",
+                                   dataEngine=DATA_ENGINE)
 
     volume4 = wait_for_volume_detached(client, volume4_name)
     volume4 = client.by_id_volume(volume4_name)
@@ -1785,6 +1800,7 @@ def test_data_locality_basic(client, core_api, volume_name, pod, settings_reset)
     assert v4_node2_replica_count == 1
     assert v4_node3_replica_count == 0
 
+
 def test_replica_schedule_to_disk_with_most_usable_storage(client, volume_name, request):  # NOQA
     """
     Scenario : test replica schedule to disk with the most usable storage
@@ -1885,7 +1901,8 @@ def test_soft_anti_affinity_scheduling_volume_enable(client, volume_name): # NOQ
                          backingImage="",
                          frontend=VOLUME_FRONTEND_BLOCKDEV,
                          snapshotDataIntegrity=SNAPSHOT_DATA_INTEGRITY_IGNORED,
-                         replicaSoftAntiAffinity="enabled")
+                         replicaSoftAntiAffinity="enabled",
+                         dataEngine=DATA_ENGINE)
 
     volume = wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=host_id)
@@ -1937,7 +1954,8 @@ def test_soft_anti_affinity_scheduling_volume_disable(client, volume_name): # NO
                          backingImage="",
                          frontend=VOLUME_FRONTEND_BLOCKDEV,
                          snapshotDataIntegrity=SNAPSHOT_DATA_INTEGRITY_IGNORED,
-                         replicaSoftAntiAffinity="disabled")
+                         replicaSoftAntiAffinity="disabled",
+                         dataEngine=DATA_ENGINE)
 
     volume = wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=host_id)
@@ -1967,6 +1985,7 @@ def test_soft_anti_affinity_scheduling_volume_disable(client, volume_name): # NO
     check_volume_data(volume, data)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_data_locality_strict_local_node_affinity(client, core_api, apps_api, storage_class, statefulset, request):  # NOQA
     """
     Scenario: data-locality (strict-local) should schedule Pod to the same node
@@ -2037,6 +2056,7 @@ def test_data_locality_strict_local_node_affinity(client, core_api, apps_api, st
     wait_for_statefulset_pods_healthy(statefulset)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_allow_empty_node_selector_volume_setting(client, volume_name): # NOQA
     """
     Test the global setting allow-empty-node-selector-volume
@@ -2075,7 +2095,8 @@ def test_allow_empty_node_selector_volume_setting(client, volume_name): # NOQA
     update_setting(client, SETTING_ALLOW_EMPTY_NODE_SELECTOR_VOLUME, "false")
 
     # Check volume can not be scehduled
-    client.create_volume(name=volume_name, size=SIZE)
+    client.create_volume(name=volume_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
 
     volume = client.by_id_volume(volume.name)
@@ -2148,6 +2169,7 @@ def prepare_for_affinity_tests(client, volume_name, request): # NOQA
     return disk_path1, disk_path2
 
 
+
 def test_global_disk_soft_anti_affinity(client, volume_name, request): # NOQA
     """
     1. When Replica Disk Soft Anti-Affinity is false, it should be impossible
@@ -2205,7 +2227,8 @@ def test_global_disk_soft_anti_affinity(client, volume_name, request): # NOQA
     update_setting(client, SETTING_REPLICA_DISK_SOFT_ANTI_AFFINITY, "false")
 
     lht_hostId = get_self_host_id()
-    client.create_volume(name=volume_name, size=str(500*Mi))
+    client.create_volume(name=volume_name, size=str(500*Mi),
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
     volume.attach(hostId=lht_hostId)
     volume = wait_for_volume_degraded(client, volume_name)
@@ -2252,7 +2275,7 @@ def test_global_disk_soft_anti_affinity(client, volume_name, request): # NOQA
         assert replica.diskID not in disk_id
         disk_id.append(replica.diskID)
 
-
+@pytest.mark.v2_volume_test  # NOQA
 def test_allow_empty_disk_selector_volume_setting(client, volume_name): # NOQA
     """
     Test the global setting allow-empty-disk-selector-volume
@@ -2292,7 +2315,8 @@ def test_allow_empty_disk_selector_volume_setting(client, volume_name): # NOQA
     update_setting(client, SETTING_ALLOW_EMPTY_DISK_SELECTOR_VOLUME, "false")
 
     # Check volume can not be scehduled
-    client.create_volume(name=volume_name, size=SIZE)
+    client.create_volume(name=volume_name, size=SIZE,
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
 
     volume = client.by_id_volume(volume.name)
@@ -2374,7 +2398,8 @@ def test_volume_disk_soft_anti_affinity(client, volume_name, request): # NOQA
 
     lht_hostId = get_self_host_id()
     client.create_volume(name=volume_name, size=str(500*Mi),
-                         replicaDiskSoftAntiAffinity="disabled")
+                         replicaDiskSoftAntiAffinity="disabled",
+                         dataEngine=DATA_ENGINE)
     volume = wait_for_volume_detached(client, volume_name)
     assert volume.replicaDiskSoftAntiAffinity == "disabled"
 

--- a/manager/integration/tests/test_system_backup_restore.py
+++ b/manager/integration/tests/test_system_backup_restore.py
@@ -35,6 +35,7 @@ from common import write_volume_random_data
 
 from common import SETTING_BACKUPSTORE_POLL_INTERVAL
 from common import SIZE
+from common import DATA_ENGINE
 
 from backupstore import set_random_backupstore  # NOQA
 
@@ -44,6 +45,7 @@ DISABLED = "disabled"
 IF_NOT_PRESENT = "if-not-present"
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.system_backup_restore   # NOQA
 def test_system_backup_and_restore(client, set_random_backupstore):  # NOQA
     """
@@ -71,6 +73,7 @@ def test_system_backup_and_restore(client, set_random_backupstore):  # NOQA
     system_restore_wait_for_state("Completed", system_restore_name, client)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.system_backup_restore   # NOQA
 def test_system_backup_and_restore_volume_with_data(client, volume_name, set_random_backupstore):  # NOQA
     """
@@ -204,6 +207,7 @@ def test_system_backup_and_restore_volume_with_backingimage(client, core_api, vo
     restored_volume = wait_for_volume_healthy(client, volume_name)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.system_backup_restore   # NOQA
 def test_system_backup_with_volume_backup_policy_if_not_present(client, volume_name, set_random_backupstore):  # NOQA
     """
@@ -260,6 +264,7 @@ def test_system_backup_with_volume_backup_policy_if_not_present(client, volume_n
     create_system_backup_and_assert_volume_backup_count(2)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.system_backup_restore   # NOQA
 def test_system_backup_with_volume_backup_policy_always(client, volume_name, set_random_backupstore):  # NOQA
     """
@@ -296,7 +301,8 @@ def test_system_backup_with_volume_backup_policy_always(client, volume_name, set
     dr_volume_name = volume_name + "-dr"
     client.create_volume(name=dr_volume_name, size=SIZE,
                          numberOfReplicas=1, fromBackup=backup.url,
-                         frontend="", standby=True)
+                         frontend="", standby=True,
+                         dataEngine=DATA_ENGINE)
     wait_for_backup_restore_completed(client, dr_volume_name, backup.name)
 
     system_backup_name = system_backup_random_name()
@@ -319,6 +325,7 @@ def test_system_backup_with_volume_backup_policy_always(client, volume_name, set
     wait_for_backup_count(backup_volume, 3)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.system_backup_restore   # NOQA
 def test_system_backup_with_volume_backup_policy_disabled(client, volume_name, set_random_backupstore):  # NOQA
     """
@@ -350,6 +357,7 @@ def test_system_backup_with_volume_backup_policy_disabled(client, volume_name, s
     wait_for_backup_count(backup_volume, 0)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.system_backup_restore   # NOQA
 def test_system_backup_delete_when_other_system_backup_using_name_as_prefix(client, set_random_backupstore):  # NOQA
     """

--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -117,6 +117,8 @@ node {
                                        --env LONGHORN_TRANSIENT_VERSION=${LONGHORN_TRANSIENT_VERSION} \
                                        --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} \
                                        --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} \
+                                       --env TF_VAR_extra_block_device=${RUN_V2_TEST} \
+                                       --env RUN_V2_TEST=${RUN_V2_TEST} \
                                        --env PYTEST_CUSTOM_OPTIONS="${PYTEST_CUSTOM_OPTIONS}" \
                                        --env BACKUP_STORE_TYPE="${BACKUP_STORE_TYPE}" \
                                        --env TF_VAR_use_hdd=${USE_HDD} \

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -450,6 +450,9 @@ run_longhorn_upgrade_test(){
   RESOURCE_SUFFIX=$(terraform -chdir=${TF_VAR_tf_workspace}/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} output -raw resource_suffix)
   yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[7].value="'${RESOURCE_SUFFIX}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
 
+  ## for v2 volume test
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "RUN_V2_TEST", "value": "'${TF_VAR_extra_block_device}'"}' "${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}"
+
   kubectl apply -f ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
 
   # wait upgrade test pod to start running
@@ -520,6 +523,9 @@ run_longhorn_tests(){
   yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "AWS_SECRET_ACCESS_KEY", "valueFrom": {"secretKeyRef": {"name": "aws-cred-secret", "key": "AWS_SECRET_ACCESS_KEY"}}}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
   yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "AWS_DEFAULT_REGION", "valueFrom": {"secretKeyRef": {"name": "aws-cred-secret", "key": "AWS_DEFAULT_REGION"}}}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
   set -x
+
+  ## for v2 volume test
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "RUN_V2_TEST", "value": "'${TF_VAR_extra_block_device}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
 
   LONGHORN_TEST_POD_NAME=`yq e 'select(.spec.containers[0] != null).metadata.name' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}`
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #[9760](https://github.com/longhorn/longhorn/issues/9760)

#### What this PR does / why we need it:

Make test cases in below files can run on v2 volume
- test_basic.py
- test_recurring_job.py
- test_scheduling.py
- test_sysetm_backup_restore.py
- test_csi.py
- test_csi_snapshotter.py

#### Special notes for your reviewer:

Enable `RUN_V2_TEST` jenkins and use `-m v2_volume_test` to run test case with block disk

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced volume management with the ability to specify different data engines during volume creation and backup operations.
  - New test cases added for various scenarios, including backup and restore operations, volume scheduling, recurring jobs, and CSI interactions.
  - Introduced a new marker for version 2 volume tests to categorize and selectively run tests.
  - Improved configurability and flexibility in volume snapshot and restoration processes.

- **Bug Fixes**
  - Improved error handling in backup and restore processes to ensure data integrity.

- **Documentation**
  - Updated tests to reflect the new functionalities and ensure comprehensive coverage of volume management features.

These updates significantly improve the flexibility and reliability of volume management within the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->