### PR TITLE
test(robot): test reject strict-local rwx v2 volumes

### DIFF
--- a/e2e/tests/regression/test_volume.robot
+++ b/e2e/tests/regression/test_volume.robot
@@ -63,5 +63,5 @@ Test RWX Volume Without Migratable Should Be Incompatible With Strict-Local
     ...
     ...                Issue: https://github.com/longhorn/longhorn/issues/6735
 
-    When Create volume 0 with    numberOfReplicas=1    migratable=False    accessMode=RWX    dataLocality=strict-local
+    When Create volume 0 with    numberOfReplicas=1    migratable=False    accessMode=RWX    dataLocality=strict-local    dataEngine=${DATA_ENGINE}
     Then No volume created


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/6736

#### What this PR does / why we need it:

test reject strict-local rwx v2 volumes

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the volume creation test to include an additional data engine parameter, enhancing test coverage for volume provisioning under strict-local settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->