### PR TITLE
test(robot): add block disk back to previously deleted node for v2 test cases

### DIFF
--- a/e2e/keywords/k8s.resource
+++ b/e2e/keywords/k8s.resource
@@ -31,6 +31,9 @@ Delete volume of ${workload_kind} ${workload_id} replica node
 
 Add deleted node back
     reboot_node_by_name    ${deleted_node}
+    ${host_provider}=    Get Environment Variable    HOST_PROVIDER
+    ${disk_path}=    Set Variable If    "${host_provider}" == "harvester"    /dev/vdc    /dev/xvdh
+    add_disk    block-disk    ${deleted_node}    block    ${disk_path}
 
 Force drain volume of ${workload_kind} ${workload_id} volume node
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

add block disk back to previously deleted node for v2 test cases

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new keyword for adding deleted nodes back in Kubernetes.
- **Improvements**
	- Enhanced existing keywords for draining volumes to capture the last volume node before operations.
	- Updated the drain completion keyword to ensure all pods are evicted before confirming the process.
	- Added retry logic to the disk addition process for improved reliability and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->