### PR TITLE
test(robot): refine system backup recurring job test cases

### DIFF
--- a/e2e/libs/recurringjob/crd.py
+++ b/e2e/libs/recurringjob/crd.py
@@ -116,12 +116,15 @@ class CRD(Base):
 
                 for item in system_backup_list['items']:
                     state = item['status']['state']
-                    assert state == expected_state
+                    logging(f"Waiting for systembackup created by job {job_name} in state '{state}' to reach state '{expected_state}' ... ({i})")
+                    if state == expected_state:
+                        return
 
-                return
-            except AssertionError:
-                logging(f"Waiting for systembackup in state '{state}' to reach state '{expected_state}' ({i}) ...")
-                time.sleep(self.retry_interval)
+            except Exception as e:
+                logging(f"Waiting for systembackup created by job {job_name} to reach state {expected_state} failed: {e}")
+
+            time.sleep(self.retry_interval)
+        assert False, logging(f"Waiting for systembackup created by job {job_name} to reach state {expected_state} failed")
 
     def assert_volume_backup_created(self, volume_name, retry_count=-1):
         logging("Delegating the assert_volume_backup_created call to API because there is no CRD implementation")

--- a/e2e/tests/regression/test_recurringjob.robot
+++ b/e2e/tests/regression/test_recurringjob.robot
@@ -18,17 +18,13 @@ Test System Backup Recurring Job When volume-backup-policy is disabled
     Given Create volume 0 with    size=2Gi    numberOfReplicas=1    dataEngine=${DATA_ENGINE}
     When Create system-backup recurringjob 0    parameters={"volume-backup-policy":"disabled"}
 
-    FOR    ${i}    IN RANGE    ${LOOP_COUNT}
-        Then Assert recurringjob not created backup for volume 0
-        And Wait for recurringjob 0 created systembackup to reach Ready state
-    END
+    Then Assert recurringjob not created backup for volume 0
+    And Wait for recurringjob 0 created systembackup to reach Ready state
 
 Test System Backup Recurring Job When volume-backup-policy is if-not-present
     [Tags]    recurring_job
     Given Create volume 0 with    size=2Gi    numberOfReplicas=1    dataEngine=${DATA_ENGINE}
     When Create system-backup recurringjob 0    parameters={"volume-backup-policy":"if-not-present"}
 
-    FOR    ${i}    IN RANGE    ${LOOP_COUNT}
-        Then Assert recurringjob created backup for volume 0
-        And Wait for recurringjob 0 created systembackup to reach Ready state
-    END
+    Then Assert recurringjob created backup for volume 0
+    And Wait for recurringjob 0 created systembackup to reach Ready state


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/6534

#### What this PR does / why we need it:

refine system backup recurring job test cases

(1) It's possible that a system backup object doesn't have the `status` field:

https://ci.longhorn.io/job/private/job/longhorn-e2e-test/2579/robot/report/log.html

(2) After the 2nd round of `Test System Backup Recurring Job When volume-backup-policy is if-not-present`, there won't be new backup created and fail the test case

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced logging and error handling for backup state checks, providing clearer feedback and more effective notifications when backup statuses change.

- **Tests**
  - Streamlined recurring job validations by eliminating redundant iterations, ensuring that backup verifications execute more directly and efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->