### PR TITLE
test(integration): support v2 volume test on test_provisioner.py

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -1684,7 +1684,13 @@ def node_default_tags():
 
     tag_mappings = {}
     for tags, node in zip(DEFAULT_TAGS, nodes):
-        assert len(node.disks) == 1
+        if DATA_ENGINE == "v2":
+            # if the v2 data engine is enabled, both a file system disk
+            # and a block disk will coexist. This is because a v2 backing image
+            # requires a file system disk to function.
+            assert len(node.disks) == 2
+        else:
+            assert len(node.disks) == 1
 
         update_disks = get_update_disks(node.disks)
         update_disks[list(update_disks)[0]].tags = tags["disk"]

--- a/manager/integration/tests/test_provisioner.py
+++ b/manager/integration/tests/test_provisioner.py
@@ -9,6 +9,7 @@ from common import get_volume_name, read_volume_data, size_to_string
 from common import write_pod_volume_data, check_volume_replicas
 from common import SETTING_REPLICA_NODE_SOFT_ANTI_AFFINITY
 from common import get_self_host_id
+from common import DATA_ENGINE
 import subprocess
 
 DEFAULT_STORAGECLASS_NAME = "longhorn-provisioner"
@@ -26,6 +27,8 @@ def create_storage(api, sc_manifest, pvc_manifest):
         body=pvc_manifest,
         namespace='default')
 
+
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.coretest   # NOQA
 def test_provisioner_mount(client, core_api, storage_class, pvc, pod):  # NOQA
     """
@@ -81,6 +84,7 @@ def test_provisioner_generic_ephemeral():
     pass
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_provisioner_params(client, core_api, storage_class, pvc, pod):  # NOQA
     """
     Test that substituting different StorageClass parameters is reflected in
@@ -107,7 +111,8 @@ def test_provisioner_params(client, core_api, storage_class, pvc, pod):  # NOQA
     storage_class['metadata']['name'] = DEFAULT_STORAGECLASS_NAME
     storage_class['parameters'] = {
         'numberOfReplicas': '2',
-        'staleReplicaTimeout': '20'
+        'staleReplicaTimeout': '20',
+        'dataEngine': DATA_ENGINE
     }
 
     create_storage(core_api, storage_class, pvc)
@@ -124,6 +129,7 @@ def test_provisioner_params(client, core_api, storage_class, pvc, pod):  # NOQA
     assert volumes.data[0].state == "attached"
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_provisioner_io(client, core_api, storage_class, pvc, pod):  # NOQA
     """
     Test that input and output on a StorageClass provisioned
@@ -165,6 +171,7 @@ def test_provisioner_io(client, core_api, storage_class, pvc, pod):  # NOQA
     assert resp == test_data
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_provisioner_tags(client, core_api, node_default_tags, storage_class, pvc, pod):  # NOQA
     """
     Test that a StorageClass can properly provision a volume with requested
@@ -216,6 +223,7 @@ def test_provisioner_tags(client, core_api, node_default_tags, storage_class, pv
     check_volume_replicas(volumes.data[0], tag_spec, node_default_tags)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 @pytest.mark.parametrize(
     "inode_size,block_size",
     [


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #9760

#### What this PR does / why we need it:

support v2 volume test on test_provisioner.py

#### Special notes for your reviewer:

Test result
- [v1 volume](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8422/testReport/)
- [v2 volume](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8423/)

#### Additional documentation or context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated provisioning validations to dynamically adjust disk configuration checks based on the current engine version.
  - Enhanced storage provisioning tests by adding an engine-specific parameter and categorizing them for clearer test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->