### PR TITLE
test(integration): skip failed replica validation in test_allow_volume_creation_with_degraded_availability_restore

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2536,8 +2536,9 @@ def wait_for_replica_scheduled(client, volume_name, to_nodes,
             assert volume.robustness == VOLUME_ROBUSTNESS_HEALTHY
 
         scheduled = 0
-        unexpect_fail = expect_fail
-        expect_nodes = [n for n in to_nodes]
+        unexpect_fail = max(0, expect_fail)
+
+        expect_nodes = set(to_nodes)
         for r in volume.replicas:
             try:
                 assert r.hostId in expect_nodes
@@ -2551,7 +2552,8 @@ def wait_for_replica_scheduled(client, volume_name, to_nodes,
 
                 scheduled += 1
             except AssertionError:
-                unexpect_fail -= 1
+                if expect_fail >= 0:
+                    unexpect_fail -= 1
 
         if scheduled == expect_success and unexpect_fail == 0:
             break
@@ -2559,9 +2561,12 @@ def wait_for_replica_scheduled(client, volume_name, to_nodes,
         time.sleep(RETRY_INTERVAL)
 
     assert scheduled == expect_success, f" Volume = {volume}"
-    assert unexpect_fail == 0, f" Volume = {volume}"
-    assert len(volume.replicas) == expect_success + expect_fail, \
-        f" Volume = {volume}"
+    assert unexpect_fail == 0, f"Got {unexpect_fail} unexpected fail"
+
+    if expect_fail >= 0:
+        assert len(volume.replicas) == expect_success + expect_fail, \
+            f" Volume = {volume}"
+
     return volume
 
 

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -3791,7 +3791,7 @@ def test_allow_volume_creation_with_degraded_availability_restore(set_random_bac
                                                 to_nodes=[node1.name,
                                                           node2.name],
                                                 expect_success=2,
-                                                expect_fail=0,
+                                                expect_fail=-1,
                                                 chk_vol_healthy=False,
                                                 chk_replica_running=False)
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9852

#### What this PR does / why we need it:

When a volume is initially created, the number of replicas scheduled matches the `numberOfReplicas` specified in the volume's spec. This behavior can cause the test case to fail under the v2 scenario. This PR proposes skipping failed replica checks, focusing only on the running replicas.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced testing for volume operations, including backup and restoration processes.
	- Added new tests to validate cleanup behavior for failed backups and access mode restoration.

- **Bug Fixes**
	- Improved error handling and robustness in volume replica scheduling checks.

- **Tests**
	- Introduced multiple new test functions to ensure comprehensive coverage of backup management and volume state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->