### PR TITLE
docs(backup): add a manual test case

### DIFF
--- a/docs/content/manual/release-specific/v1.8.0/test-backups-and-system-backups-removed-during-uninstalling.md
+++ b/docs/content/manual/release-specific/v1.8.0/test-backups-and-system-backups-removed-during-uninstalling.md
@@ -1,0 +1,32 @@
+---
+title: Backups And System Backups Removed During Uninstalling
+---
+
+## Related issues
+
+- https://github.com/longhorn/longhorn/issues/10104
+
+## LEP
+
+- https://github.com/longhorn/longhorn/pull/5411
+
+## Test Uninstall Longhorn After An Upgrade
+
+**Given** a Longhorn 1.7.x cluster with 3 worker nodes.
+
+**AND** the default backup target is set.
+
+**When** volumes, completed backups, failed backups, and a system backup are created.
+
+**And** Longhorn is upgraded to v1.8.0.
+
+**Then** Upgrade successfully.
+
+**And** the `OwnerReference` of the system backup is added.
+
+**When** Longhorn is uninstalled.
+
+**Then** the uninstallation completes successfully.
+
+**And** backups and the system backup remain on the backupstore.
+


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#10104, longhorn/longhorn#10148

#### What this PR does / why we need it:

Manual test case to check if a system backup can be removed during uninstalling

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added new documentation for Longhorn version 1.8.0 explaining the backup and system backup behavior during uninstallation after an upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->