### PR TITLE
fix(configmap): remove data of Configmap after test

### DIFF
--- a/manager/integration/tests/backupstore.py
+++ b/manager/integration/tests/backupstore.py
@@ -359,6 +359,22 @@ def backup_cleanup():
             else:
                 assert (not e)
 
+    backups = api.list_namespaced_custom_object("longhorn.io",
+                                                "v1beta2",
+                                                "longhorn-system",
+                                                "backups")
+    ok = False
+    for _ in range(RETRY_COUNTS_SHORT):
+        if backups['items'] == []:
+            ok = True
+            break
+        time.sleep(RETRY_INTERVAL)
+        backups = api.list_namespaced_custom_object("longhorn.io",
+                                                    "v1beta2",
+                                                    "longhorn-system",
+                                                    "backups")
+    assert ok, f"backups: {backups['items']}"
+
 
 def backupstore_cleanup(client):
     backup_volumes = client.list_backupVolume()


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#10213

#### What this PR does / why we need it:

The config map `longhorn-default-resource` is reset
with data of `backup-target`, `backup-target-credential-secret`,
and `backupstore-poll-interval` but they should be removed, not reset.

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced backup cleanup process with retry mechanism to ensure complete backup deletion
	- Updated test settings import statements for better clarity
	- Improved configuration management for default settings in Longhorn system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->