### PR TITLE
ci: update longhorn-e2e-test pipeline for new HAL environment

### DIFF
--- a/pipelines/e2e/Jenkinsfile
+++ b/pipelines/e2e/Jenkinsfile
@@ -56,7 +56,7 @@ node {
             stage('build') {
 
                 echo "Using credentials: $CREDS_ID"
-                echo "Using registration coce: $REGISTRATION_CODE_ID"
+                echo "Using registration code: $REGISTRATION_CODE_ID"
 
                 sh "pipelines/e2e/scripts/build.sh"
                 sh """ docker run -itd --cap-add=NET_ADMIN \

--- a/test_framework/terraform/harvester/sles/main.tf
+++ b/test_framework/terraform/harvester/sles/main.tf
@@ -48,7 +48,7 @@ resource "rancher2_machine_config_v2" "e2e-machine-config-controlplane" {
     disk_info = <<EOF
     {
         "disks": [{
-            "imageName": "longhorn-qa/image-qn4cg",
+            "imageName": "longhorn-qa/image-pqjk7",
             "size": 100,
             "bootOrder": 1
         }]
@@ -58,7 +58,7 @@ resource "rancher2_machine_config_v2" "e2e-machine-config-controlplane" {
     network_info = <<EOF
     {
         "interfaces": [{
-            "networkName": "longhorn-qa/vlan104"
+            "networkName": "longhorn-qa/vlan-2011"
         }]
     }
     EOF
@@ -95,7 +95,7 @@ resource "rancher2_machine_config_v2" "e2e-machine-config-worker" {
     disk_info = <<EOF
     {
         "disks": [{
-            "imageName": "longhorn-qa/image-qn4cg",
+            "imageName": "longhorn-qa/image-pqjk7",
             "size": 100,
             "bootOrder": 1
         },
@@ -110,7 +110,7 @@ resource "rancher2_machine_config_v2" "e2e-machine-config-worker" {
     network_info = <<EOF
     {
         "interfaces": [{
-            "networkName": "longhorn-qa/vlan104"
+            "networkName": "longhorn-qa/vlan-2011"
         }]
     }
     EOF


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

#### What this PR does / why we need it:

Update `longhorn-e2e-test` pipeline for running new HAL environment

#### Special notes for your reviewer:

Running `Test Volume Basic`(both v1 and v2 volume) passed on my local after connected to infraVPN

![image](https://github.com/user-attachments/assets/f7f3b7a6-9cd3-499c-8766-786c382e4510)
![image](https://github.com/user-attachments/assets/21248296-dda0-4601-bf84-7cbd70f87195)


#### Additional documentation or context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typographical error in a build output message for clearer logging.

- **Chores**
  - Updated configuration settings for machine resources, reflecting revised image and network parameters to ensure accurate resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->