### PR TITLE
ci: enable syncing robot test cases with qase

### DIFF
--- a/pipelines/utilities/junit_to_qase.py
+++ b/pipelines/utilities/junit_to_qase.py
@@ -246,11 +246,9 @@ if __name__ == "__main__":
         parent_suite_id = 58 # e2e-pytest
     else:
         test_type = "robot"
-        # TODO
-        # the folder structure of robot test hasn't been
-        # well-defined in qase
-        parent_suite_id = None
-        raise Exception(f"Unsupported test_type = {test_type}")
+        # if it's a robot report, missing suites will be added under
+        # parent suite e2e-robot (id=89)
+        parent_suite_id = 89 # e2e-robot
     print(f"test_type = {test_type}")
 
     # collect test results dict from test cases xml


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/8853

#### What this PR does / why we need it:

enable syncing robot test cases with qase

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of test suite identification for robot reports, preventing exceptions for unsupported test types.
	- Assigned a default suite ID for missing robot suites to ensure proper categorization. 

- **Documentation**
	- Updated comments to reflect changes in logic regarding test suite handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->