### PR TITLE
fix: pytest test cases for removing global backup settings.

### DIFF
--- a/manager/integration/tests/test_system_backup_restore.py
+++ b/manager/integration/tests/test_system_backup_restore.py
@@ -16,7 +16,6 @@ from common import system_backup_random_name
 from common import system_backup_wait_for_state
 from common import system_restore_random_name
 from common import system_restore_wait_for_state
-from common import update_setting
 from common import wait_for_backup_count
 from common import wait_for_volume_detached
 from common import wait_for_volume_healthy
@@ -34,11 +33,11 @@ from common import check_backing_image_disk_map_status
 from common import wait_for_backup_restore_completed
 from common import write_volume_random_data
 
-from common import SETTING_BACKUPSTORE_POLL_INTERVAL
 from common import SIZE
 from common import DATA_ENGINE
 
 from backupstore import set_random_backupstore  # NOQA
+from backupstore import set_backupstore_poll_interval  # NOQA
 
 
 ALWAYS = "always"
@@ -376,7 +375,7 @@ def test_system_backup_delete_when_other_system_backup_using_name_as_prefix(clie
     And wait 60 seconds
     Then system backups should exists (aaa, aaaa)
     """
-    update_setting(client, SETTING_BACKUPSTORE_POLL_INTERVAL, "10")
+    set_backupstore_poll_interval(client, "10")
 
     system_backup_names = ["aa", "aaa", "aaaa"]
     for name in system_backup_names:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#5411, longhorn/longhorn#10043

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced backup store management with new methods for setting and retrieving configurations.
	- Introduced error handling for unsupported backup settings.
	- Added utility functions for converting Kubernetes duration strings to seconds.
	- New function to wait for the backup target URL to be updated.

- **Bug Fixes**
	- Improved error handling during backup target updates to prevent unhandled exceptions.

- **Tests**
	- Updated test cases for backup settings to ensure robust handling of various scenarios and configurations.
	- Streamlined the configuration process for the backup store polling interval in tests.

- **Chores**
	- Refined import statements and constants related to backup store settings for better clarity and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->