### PR TITLE
fix(system-backup): wait for last backup of volume updated

### DIFF
--- a/manager/integration/tests/test_system_backup_restore.py
+++ b/manager/integration/tests/test_system_backup_restore.py
@@ -6,6 +6,7 @@ from common import volume_name # NOQA
 from common import core_api # NOQA
 
 from common import check_volume_data
+from common import check_volume_last_backup
 from common import cleanup_volume
 from common import create_and_check_volume
 from common import create_backup
@@ -257,6 +258,9 @@ def test_system_backup_with_volume_backup_policy_if_not_present(client, volume_n
 
         backup_volume = find_backup_volume(client, volume_name)
         wait_for_backup_count(backup_volume, count)
+        check_volume_last_backup(client,
+                                 volume_name,
+                                 backup_volume.lastBackupName)
 
     create_system_backup_and_assert_volume_backup_count(1)
     create_system_backup_and_assert_volume_backup_count(1)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

Modify the test case:
- `test_system_backup_with_volume_backup_policy_if_not_present`

to wait for the last backup of the volume to be updated when creating the first backup.

#### Special notes for your reviewer:

#### Additional documentation or context
~https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7935/~
re-run: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/7945/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced backup verification process to ensure immediate validation of the last backup after creation.
  
- **Bug Fixes**
	- Improved logic for system backup creation and volume backup checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->