### PR TITLE
ci: update gke version to `1.31.1-gke.2105000`

### DIFF
--- a/pipelines/gke/terraform/main.tf
+++ b/pipelines/gke/terraform/main.tf
@@ -42,7 +42,7 @@ resource "google_container_cluster" "cluster" {
   network            = google_compute_network.vpc_network.id
   subnetwork         = google_compute_subnetwork.subnetwork.id
   location           = data.google_compute_zones.available.names[0]
-  min_master_version = "1.30.2-gke.1587003"
+  min_master_version = "1.31.1-gke.2105000"
   remove_default_node_pool = true
   deletion_protection = false
   initial_node_count       = 1


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#9879

#### What this PR does / why we need it:

Master version `1.30.2-gke.1587003` is unsupported. Update to the lastest version `1.31.1-gke.2105000`.

![Screenshot_20241203_212939](https://github.com/user-attachments/assets/a7c44d95-1f1b-460c-a790-fff63d8764a4)

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the Google Kubernetes Engine (GKE) cluster to a newer master version, which may provide enhancements and fixes for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->