### PR TITLE
Adjust snapshot purge frequency in backup loop

### DIFF
--- a/e2e/tests/negative/test_backup_listing.robot
+++ b/e2e/tests/negative/test_backup_listing.robot
@@ -1,6 +1,11 @@
 *** Settings ***
 Documentation    Test backup listing
-...              https://longhorn.github.io/longhorn-tests/manual/pre-release/stress/backup-listing/
+...              - https://longhorn.github.io/longhorn-tests/manual/pre-release/stress/backup-listing/
+...              - After purging the snapshots on the volume, the snapshot count was reduced to two, 
+...              - one volume-head and one hidden system snapshot.
+...              - During the subsequent process of creating 250 backups, the snapshot count exceeded 250.
+...              - 248 regular snapshots and one volume-head and one hidden system snapshot, 
+...              - which resulted in a failed to create backup error.
 
 Test Tags    manual    negative
 
@@ -82,7 +87,7 @@ Perform backup 1001 times for deployment 0 volume
     FOR    ${i}    IN RANGE    ${LOOP_COUNT}
         Create backup ${i} for deployment 0 volume
         Delete snapshot ${i} of deployment 0 volume
-        IF    ${i} % 249 == 0
+        IF    ${i} % 100 == 0
             ${workload_name}=   generate_name_with_suffix    deployment    0
             ${volume_name}=    get_workload_volume_name    ${workload_name}
             purge_snapshot    ${volume_name}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
N/A

#### What this PR does / why we need it:
In our original test case, after creating 250 backups, we performed a purge of volume snapshots.

After purging the snapshots on the volume, the snapshot count was reduced to two: one volume-head and one hidden system snapshot.

During the subsequent process of creating 250 backups, the snapshot count exceeded 250 (248 regular snapshots and one volume-head and one hidden system snapshot), which resulted in a failed to create backup error.

Changed the condition for purging snapshots
from every `249` iterations to every `100` iterations.

robot log : 
[update_purge_log.tar.gz](https://github.com/user-attachments/files/18934889/update_purge_log.tar.gz)


![Screenshot_20250224_091538](https://github.com/user-attachments/assets/d55dc7c7-eca3-4b99-ab3e-72489bb3bc62)

#### Special notes for your reviewer:

#### Additional documentation or context
https://github.com/longhorn/longhorn/issues/10308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated the `Settings` section with details on snapshot count behavior after purging and backup creation errors.
  
- **Tests**
  - Adjusted the backup process test to trigger snapshot purges at a revised interval, enhancing test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->