### PR TITLE
test(robot): fix migration confirmation after migration node down test case for v2 volumes

### DIFF
--- a/e2e/tests/negative/live_migration.robot
+++ b/e2e/tests/negative/live_migration.robot
@@ -19,7 +19,6 @@ Migration Confirmation After Migration Node Down
     And Attach volume 0 to node 0
     And Wait for volume 0 healthy
     And Write data to volume 0
-    And Get volume 0 engine and replica names
 
     And Attach volume 0 to node 1
     And Wait for volume 0 migration to be ready
@@ -31,7 +30,6 @@ Migration Confirmation After Migration Node Down
 
     # volume stuck in attaching status and waiting for migration node to come back
     Then Check volume 0 kept in attaching
-    And Volume 0 migration should fail or rollback
 
     # power on migration node
     When Power on off nodes


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

Fix migration confirmation after migration node down test case for v2 volumes.
Since v2 volumes delete stopped replicas on down nodes, replica name checks will fail for v2 volumes.

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the migration confirmation test case to streamline the process by removing unnecessary steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->