### PR TITLE
ci: fix backup related test cases fail on talos

### DIFF
--- a/manager/integration/deploy/backupstores/minio-backupstore.yaml
+++ b/manager/integration/deploy/backupstores/minio-backupstore.yaml
@@ -41,8 +41,16 @@ spec:
       labels:
         app: longhorn-test-minio
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+                - ""
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"

--- a/manager/integration/deploy/backupstores/nfs-backupstore.yaml
+++ b/manager/integration/deploy/backupstores/nfs-backupstore.yaml
@@ -14,8 +14,16 @@ spec:
       labels:
         app: longhorn-test-nfs
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+                - ""
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10063

#### What this PR does / why we need it:

fix backup related test cases fail on talos

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced node selection logic for MinIO and NFS backup stores through updated affinity configurations.
	- New secret `minio-secret` created in the `longhorn-system` namespace for sensitive data management.

- **Bug Fixes**
	- Improved scheduling flexibility for `longhorn-test-minio` and `longhorn-test-nfs` deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->