### PR TITLE
ci: scale up coredns to 3 replicas to prevent it from being affected by node down test cases

### DIFF
--- a/pipelines/e2e/scripts/longhorn-setup.sh
+++ b/pipelines/e2e/scripts/longhorn-setup.sh
@@ -55,6 +55,8 @@ main(){
   install_backupstores
   install_csi_snapshotter
 
+  scale_up_coredns
+
   # msg="failed to get package manager" error="operating systems amzn are not supported"
   if [[ "${TF_VAR_k8s_distro_name}" != "eks" ]] && \
     [[ "${DISTRO}" != "talos" ]]; then

--- a/pipelines/utilities/coredns.sh
+++ b/pipelines/utilities/coredns.sh
@@ -1,0 +1,7 @@
+scale_up_coredns(){
+  if [[ "${TF_VAR_k8s_distro_name}" == "rke2" ]]; then
+    kubectl get configmap -n kube-system rke2-coredns-rke2-coredns-autoscaler -oyaml | sed 's/\"min\": 0/\"min\": 3/' | kubectl apply -n kube-system -f -
+  else
+    kubectl patch deployment coredns -n kube-system --type='merge' -p '{"spec": {"replicas": 3}}'
+  fi
+}

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -6,6 +6,7 @@ source test_framework/scripts/kubeconfig.sh
 source pipelines/utilities/longhorn_manifest.sh
 source pipelines/utilities/longhorn_ui.sh
 source pipelines/utilities/install_metrics_server.sh
+source pipelines/utilities/coredns.sh
 
 # create and clean tmpdir
 TMPDIR="/tmp/longhorn"
@@ -562,6 +563,8 @@ main(){
   if [[ "${TF_VAR_enable_mtls}" == true ]]; then
     enable_mtls
   fi
+
+  scale_up_coredns
 
   # msg="failed to get package manager" error="operating systems amzn are not supported"
   if [[ "${TF_VAR_k8s_distro_name}" != "eks" ]] && \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9870 https://github.com/longhorn/longhorn/issues/9752

#### What this PR does / why we need it:

scale up coredns to 3 replicas to prevent it from being affected by node down test cases

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to scale up CoreDNS during the Longhorn installation process.
	- Enhanced setup scripts to manage CoreDNS configurations more effectively.
  
- **Bug Fixes**
	- Ensured error handling remains intact while integrating new functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->