### PR TITLE
test(robot): fix pull backup created by another longhorn system test case for v2 volumes

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -24,12 +24,7 @@ Library             ../libs/keywords/sharemanager_keywords.py
 Library             ../libs/keywords/k8s_keywords.py
 
 *** Keywords ***
-Set test environment
-    init_k8s_api_client
-
-    setup_control_plane_network_latency
-    set_backupstore
-
+Set up v2 environment
     update_setting    v2-data-engine    true
     ${worker_nodes}=    get_worker_nodes
     ${host_provider}=    Get Environment Variable    HOST_PROVIDER
@@ -37,6 +32,12 @@ Set test environment
     FOR    ${worker_node}    IN    @{worker_nodes}
         add_disk    block-disk    ${worker_node}    block    ${disk_path}
     END
+
+Set test environment
+    init_k8s_api_client
+    setup_control_plane_network_latency
+    set_backupstore
+    set_up_v2_environment
 
 Cleanup test resources
     FOR    ${powered_off_node}    IN    @{powered_off_nodes}

--- a/e2e/tests/negative/pull_backup_from_another_longhorn.robot
+++ b/e2e/tests/negative/pull_backup_from_another_longhorn.robot
@@ -59,6 +59,7 @@ Pull Backup Created By Another Longhorn System
     Then Install Longhorn
     And Set setting deleting-confirmation-flag to true
     And Set backupstore
+    And Set up v2 environment
     And Check backup synced from backupstore
     And Create volume 1 from backup 0 in another cluster
     And Wait for volume 1 detached
@@ -72,6 +73,7 @@ Pull Backup Created By Another Longhorn System
     Then Install Longhorn stable version
     And Set setting deleting-confirmation-flag to true
     And Set backupstore
+    And Set up v2 environment
     And Create volume 2 with    dataEngine=${DATA_ENGINE}
     And Attach volume 2
     And Wait for volume 2 healthy
@@ -85,6 +87,7 @@ Pull Backup Created By Another Longhorn System
      # Install current version then pull backup and verify data
     Then Install Longhorn
     And Set backupstore
+    And Set up v2 environment
     And Check backup synced from backupstore
     And Create volume 3 from backup 1 in another cluster
     And Wait for volume 3 detached


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix pull backup created by another longhorn system test case for v2 volumes by re-setting up v2 environment after reinstallation

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new keyword for setting up the v2 environment, enhancing the configuration process.
	- Added a step to the test case for setting up the v2 environment, improving backup synchronization testing.

- **Bug Fixes**
	- Rearranged the sequence of existing keywords to maintain functionality while improving clarity.

- **Documentation**
	- Updated references to reflect the new environment setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->