### PR TITLE
fix(intergration): update block disk path for arm64

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -86,7 +86,10 @@ UPGRADE_TEST_IMAGE_PREFIX = "longhornio/longhorn-test:upgrade-test"
 ISCSI_DEV_PATH = "/dev/disk/by-path"
 ISCSI_PROCESS = "iscsid"
 
-BLOCK_DEV_PATH = "/dev/xvdh"
+if os.uname().machine == "x86_64":
+    BLOCK_DEV_PATH = "/dev/xvdh"
+else:
+    BLOCK_DEV_PATH = "/dev/nvme1n1"
 
 VOLUME_FIELD_STATE = "state"
 VOLUME_STATE_ATTACHED = "attached"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #10218

#### What this PR does / why we need it:

Change default block disk path by arch

#### Special notes for your reviewer:

Test result:
- [amd64](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8318/console)
- [arm64](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8312/)

#### Additional documentation or context

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated block device path detection to support different system architectures, ensuring more reliable volume access across various environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->