### PR TITLE
ci: migrate air-gap private registry from digitalocean to aws

### DIFF
--- a/airgap/terraform/output.tf
+++ b/airgap/terraform/output.tf
@@ -4,7 +4,7 @@ output "registry_url" {
     null_resource.post_setup
   ]
 
-  value = digitalocean_record.lh_registry.fqdn
+  value = aws_route53_record.lh_registry.fqdn
 }
 
 output "registry_username" {

--- a/airgap/terraform/variables.tf
+++ b/airgap/terraform/variables.tf
@@ -13,11 +13,6 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-variable "do_token" {
-  type        = string
-  description = "DO TOKEN"
-}
-
 variable "os_distro_version" {
   type        = string
   default     = "20.04"

--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -33,7 +33,6 @@ node {
 
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
-        string(credentialsId: 'DO_CREDS', variable: 'DO_TOKEN'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
         string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
         file(credentialsId: 'AZURE_CRT_FILE', variable: 'AZURE_CRT_FILE'),
@@ -57,7 +56,6 @@ node {
                     sh "airgap/scripts/build.sh"
                     sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
                                            --env TF_VAR_longhorn_version=${LONGHORN_INSTALL_VERSION} \
-                                           --env TF_VAR_do_token=${DO_TOKEN} \
                                            --env TF_VAR_aws_access_key=${AWS_ACCESS_KEY} \
                                            --env TF_VAR_aws_secret_key=${AWS_SECRET_KEY} \
                                            airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}
@@ -129,7 +127,6 @@ node {
                                        --env TF_VAR_aws_availability_zone=${AWS_AVAILABILITY_ZONE} \
                                        --env TF_VAR_aws_region=${AWS_REGION} \
                                        --env TF_VAR_os_distro_version=${DISTRO_VERSION} \
-                                       --env TF_VAR_do_token=${env.TF_VAR_do_token} \
                                        --env TF_VAR_lh_aws_access_key=${AWS_ACCESS_KEY} \
                                        --env TF_VAR_lh_aws_instance_name_controlplane="${JOB_BASE_NAME}-ctrl" \
                                        --env TF_VAR_lh_aws_instance_name_worker="${JOB_BASE_NAME}-wrk" \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10338

#### What this PR does / why we need it:

migrate air-gap private registry from digitalocean to aws

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Migrated cloud DNS and registry management from the previous provider to AWS.
	- Updated the registry URL so it now resolves using the new AWS-based endpoint (displaying the updated domain).
	- Streamlined the CI/CD pipeline by removing unused credentials and environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->