### PR TITLE
fix(pytest): update test_setting_update_with_invalid_value_via_configmap description

### DIFF
--- a/manager/integration/tests/test_settings.py
+++ b/manager/integration/tests/test_settings.py
@@ -1208,9 +1208,9 @@ def test_setting_update_with_invalid_value_via_configmap(core_api, request):  # 
     2. Initialize longhorn-default-setting configmap containing
        valid and invalid settings
     3. Update longhorn-default-setting configmap with invalid settings.
-       The invalid settings SETTING_TAINT_TOLERATION will be ignored
-       when there is an attached volume.
-    4. Validate the default settings values.
+       The invalid settings SETTING_TAINT_TOLERATION will be updated
+    4. The changes will be applied once the volumes are detached. (To Do)
+    5. Validate the default settings values.
     """
 
     # Step 1


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Update description of test case `test_setting_update_with_invalid_value_via_configmap`

#### What this PR does / why we need it:

#### Special notes for your reviewer:

https://github.com/longhorn/longhorn-tests/pull/1670/files

#### Additional documentation or context

cc @mantissahz 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated test case for configuration settings to validate handling of invalid settings with attached volumes.
	- Modified test behavior to ensure invalid settings are recorded and applied consistently across different scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->