### PR TITLE
test(robot): Add test cases for Test Volume Attached at Maximum Snapshot Count

### DIFF
--- a/e2e/keywords/snapshot.resource
+++ b/e2e/keywords/snapshot.resource
@@ -6,6 +6,7 @@ Library    ../libs/keywords/snapshot_keywords.py
 
 *** Keywords ***
 Create snapshot ${snapshot_id} of volume ${volume_id}
+    ${snapshot_id}=  Convert To String  ${snapshot_id}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     create_snapshot    ${volume_name}    ${snapshot_id}
 
@@ -55,3 +56,8 @@ Validate snapshot ${snapshot_id} is in volume ${volume_id} snapshot list
 Create snapshot ${snapshot_id} of volume ${volume_id} will fail
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     Run Keyword And Expect Error    *    create_snapshot    ${volume_name}    ${snapshot_id}    waiting=False
+
+Create ${snapshot_count} snapshot for volume ${volume_id}
+    FOR    ${i}    IN RANGE    ${snapshot_count}
+        Create snapshot ${i} of volume ${volume_id}
+    END

--- a/e2e/tests/regression/test_volume.robot
+++ b/e2e/tests/regression/test_volume.robot
@@ -11,6 +11,7 @@ Resource    ../keywords/persistentvolumeclaim.resource
 Resource    ../keywords/setting.resource
 Resource    ../keywords/workload.resource
 Resource    ../keywords/node.resource
+Resource    ../keywords/snapshot.resource
 Resource    ../keywords/volume.resource
 
 Test Setup    Set test environment
@@ -65,3 +66,16 @@ Test RWX Volume Without Migratable Should Be Incompatible With Strict-Local
 
     When Create volume 0 with    numberOfReplicas=1    migratable=False    accessMode=RWX    dataLocality=strict-local    dataEngine=${DATA_ENGINE}
     Then No volume created
+
+Test Volume Attached at Maximum Snapshot Count
+    [Tags]    volume    snapshot-limit
+    [Documentation]    Validate that reaching the snapshot limit of 250 does not affect
+    ...                volume attach/detach operations.
+    ...                Issue: https://github.com/longhorn/longhorn/issues/10308
+    Given Create volume 0 with    dataEngine=${DATA_ENGINE}    numberOfReplicas=1
+    And Attach volume 0
+    And Wait for volume 0 healthy
+    When Create 249 snapshot for volume 0
+    And Detach volume 0
+    Then Attach volume 0
+    And Wait for volume 0 healthy


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#10322

#### What this PR does / why we need it:
Validate that reaching the snapshot limit of 250 does not affect volume attach/detach operations.

#### Special notes for your reviewer:
@PhanLe1010 

#### Additional documentation or context
longhorn/longhorn#10322
longhorn/longhorn#10308


- PR test log : 
  - [pr2312log.tar.gz](https://github.com/user-attachments/files/18904572/pr2312log.tar.gz)


- Here's how to execute test case: ` ./run.sh -t 'Test Volume Attached at Maximum Snapshot Count'`
![Screenshot_20250221_175411](https://github.com/user-attachments/assets/112ca6c2-e804-4a8d-8029-335704b08373)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced snapshot operations for greater consistency and reliability during creation and deletion.
	- Introduced a new feature for batch creation of snapshots.
- **Tests**
	- Introduced an end-to-end validation to ensure volume attach and detach operations remain stable when approaching the maximum snapshot limit.
	- Added a new test case to validate functionality when the maximum snapshot count is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->