### PR TITLE
fix: deprecate snapshotCreate and use snapshotCRCreate instead

### DIFF
--- a/e2e/libs/snapshot/rest.py
+++ b/e2e/libs/snapshot/rest.py
@@ -16,7 +16,7 @@ class Rest(Base):
     def create(self, volume_name, snapshot_id, waiting):
         logging(f"Creating volume {volume_name} snapshot {snapshot_id}")
         volume = self.volume.get(volume_name)
-        snapshot = volume.snapshotCreate()
+        snapshot = volume.snapshotCRCreate()
         snap_name = snapshot.name
 
         if not waiting:
@@ -28,6 +28,7 @@ class Rest(Base):
             for vs in snapshots:
                 if vs.name == snap_name:
                     snapshot_created = True
+                    snapshot = vs 
                     break
             if snapshot_created is True:
                 break

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4578,7 +4578,7 @@ def wait_for_engine_image_deletion(client, core_api, engine_image_name):
 
 def create_snapshot(longhorn_api_client, volume_name):
     volume = longhorn_api_client.by_id_volume(volume_name)
-    snap = volume.snapshotCreate()
+    snap = volume.snapshotCRCreate()
     snap_name = snap.name
 
     snapshot_created = False
@@ -4588,6 +4588,7 @@ def create_snapshot(longhorn_api_client, volume_name):
         for vs in snapshots.data:
             if vs.name == snap_name:
                 snapshot_created = True
+                snap = vs
                 break
         if snapshot_created is True:
             break

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -2037,7 +2037,7 @@ def test_pvc_storage_class_name_from_backup_volume(set_random_backupstore, # NOQ
 
     volume_name = pv.spec.csi.volume_handle
     volume_id = client.by_id_volume(volume_name)
-    snapshot = volume_id.snapshotCreate()
+    snapshot = volume_id.snapshotCRCreate()
 
     volume_id.snapshotBackup(name=snapshot.name)
     wait_for_backup_completion(client, volume_name, snapshot.name)
@@ -2318,7 +2318,7 @@ def test_storage_class_from_backup(set_random_backupstore, volume_name, pvc_name
     write_pod_volume_data(core_api, pod_name, test_data)
 
     volume_id = client.by_id_volume(volume_name)
-    snapshot = volume_id.snapshotCreate()
+    snapshot = volume_id.snapshotCRCreate()
 
     volume_id.snapshotBackup(name=snapshot.name)
     wait_for_backup_completion(client, volume_name, snapshot.name)

--- a/manager/integration/tests/test_csi_snapshotter.py
+++ b/manager/integration/tests/test_csi_snapshotter.py
@@ -1003,7 +1003,7 @@ def test_csi_snapshot_snap_create_volume_from_snapshot(apps_api, # NOQA
     vol = client.by_id_volume(vol.name)
     # create new snapshot to avoid the case the volume only has 1
     # snapshot so the snapshot can not deleted
-    vol.snapshotCreate()
+    vol.snapshotCRCreate()
     snapshot_content = get_volumesnapshotcontent(csivolsnap["metadata"]["uid"])
     snap_name = snapshot_content["status"]["snapshotHandle"]
 

--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -1232,19 +1232,19 @@ def test_single_replica_failed_during_engine_start(client, core_api, volume_name
     write_pod_volume_random_data(core_api, pod_name,
                                  data_path1, DATA_SIZE_IN_MB_1)
     data_md5sum1 = get_pod_data_md5sum(core_api, pod_name, data_path1)
-    snap1 = volume.snapshotCreate()
+    snap1 = create_snapshot(client, volume_name)
 
     data_path2 = "/data/file2"
     write_pod_volume_random_data(core_api, pod_name,
                                  data_path2, DATA_SIZE_IN_MB_1)
     data_md5sum2 = get_pod_data_md5sum(core_api, pod_name, data_path2)
-    snap2 = volume.snapshotCreate()
+    snap2 = create_snapshot(client, volume_name)
 
     data_path3 = "/data/file3"
     write_pod_volume_random_data(core_api, pod_name,
                                  data_path3, DATA_SIZE_IN_MB_1)
     data_md5sum3 = get_pod_data_md5sum(core_api, pod_name, data_path3)
-    snap3 = volume.snapshotCreate()
+    snap3 = create_snapshot(client, volume_name)
 
     volume = client.by_id_volume(volume_name)
     host_id = get_self_host_id()
@@ -1290,7 +1290,7 @@ def test_single_replica_failed_during_engine_start(client, core_api, volume_name
     res_data_md5sum4 = get_pod_data_md5sum(core_api, pod_name, data_path4)
     assert data_md5sum4 == res_data_md5sum4
 
-    snap4 = volume.snapshotCreate()
+    snap4 = create_snapshot(client, volume_name)
 
     snapshots = volume.snapshotList()
     for snap in snapshots:


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/10166

deprecate snapshotCreate and use snapshotCRCreate instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated snapshot creation method from `snapshotCreate()` to `snapshotCRCreate()` across multiple test files.
	- Introduced a new approach to snapshot creation potentially involving custom resource (CR) handling.

- **Tests**
	- Modified snapshot creation method in integration tests for various scenarios including:
		- PVC storage class tests
		- CSI snapshotter tests
		- High availability tests

- **Chores**
	- Removed `# NOQA` comments from method signatures.
	- Cleaned up code related to snapshot creation methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->