### PR TITLE
test(robot): clean up backing images before cleaning up disks

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -74,8 +74,8 @@ Cleanup test resources
     cleanup_backups
     cleanup_system_backups
     cleanup_system_restores
-    cleanup_disks
     cleanup_backing_images
+    cleanup_disks
     cleanup_engine_images
     reset_backupstore
     reset_settings


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10522

#### What this PR does / why we need it:

clean up backing images before cleaning up disks

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored a key step in the system’s cleanup process to ensure that all storage components are properly managed during maintenance. This update enhances overall system reliability by fully executing cleanup routines, which improves performance and stability for end users. It also boosts the consistency and predictability of system behavior during routine maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->