### PR TITLE
test(robot): refine adding block device to arm64 nodes

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -66,6 +66,13 @@ terraform output -raw instance_mapping | jq 'map({(.name | split(".")[0]): .id})
 # }
 ```
 
+1. To determine the block device path for v2 volumes, export `HOST_PROVIDER` and `ARCH` environment variables:
+
+```
+export HOST_PROVIDER=aws
+export ARCH=amd64
+```
+
 1. Prepare test environment and run the test:
 ```
 cd e2e

--- a/e2e/deploy/test.yaml
+++ b/e2e/deploy/test.yaml
@@ -78,6 +78,8 @@ spec:
       value: "false"
     - name: HOST_PROVIDER
       value: "aws"
+    - name: ARCH
+      value: "amd64"
     - name: AWS_ACCESS_KEY_ID
       valueFrom:
         secretKeyRef:

--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -24,13 +24,25 @@ Library             ../libs/keywords/sharemanager_keywords.py
 Library             ../libs/keywords/k8s_keywords.py
 
 *** Keywords ***
+Set disk path based on host provider and architecture
+    ${HOST_PROVIDER}=    Get Environment Variable    HOST_PROVIDER
+    ${ARCH}=    Get Environment Variable    ARCH
+    IF    "${HOST_PROVIDER}" == "aws"
+        IF    "${ARCH}" == "amd64"
+            Set Test Variable    ${DISK_PATH}    /dev/xvdh
+        ELSE IF    "${ARCH}" == "arm64"
+            Set Test Variable    ${DISK_PATH}    /dev/nvme1n1
+        END
+    ELSE IF    '${HOST_PROVIDER}' == "harvester"
+        Set Test Variable    ${DISK_PATH}    /dev/vdc
+    END
+
 Set up v2 environment
+    set_disk_path_based_on_host_provider_and_architecture
     update_setting    v2-data-engine    true
     ${worker_nodes}=    get_worker_nodes
-    ${host_provider}=    Get Environment Variable    HOST_PROVIDER
-    ${disk_path}=    Set Variable If    "${host_provider}" == "harvester"    /dev/vdc    /dev/xvdh
     FOR    ${worker_node}    IN    @{worker_nodes}
-        add_disk    block-disk    ${worker_node}    block    ${disk_path}
+        add_disk    block-disk    ${worker_node}    block    ${DISK_PATH}
     END
 
 Set test environment

--- a/e2e/keywords/k8s.resource
+++ b/e2e/keywords/k8s.resource
@@ -31,9 +31,7 @@ Delete volume of ${workload_kind} ${workload_id} replica node
 
 Add deleted node back
     reboot_node_by_name    ${deleted_node}
-    ${host_provider}=    Get Environment Variable    HOST_PROVIDER
-    ${disk_path}=    Set Variable If    "${host_provider}" == "harvester"    /dev/vdc    /dev/xvdh
-    add_disk    block-disk    ${deleted_node}    block    ${disk_path}
+    add_disk    block-disk    ${deleted_node}    block    ${DISK_PATH}
 
 Force drain volume of ${workload_kind} ${workload_id} volume node
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}

--- a/pipelines/utilities/run_longhorn_e2e_test.sh
+++ b/pipelines/utilities/run_longhorn_e2e_test.sh
@@ -39,6 +39,7 @@ run_longhorn_e2e_test(){
   fi
 
   yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[6].value="'${LONGHORN_TEST_CLOUDPROVIDER}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
+  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[7].value="'${TF_VAR_arch}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
 
   yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env += {"name": "LONGHORN_REPO_URI", "value": "'${LONGHORN_REPO_URI}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
   yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env += {"name": "LONGHORN_REPO_BRANCH", "value": "'${LONGHORN_REPO_BRANCH}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
@@ -105,6 +106,7 @@ run_longhorn_e2e_test_out_of_cluster(){
              -e LONGHORN_CLIENT_URL="${LONGHORN_CLIENT_URL}" \
              -e KUBECONFIG="/tmp/kubeconfig" \
              -e HOST_PROVIDER="${LONGHORN_TEST_CLOUDPROVIDER}" \
+             -e ARCH="${TF_VAR_arch}" \
              -e LAB_URL="${TF_VAR_lab_url}" \
              -e LAB_ACCESS_KEY="${TF_VAR_lab_access_key}" \
              -e LAB_SECRET_KEY="${TF_VAR_lab_secret_key}" \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10218

#### What this PR does / why we need it:

refine adding block device to arm64 nodes

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added architecture-specific environment variable `ARCH` to support dynamic configuration in test environments.
  - Introduced new keyword for setting disk path based on host provider and architecture.

- **Improvements**
  - Enhanced logging in node management methods to provide more detailed operational insights.
  - Simplified disk path determination logic in test scripts.

- **Chores**
  - Updated test deployment and pipeline utility scripts to support architecture-specific configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->