### PR TITLE
test(robot): fix volume nodeID transient state that causes test case to fail after a cluster restart

### DIFF
--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -438,7 +438,15 @@ class CRD(Base):
         return Rest().get_endpoint(volume_name)
 
     def write_random_data(self, volume_name, size, data_id):
-        node_name = self.get(volume_name)["spec"]["nodeID"]
+
+        self.wait_for_volume_state(volume_name, "attached")
+
+        for i in range(self.retry_count):
+            node_name = self.get(volume_name)["spec"]["nodeID"]
+            if node_name:
+                break
+            time.sleep(self.retry_interval)
+
         endpoint = self.get_endpoint(volume_name)
 
         cmd = [
@@ -454,7 +462,15 @@ class CRD(Base):
         self.set_last_data_checksum(volume_name, checksum)
 
     def keep_writing_data(self, volume_name, size):
-        node_name = self.get(volume_name)["spec"]["nodeID"]
+
+        self.wait_for_volume_state(volume_name, "attached")
+
+        for i in range(self.retry_count):
+            node_name = self.get(volume_name)["spec"]["nodeID"]
+            if node_name:
+                break
+            time.sleep(self.retry_interval)
+
         endpoint = self.get_endpoint(volume_name)
         logging(f"Keeping writing data to volume {volume_name}")
         res = NodeExec(node_name).issue_cmd(

--- a/e2e/tests/negative/cluster_restart.robot
+++ b/e2e/tests/negative/cluster_restart.robot
@@ -19,6 +19,7 @@ Test Teardown    Cleanup test resources
 
 *** Test Cases ***
 Restart Cluster While Workload Heavy Writing
+    [Tags]    cluster
     Given Set setting rwx-volume-fast-failover to ${RWX_VOLUME_FAST_FAILOVER}
     And Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}
     And Create storageclass strict-local with    numberOfReplicas=1    dataLocality=strict-local    dataEngine=${DATA_ENGINE}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10203

#### What this PR does / why we need it:

fix volume nodeID transient state that causes test case to fail after a cluster restart

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced cluster restart test scenarios with improved tagging.
	- Added test case for cluster restart during heavy writing and recurring jobs.

- **Tests**
	- Expanded negative test coverage for cluster resilience with new test cases.
	- Improved organization of existing tests through tagging for better categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->