### PR TITLE
ci: automatically run robot regression and negative tests daily and weekly

### DIFF
--- a/pipelines/e2e/Jenkinsfile
+++ b/pipelines/e2e/Jenkinsfile
@@ -118,7 +118,7 @@ node {
                                        --env LONGHORN_TRANSIENT_VERSION=${LONGHORN_TRANSIENT_VERSION} \
                                        --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} \
                                        --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} \
-                                       --env PYTEST_CUSTOM_OPTIONS="${PYTEST_CUSTOM_OPTIONS}" \
+                                       --env ROBOT_CUSTOM_OPTIONS="${ROBOT_CUSTOM_OPTIONS}" \
                                        --env BACKUP_STORE_TYPE="${BACKUP_STORE_TYPE}" \
                                        --env TF_VAR_use_hdd=${USE_HDD} \
                                        --env TF_VAR_arch=${ARCH} \

--- a/pipelines/utilities/run_longhorn_e2e_test.sh
+++ b/pipelines/utilities/run_longhorn_e2e_test.sh
@@ -10,7 +10,7 @@ run_longhorn_e2e_test(){
 
   LONGHORN_TESTS_MANIFEST_FILE_PATH="e2e/deploy/test.yaml"
 
-  eval "ROBOT_COMMAND_ARGS=($PYTEST_CUSTOM_OPTIONS)"
+  eval "ROBOT_COMMAND_ARGS=($ROBOT_CUSTOM_OPTIONS)"
   for OPT in "${ROBOT_COMMAND_ARGS[@]}"; do
     ROBOT_COMMAND_ARR="${ROBOT_COMMAND_ARR}\"${OPT}\", "
   done
@@ -89,7 +89,7 @@ run_longhorn_e2e_test_out_of_cluster(){
   fi
   LONGHORN_BACKUPSTORE_POLL_INTERVAL="30"
 
-  eval "ROBOT_COMMAND_ARGS=($PYTEST_CUSTOM_OPTIONS)"
+  eval "ROBOT_COMMAND_ARGS=($ROBOT_CUSTOM_OPTIONS)"
 
   cat /tmp/instance_mapping
   cp "${KUBECONFIG}" /tmp/kubeconfig


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9679

#### What this PR does / why we need it:

ci: automatically run robot regression and negative tests daily and weekly

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated testing framework from pytest to robot framework, affecting command-line argument handling.

- **Bug Fixes**
	- Enhanced error handling and resource cleanup during the build process.

- **Chores**
	- Maintained existing structure for backup store configurations and test execution flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->