### PR TITLE
fix(pytest): test_csi_encrypted_block_volume for GKE COS

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3446,6 +3446,12 @@ def reset_node(client, core_api):
 def reset_longhorn_node_zone(client):
     core_api = get_core_api_client()
 
+    # No need to reset zone label for GKE COS node as the node zone label is
+    # periodically updated with the actual GCP zone.
+    # https://github.com/longhorn/longhorn-tests/pull/1819
+    if is_k8s_node_gke_cos(core_api):
+        return
+
     nodes = client.list_node()
     for n in nodes:
         set_k8s_node_zone_label(core_api, n.name, None)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10049

#### What this PR does / why we need it:

https://github.com/longhorn/longhorn/issues/10049#issuecomment-2562253129

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `crypto_secret` fixture to ensure compatibility with GKE COS by setting the appropriate cryptographic key.
  
- **Refactor**
	- Streamlined the finalizer function in the `crypto_secret` fixture to reduce redundant API client initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->