### PR TITLE
test(robot): add node down during migration test cases

### DIFF
--- a/e2e/tests/negative/live_migration.robot
+++ b/e2e/tests/negative/live_migration.robot
@@ -37,3 +37,70 @@ Migration Confirmation After Migration Node Down
     Then Wait for volume 0 to migrate to node 1
     And Wait for volume 0 healthy
     And Check volume 0 data is intact
+
+Migration Rollback After Migration Node Down
+    Given Create volume 0 with    migratable=True    accessMode=RWX    dataEngine=${DATA_ENGINE}
+    And Attach volume 0 to node 0
+    And Wait for volume 0 healthy
+    And Write data to volume 0
+
+    And Attach volume 0 to node 1
+    And Wait for volume 0 migration to be ready
+
+    # power off migration node
+    When Power off node 1
+    # migration rollback by detaching from the migration node
+    And Detach volume 0 from node 1
+
+    # migration rollback succeed
+    Then Wait for volume 0 to stay on node 0
+    And Wait for volume 0 degraded
+    And Check volume 0 data is intact
+
+Migration Confirmation After Original Node Down
+    Given Create volume 0 with    migratable=True    accessMode=RWX    dataEngine=${DATA_ENGINE}
+    And Attach volume 0 to node 0
+    And Wait for volume 0 healthy
+    And Write data to volume 0
+
+    And Attach volume 0 to node 1
+    And Wait for volume 0 migration to be ready
+
+    # power off original node
+    When Power off node 0
+    # migration confirmation by detaching from the original node
+    And Detach volume 0 from node 0
+
+    # migration is stuck until the Kubernetes pod eviction controller decides to
+    # terminate the instance-manager pod that was running on the original node.
+    # then Longhorn detaches the volume and cleanly reattaches it to the migration node.
+    Then Wait for volume 0 to migrate to node 1
+    And Wait for volume 0 degraded
+    And Check volume 0 data is intact
+
+Migration Rollback After Original Node Down
+    Given Create volume 0 with    migratable=True    accessMode=RWX    dataEngine=${DATA_ENGINE}
+    And Attach volume 0 to node 0
+    And Wait for volume 0 healthy
+    And Write data to volume 0
+
+    And Attach volume 0 to node 1
+    And Wait for volume 0 migration to be ready
+
+    # power off original node
+    When Power off node 0
+    # migration rollback by detaching from the migration node
+    And Detach volume 0 from node 1
+
+    # migration is stuck until the Kubernetes pod eviction controller decides to
+    # terminate the instance-manager pod that was running on the original node.
+    # then Longhorn detaches the volume and attempts to cleanly reattach it to the original node,
+    # but it is stuck in attaching until the node comes back.
+    Then Check volume 0 kept in attaching
+
+    # power on original node
+    When Power on off nodes
+
+    Then Wait for volume 0 to stay on node 0
+    And Wait for volume 0 healthy
+    And Check volume 0 data is intact


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/9905 https://github.com/longhorn/longhorn/issues/8817 https://github.com/longhorn/longhorn/issues/8906

#### What this PR does / why we need it:

add node down during migration test cases

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced four new test cases for negative scenarios in volume migration, enhancing the testing framework's coverage.
		- Migration Rollback After Migration Node Down
		- Migration Confirmation After Original Node Down
		- Migration Rollback After Original Node Down
		- Migration Confirmation After Migration Node Down

<!-- end of auto-generated comment: release notes by coderabbit.ai -->