### PR TITLE
test(robot): v2 volume should cleanup resources when instance manager is deleted

### DIFF
--- a/e2e/keywords/k8s.resource
+++ b/e2e/keywords/k8s.resource
@@ -117,6 +117,6 @@ The drain process completed
     check_drain_process_completed    ${drain_process}
 
 Check PDB not exist
-    [Arguments]    ${instance_manger}
-    check_instance_manager_pdb_not_exist    ${instance_manger}
+    [Arguments]    ${instance_manager}
+    check_instance_manager_pdb_not_exist    ${instance_manager}
 

--- a/e2e/keywords/k8s.resource
+++ b/e2e/keywords/k8s.resource
@@ -72,6 +72,10 @@ Drain volume of ${workload_kind} ${workload_id} volume node
 Uncordon the drained node
     uncordon_node    ${drained_node}
 
+Uncordon node ${node_id}
+    ${node_name} =    get_node_by_index    ${node_id}
+    uncordon_node    ${node_name}
+
 Cordon node ${node_id}
     ${node_name} =    get_node_by_index    ${node_id}
     cordon_node    ${node_name}

--- a/e2e/keywords/longhorn.resource
+++ b/e2e/keywords/longhorn.resource
@@ -69,16 +69,14 @@ Install Longhorn
 
 Delete instance-manager of volume ${volume_id}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
-    ${node_name} =    get_volume_node    ${volume_name}
-    ${pod_name} =     get_instance_manager_on_node    ${node_name}
-    delete_pod    ${pod_name}    longhorn-system
+    ${instance_manager} =     get_volume_instance_manager    ${volume_name}
+    delete_pod    ${instance_manager}    longhorn-system
 
 Delete instance-manager of deployment ${deployment_id} volume
     ${deployment_name} =   generate_name_with_suffix    deployment    ${deployment_id}
     ${volume_name} =    get_workload_volume_name    ${deployment_name}
-    ${node_name} =    get_volume_node    ${volume_name}
-    ${pod_name} =     get_instance_manager_on_node    ${node_name}
-    delete_pod    ${pod_name}    longhorn-system
+    ${instance_manager} =     get_volume_instance_manager    ${volume_name}
+    delete_pod    ${instance_manager}    longhorn-system
 
 Wait for Longhorn components all running
     wait_for_namespace_pods_running    longhorn-system

--- a/e2e/keywords/longhorn.resource
+++ b/e2e/keywords/longhorn.resource
@@ -87,6 +87,6 @@ Install Longhorn stable version
     install_longhorn_system    is_stable_version=True
 
 Uninstall Longhorn stable version
-    ${backups_before_uninstall} =     list_all_backups    
+    ${backups_before_uninstall} =     list_all_backups
     uninstall_longhorn_system    is_stable_version=True
     Set Test Variable    ${backups_before_uninstall}

--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -376,3 +376,27 @@ Wait for volume ${volume_id} restoration from backup ${backup_id} in another clu
 Volume ${volume_id} setting ${setting_name} should be ${setting_value}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     validate_volume_setting    ${volume_name}    ${setting_name}    ${setting_value}
+
+Assert DM device for volume ${volume_id} ${condition} exist on node ${node_id}
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${node_name} =    get_node_by_index    ${node_id}
+    ${dm_devices} =   list_dm_devices_on_node    ${node_name}
+    IF   '${condition}' == 'does'
+        Should Contain    ${dm_devices}    ${volume_name}
+    ELSE IF   '${condition}' == 'not'
+        Should Not Contain    ${dm_devices}    ${volume_name}
+    ELSE
+        Fail    Invalid condition: ${condition}
+    END
+
+Assert device for volume ${volume_id} ${condition} exist on node ${node_id}
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${node_name} =    get_node_by_index    ${node_id}
+    ${devices} =   list_volume_devices_on_node    ${node_name}
+    IF   '${condition}' == 'does'
+        Should Contain    ${devices}    ${volume_name}
+    ELSE IF   '${condition}' == 'not'
+        Should Not Contain    ${devices}    ${volume_name}
+    ELSE
+        Fail    Invalid condition: ${condition}
+    END

--- a/e2e/libs/backing_image/crd.py
+++ b/e2e/libs/backing_image/crd.py
@@ -1,16 +1,19 @@
-from kubernetes import client
+import time
+
 from datetime import datetime
+from kubernetes import client
+
 from backing_image.base import Base
 
 from utility.utility import logging
 from utility.utility import get_retry_count_and_interval
-import time
+
 
 class CRD(Base):
     def __init__(self):
         self.obj_api = client.CustomObjectsApi()
         self.retry_count, self.retry_interval = get_retry_count_and_interval()
-        
+
     def create(self, bi_name, source_type, url, expected_checksum):
         return NotImplemented
 
@@ -33,7 +36,7 @@ class CRD(Base):
 
     def cleanup_backing_images(self):
         return NotImplemented
-    
+
     def list_backing_image_manager(self):
         label_selector = 'longhorn.io/component=backing-image-manager'
         return self.obj_api.list_namespaced_custom_object(
@@ -42,7 +45,7 @@ class CRD(Base):
             namespace="longhorn-system",
             plural="backingimagemanagers",
             label_selector=label_selector)
-    
+
     def delete_backing_image_manager(self, name):
         logging(f"deleting backing image manager {name} ...")
         self.obj_api.delete_namespaced_custom_object(
@@ -56,7 +59,7 @@ class CRD(Base):
     def wait_all_backing_image_managers_running(self):
         for i in range(self.retry_count):
             all_running = True
-            backing_image_managers = self.list_backing_image_manager()            
+            backing_image_managers = self.list_backing_image_manager()
             for backing_image_manager in backing_image_managers["items"]:
                 current_state = backing_image_manager["status"]["currentState"]
                 name = backing_image_manager["metadata"]["name"]
@@ -70,7 +73,7 @@ class CRD(Base):
 
     def wait_backing_image_manager_restart(self, name, last_creation_time):
         for i in range(self.retry_count):
-            time.sleep(self.retry_interval)            
+            time.sleep(self.retry_interval)
             try:
                 backing_image_manager = self.obj_api.get_namespaced_custom_object(
                     group="longhorn.io",
@@ -82,7 +85,7 @@ class CRD(Base):
             except Exception as e:
                 logging(f"Finding backing image manager {name} failed with error {e}")
                 continue
-            
+
             creation_time = backing_image_manager["metadata"]["creationTimestamp"]
             fmt = "%Y-%m-%dT%H:%M:%SZ"
             if datetime.strptime(creation_time, fmt) > datetime.strptime(last_creation_time, fmt):

--- a/e2e/libs/keywords/node_keywords.py
+++ b/e2e/libs/keywords/node_keywords.py
@@ -75,3 +75,9 @@ class node_keywords:
 
     def get_disk_uuid(self, node_name, disk_name):
         return self.node.get_disk_uuid(node_name, disk_name)
+
+    def list_dm_devices_on_node(self, node_name):
+        return self.node.list_dm_devices(node_name)
+
+    def list_volume_devices_on_node(self, node_name):
+        return self.node.list_volume_devices(node_name)

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -124,7 +124,7 @@ class volume_keywords:
     def delete_replica_on_nodes(self, volume_name, replica_locality):
         check_replica_locality(replica_locality)
 
-        node_ids = self.get_node_ids_by_replica_locality(volume_name, replica_locality)        
+        node_ids = self.get_node_ids_by_replica_locality(volume_name, replica_locality)
         for node_id in node_ids:
             logging(f"Deleting volume {volume_name}'s replica on node {node_id}")
             self.volume.delete_replica(volume_name, node_id)

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -14,6 +14,7 @@ from utility.utility import logging
 from utility.utility import get_retry_count_and_interval
 
 from volume import Volume
+from volume.rest import Rest as VolumeRest
 
 
 class volume_keywords:
@@ -69,6 +70,11 @@ class volume_keywords:
 
     def get_volume_node(self, volume_name):
         return self.get_node_id_by_replica_locality(volume_name, "volume node")
+
+    def get_volume_instance_manager(self, volume_name):
+        volume = VolumeRest().get(volume_name)
+        assert len(volume['controllers']) == 1, f"Expect only one controller for volume {volume_name}; Got controllers: {volume['controllers']}"
+        return volume['controllers'][0]['instanceManagerName']
 
     def get_node_id_by_replica_locality(self, volume_name, replica_locality):
         return self.get_node_ids_by_replica_locality(volume_name, replica_locality)[0]

--- a/e2e/libs/keywords/workload_keywords.py
+++ b/e2e/libs/keywords/workload_keywords.py
@@ -46,7 +46,7 @@ class workload_keywords:
         create_pod(new_busybox_manifest(pod_name, claim_name))
 
     def delete_pod(self, pod_name, namespace='default'):
-        logging(f'Deleting pod {pod_name}')
+        logging(f'Deleting pod {pod_name} in namespace {namespace}')
         delete_pod(pod_name, namespace)
 
     def cleanup_pods(self):

--- a/e2e/libs/node/node.py
+++ b/e2e/libs/node/node.py
@@ -287,3 +287,13 @@ class Node:
                 break
             time.sleep(self.retry_interval)
         assert up, f"Waiting for node {node_name} up failed: {node.status.conditions}"
+
+    def list_dm_devices(self, node_name):
+        cmd = "dmsetup ls | awk '{print $1}'"
+        res = NodeExec(node_name).issue_cmd(cmd)
+        return res
+
+    def list_volume_devices(self, node_name):
+        cmd = "ls /dev/longhorn/"
+        res = NodeExec(node_name).issue_cmd(cmd)
+        return res

--- a/e2e/libs/node_exec/node_exec.py
+++ b/e2e/libs/node_exec/node_exec.py
@@ -100,6 +100,12 @@ class NodeExec:
                     "operator": "Equal",
                     "value": "true",
                     "effect": "NoExecute"
+                },
+                # Allow to schedule on cordoned node to execute command on its host.
+                {
+                    "key": "node.kubernetes.io/unschedulable",
+                    "operator": "Exists",
+                    "effect": "NoSchedule"
                 }],
                 'containers': [{
                     'image': 'ubuntu:16.04',

--- a/e2e/libs/node_exec/node_exec.py
+++ b/e2e/libs/node_exec/node_exec.py
@@ -51,7 +51,7 @@ class NodeExec:
             stdout=True,
             tty=False
         )
-        logging(f"Issued command: {cmd} on {self.node_name} with result {res}")
+        logging(f"Issued command: {cmd} on {self.node_name} with result:\n{res}")
         return res
 
     def launch_pod(self):

--- a/e2e/tests/negative/node_drain.robot
+++ b/e2e/tests/negative/node_drain.robot
@@ -217,4 +217,4 @@ Setting Allow Node Drain with the Last Healthy Replica protects the last healthy
 
     When Set setting node-drain-policy to always-allow
     And Force drain node 2 and expect success
-    And Check PDB not exist    instance_manger=${instance_manager_name}
+    And Check PDB not exist    instance_manager=${instance_manager_name}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9959, longhorn/longhorn#9989

#### What this PR does / why we need it:

Introduce a new robot test case.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added keywords for uncordoning nodes and validating device existence in volume management.
  - Introduced a new test case for verifying resource cleanup when an instance manager is deleted.

- **Bug Fixes**
  - Corrected variable naming inconsistencies in test scripts.

- **Documentation**
  - Enhanced documentation for test cases related to node draining.

- **Style**
  - Minor formatting adjustments for improved readability in code and logging statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->