### PR TITLE
test(robot): add Crash Instance Manager While Workload Pod Is Starting test case

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -22,6 +22,7 @@ Library             ../libs/keywords/backupstore_keywords.py
 Library             ../libs/keywords/backup_keywords.py
 Library             ../libs/keywords/sharemanager_keywords.py
 Library             ../libs/keywords/k8s_keywords.py
+Library             ../libs/keywords/secret_keywords.py
 
 *** Keywords ***
 Set disk path based on host provider and architecture
@@ -68,6 +69,7 @@ Cleanup test resources
     cleanup_persistentvolumeclaims
     cleanup_volumes
     cleanup_storageclasses
+    cleanup_secrets
     cleanup_backups
     cleanup_disks
     cleanup_backing_images

--- a/e2e/keywords/secret.resource
+++ b/e2e/keywords/secret.resource
@@ -1,0 +1,10 @@
+*** Settings ***
+Documentation    Secret Keywords
+
+Library    Collections
+Library    ../libs/keywords/common_keywords.py
+Library    ../libs/keywords/secret_keywords.py
+
+*** Keywords ***
+Create crypto secret
+    create_secret

--- a/e2e/keywords/workload.resource
+++ b/e2e/keywords/workload.resource
@@ -20,6 +20,12 @@ Wait for pod ${pod_id} running
     ${pod_name} =    generate_name_with_suffix    pod    ${pod_id}
     wait_for_workload_pods_running    ${pod_name}
 
+Delete pod of ${workload_kind} ${workload_id}
+    [Arguments]    &{config}
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${pod_name} =    get_workload_pod_name    ${workload_name}
+    delete_pod    ${pod_name}    &{config}
+
 Delete pod ${pod_id}
     ${pod_name} =    generate_name_with_suffix    pod    ${pod_id}
     delete_pod    ${pod_name}
@@ -151,6 +157,10 @@ Delete replica of ${workload_kind} ${workload_id} volume on ${replica_locality}
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${volume_name} =    get_workload_volume_name    ${workload_name}
     delete_replica_on_node    ${volume_name}    ${replica_locality}
+
+Wait for ${workload_kind} ${workload_id} pods container creating
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    wait_for_workload_pods_container_creating    ${workload_name}
 
 Wait for workloads pods stable
     [Arguments]    @{args}

--- a/e2e/libs/keywords/secret_keywords.py
+++ b/e2e/libs/keywords/secret_keywords.py
@@ -1,0 +1,13 @@
+from secret import Secret
+
+
+class secret_keywords:
+
+    def __init__(self):
+        self.secret = Secret()
+
+    def create_secret(self):
+        self.secret.create()
+
+    def cleanup_secrets(self):
+        self.secret.cleanup()

--- a/e2e/libs/keywords/storageclass_keywords.py
+++ b/e2e/libs/keywords/storageclass_keywords.py
@@ -7,9 +7,9 @@ class storageclass_keywords:
     def __init__(self):
         self.storageclass = StorageClass()
 
-    def create_storageclass(self, name, numberOfReplicas="3", migratable="false", dataLocality="disabled", fromBackup="", nfsOptions="", dataEngine="v1"):
+    def create_storageclass(self, name, numberOfReplicas="3", migratable="false", dataLocality="disabled", fromBackup="", nfsOptions="", dataEngine="v1", encrypted="false", secretName="longhorn-crypto", secretNamespace="longhorn-system"):
         logging(f'Creating storageclass with {locals()}')
-        self.storageclass.create(name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine)
+        self.storageclass.create(name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, secretName, secretNamespace)
 
     def cleanup_storageclasses(self):
         self.storageclass.cleanup()

--- a/e2e/libs/keywords/workload_keywords.py
+++ b/e2e/libs/keywords/workload_keywords.py
@@ -21,6 +21,7 @@ from workload.workload import is_workload_pods_has_annotations
 from workload.workload import keep_writing_pod_data
 from workload.workload import write_pod_random_data
 from workload.workload import write_pod_large_data
+from workload.workload import wait_for_workload_pods_container_creating
 from workload.workload import wait_for_workload_pods_running
 from workload.workload import wait_for_workload_pods_stable
 from workload.workload import wait_for_workload_pod_kept_in_state
@@ -121,6 +122,10 @@ class workload_keywords:
 
         logging(f'Keep writing data to pod {pod_name}')
         keep_writing_pod_data(pod_name)
+
+    def wait_for_workload_pods_container_creating(self, workload_name, namespace="default"):
+        logging(f'Waiting for {namespace} workload {workload_name} pods container creating')
+        wait_for_workload_pods_container_creating(workload_name, namespace=namespace)
 
     def wait_for_workload_pods_running(self, workload_name, namespace="default"):
         logging(f'Waiting for {namespace} workload {workload_name} pods running')

--- a/e2e/libs/secret/__init__.py
+++ b/e2e/libs/secret/__init__.py
@@ -1,0 +1,1 @@
+from secret.secret import Secret

--- a/e2e/libs/secret/secret.py
+++ b/e2e/libs/secret/secret.py
@@ -1,0 +1,34 @@
+import yaml
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+from utility.utility import logging
+
+
+class Secret():
+
+    def __init__(self):
+        self.api = client.CoreV1Api()
+
+    def create(self):
+
+        filepath = "./templates/secret.yaml"
+
+        with open(filepath, 'r') as f:
+            manifest_dict = yaml.safe_load(f)
+            namespace = manifest_dict['metadata']['namespace']
+            logging(f"Creating secret {manifest_dict['metadata']['name']}")
+            self.api.create_namespaced_secret(namespace, body=manifest_dict)
+
+    def delete(self, name, namespace):
+        try:
+            logging(f"Deleting secret {name}")
+            self.api.delete_namespaced_secret(namespace=namespace, name=name)
+        except ApiException as e:
+            assert e.status == 404
+
+    def cleanup(self):
+        secrets = self.api.list_secret_for_all_namespaces(label_selector="test.longhorn.io=e2e")
+        for item in secrets.items:
+            self.delete(item.metadata.name, item.metadata.namespace)

--- a/e2e/libs/storageclass/storageclass.py
+++ b/e2e/libs/storageclass/storageclass.py
@@ -11,7 +11,7 @@ class StorageClass():
     def __init__(self):
         self.api = client.StorageV1Api()
 
-    def create(self, name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine):
+    def create(self, name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, secretName, secretNamespace):
 
         filepath = "./templates/workload/storageclass.yaml"
 
@@ -25,6 +25,17 @@ class StorageClass():
             manifest_dict['parameters']['fromBackup'] = fromBackup
             manifest_dict['parameters']['nfsOptions'] = nfsOptions
             manifest_dict['parameters']['dataEngine'] = dataEngine
+
+            if encrypted:
+                manifest_dict['parameters']['encrypted'] = encrypted
+                manifest_dict['parameters']['csi.storage.k8s.io/provisioner-secret-name'] = secretName
+                manifest_dict['parameters']['csi.storage.k8s.io/provisioner-secret-namespace'] = secretNamespace
+                manifest_dict['parameters']['csi.storage.k8s.io/node-publish-secret-name'] = secretName
+                manifest_dict['parameters']['csi.storage.k8s.io/node-publish-secret-namespace'] = secretNamespace
+                manifest_dict['parameters']['csi.storage.k8s.io/node-stage-secret-name'] = secretName
+                manifest_dict['parameters']['csi.storage.k8s.io/node-stage-secret-namespace'] = secretNamespace
+                manifest_dict['parameters']['csi.storage.k8s.io/node-expand-secret-name'] = secretName
+                manifest_dict['parameters']['csi.storage.k8s.io/node-expand-secret-namespace'] = secretNamespace
 
             self.api.create_storage_class(body=manifest_dict)
 

--- a/e2e/libs/workload/workload.py
+++ b/e2e/libs/workload/workload.py
@@ -223,6 +223,21 @@ def wait_for_workload_pods_running(workload_name, namespace="default"):
     assert False, f"Timeout waiting for {workload_name} pods running"
 
 
+def wait_for_workload_pods_container_creating(workload_name, namespace="default"):
+    retry_count, retry_interval = get_retry_count_and_interval()
+    for i in range(retry_count):
+        pods = get_workload_pods(workload_name, namespace=namespace)
+        if len(pods) > 0:
+            for pod in pods:
+                if pod.status.phase == "Pending":
+                    return
+
+        logging(f"Waiting for {workload_name} pods {[pod.metadata.name for pod in pods]} container creating, retry ({i}) ...")
+        time.sleep(retry_interval)
+
+    assert False, f"Timeout waiting for {workload_name} pods container creating"
+
+
 async def wait_for_workload_pods_stable(workload_name, namespace="default"):
     stable_pods = {}
     wait_for_stable_retry = {}

--- a/e2e/templates/secret.yaml
+++ b/e2e/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: longhorn-crypto
+  namespace: longhorn-system
+  labels:
+    test.longhorn.io: e2e
+stringData:
+  CRYPTO_KEY_VALUE: "Your encryption passphrase"
+  CRYPTO_KEY_PROVIDER: "secret"
+  CRYPTO_KEY_CIPHER: "aes-xts-plain64"
+  CRYPTO_KEY_HASH: "sha256"
+  CRYPTO_KEY_SIZE: "256"
+  CRYPTO_PBKDF: "argon2i"

--- a/e2e/tests/negative/instance_manager_crash.robot
+++ b/e2e/tests/negative/instance_manager_crash.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Documentation    Negative Test Cases
+
+Test Tags    negative
+
+Resource    ../keywords/variables.resource
+Resource    ../keywords/common.resource
+Resource    ../keywords/secret.resource
+Resource    ../keywords/storageclass.resource
+Resource    ../keywords/persistentvolumeclaim.resource
+Resource    ../keywords/deployment.resource
+Resource    ../keywords/workload.resource
+Resource    ../keywords/longhorn.resource
+
+Test Setup    Set test environment
+Test Teardown    Cleanup test resources
+
+*** Test Cases ***
+Crash Instance Manager While Workload Pod Is Starting
+    [Tags]    encrypted
+    Given Create crypto secret
+    And Create storageclass longhorn-crypto with    encrypted=true
+    And Create persistentvolumeclaim 0 using RWO volume with longhorn-crypto storageclass
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Wait for volume of deployment 0 healthy
+    And Write 100 MB data to file data.txt in deployment 0
+
+    FOR    ${i}    IN RANGE    ${LOOP_COUNT}
+        When Delete instance-manager of deployment 0 volume
+        # after deleting instance manager, the workload pod will be recrated as well
+        And Wait for deployment 0 pods stable
+        And Wait for volume of deployment 0 healthy
+        Then Check deployment 0 data in file data.txt is intact
+
+        And Delete pod of deployment 0    wait=False
+        And Wait for deployment 0 pods container creating
+    END


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10431

#### What this PR does / why we need it:

add Crash Instance Manager While Workload Pod Is Starting test case

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced secret management with new capabilities for crypto secret creation and cleanup.
  - Expanded storage configuration to support encryption by integrating secret associations.
  - Improved workload management with options for dynamic pod deletion based on workload identifiers.
  - Introduced a new method to wait for workload pods to be in the container creating state.

- **Tests**
  - Added a negative test suite that simulates instance manager crashes during workload initialization to validate resilience and data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->