### PR TITLE
test(robot): skip test case Test Uninstall When Backing Image Exists

### DIFF
--- a/e2e/tests/regression/test_backing_image.robot
+++ b/e2e/tests/regression/test_backing_image.robot
@@ -33,12 +33,12 @@ Test Backing Image Basic Operation
     And Delete backing image bi
 
 Test Uninstall When Backing Image Exists
-    [Tags]    uninstall    backing image
+    [Tags]    uninstall    backing image    robot:skip
     [Documentation]    Validates the uninstallation of Longhorn when backing
     ...                image exists.
     ...
     ...                Issue: https://github.com/longhorn/longhorn/issues/10044
-
+    Skip    The original issue has not been resolved yet.
     FOR    ${i}    IN RANGE    ${LOOP_COUNT}
         Given Create backing image v1-bi-qcow2 with    url=https://longhorn-backing-image.s3-us-west-1.amazonaws.com/parrot.qcow2    data_engine=v1    min_copies=3
         And Create backing image v1-bi-raw with    url=https://longhorn-backing-image.s3-us-west-1.amazonaws.com/parrot.qcow2    data_engine=v1    min_copies=3


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10044 https://github.com/longhorn/longhorn/issues/10219

#### What this PR does / why we need it:

skip test case Test Uninstall When Backing Image Exists

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Skipped the "Uninstall When Backing Image Exists" test case due to an unresolved issue.
	- Added documentation explaining the reason for test skipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->