### PR TITLE
ci: provide docker credentials when pulling Longhorn components images

### DIFF
--- a/airgap/terraform/main.tf
+++ b/airgap/terraform/main.tf
@@ -304,7 +304,7 @@ resource "null_resource" "post_setup" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/provision_registry_server.sh",
-      "registry_username=${local.registry_username} registry_password=${local.registry_password} registry_url=${aws_route53_record.lh_registry.fqdn} longhorn_version=${var.longhorn_version} /tmp/provision_registry_server.sh",
+      "docker_hub_username=${var.docker_hub_username} docker_hub_password=${var.docker_hub_password} registry_username=${local.registry_username} registry_password=${local.registry_password} registry_url=${aws_route53_record.lh_registry.fqdn} longhorn_version=${var.longhorn_version} /tmp/provision_registry_server.sh",
     ]
 
     connection {

--- a/airgap/terraform/user-data-scripts/provision_registry_server.sh
+++ b/airgap/terraform/user-data-scripts/provision_registry_server.sh
@@ -43,7 +43,11 @@ sudo docker run -d --name registry \
 
 sudo docker login -u ${registry_username} -p ${registry_password} ${registry_url}
 
-# (7) pull longhorn images into registry
+# (7) log into docker hub before pulling images
+
+sudo docker login -u ${docker_hub_username} -p ${docker_hub_password}
+
+# (8) pull longhorn images into registry
 
 wget https://raw.githubusercontent.com/longhorn/longhorn/${longhorn_version}/deploy/longhorn-images.txt
 wget https://raw.githubusercontent.com/longhorn/longhorn/${longhorn_version}/scripts/save-images.sh
@@ -53,6 +57,6 @@ chmod +x "${PWD}/load-images.sh"
 sudo "${PWD}/save-images.sh" --image-list "${PWD}/longhorn-images.txt" --images "${PWD}/longhorn-images.tar.gz"
 sudo "${PWD}/load-images.sh" --image-list "${PWD}/longhorn-images.txt" --images "${PWD}/longhorn-images.tar.gz" --registry ${registry_url}
 
-# (8) test list all images in registry
+# (9) test list all images in registry
 
 curl -X GET -u ${registry_username}:${registry_password} https://${registry_url}/v2/_catalog

--- a/airgap/terraform/variables.tf
+++ b/airgap/terraform/variables.tf
@@ -29,6 +29,16 @@ variable "registry_aws_instance_type" {
   default     = "t2.micro"
 }
 
+variable "docker_hub_username" {
+  type = string
+  sensitive = true
+}
+
+variable "docker_hub_password" {
+  type = string
+  sensitive = true
+}
+
 variable "longhorn_version" {
   type = string
   default = "master"

--- a/pipelines/argocd/Jenkinsfile
+++ b/pipelines/argocd/Jenkinsfile
@@ -9,12 +9,8 @@ def SELINUX_MODE = params.SELINUX_MODE ? params.SELINUX_MODE : ""
 def CREDS_ID = JOB_BASE_NAME == "longhorn-tests-regression" ? "AWS_CREDS_RANCHER_QA" : "AWS_CREDS"
 def REGISTRATION_CODE_ID = params.ARCH == "amd64" ? "REGISTRATION_CODE" : "REGISTRATION_CODE_ARM64"
 
-// parameters for air gap installation
-def AIR_GAP_INSTALLATION = params.AIR_GAP_INSTALLATION ? params.AIR_GAP_INSTALLATION : false
 def CIS_HARDENING = params.CIS_HARDENING ? params.CIS_HARDENING : false
-def REGISTRY_URL
-def REGISTRY_USERNAME
-def REGISTRY_PASSWORD
+def REGISTRY_URL = ""
 
 // parameter for hdd test
 def USE_HDD = params.USE_HDD ? params.USE_HDD : false
@@ -23,7 +19,7 @@ node {
 
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
-        string(credentialsId: 'DO_CREDS', variable: 'DO_TOKEN'),
+        usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
     ]) {
 
@@ -35,46 +31,13 @@ node {
 
         try {
 
-            if (params.AIR_GAP_INSTALLATION) {
-
-                stage('airgap build') {
-                    sh "airgap/scripts/build.sh"
-                    sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
-                                           --env TF_VAR_longhorn_version=${LONGHORN_INSTALL_VERSION} \
-                                           --env TF_VAR_do_token=${DO_TOKEN} \
-                                           --env TF_VAR_aws_access_key=${AWS_ACCESS_KEY} \
-                                           --env TF_VAR_aws_secret_key=${AWS_SECRET_KEY} \
-                                           airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}
-                    """
-                }
-
-                stage ('airgap setup') {
-                    sh "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} ./airgap/scripts/terraform-setup.sh"
-                    REGISTRY_URL = sh (
-                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_url",
-                        returnStdout: true
-                    )
-                    println REGISTRY_URL
-                    REGISTRY_USERNAME = sh (
-                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_username",
-                        returnStdout: true
-                    )
-                    REGISTRY_PASSWORD = sh (
-                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_password",
-                        returnStdout: true
-                    )
-                }
-
-            }
-
             stage('build') {
 
                 echo "Using credentials: $CREDS_ID"
-                echo "Using registration coce: $REGISTRATION_CODE_ID"
+                echo "Using registration code: $REGISTRATION_CODE_ID"
 
                 sh "pipelines/argocd/scripts/build.sh"
                 sh """ docker run -itd --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
-                                       --env AIR_GAP_INSTALLATION=${AIR_GAP_INSTALLATION} \
                                        --env REGISTRY_URL=${REGISTRY_URL} \
                                        --env REGISTRY_USERNAME=${REGISTRY_USERNAME} \
                                        --env REGISTRY_PASSWORD=${REGISTRY_PASSWORD} \

--- a/pipelines/argocd/scripts/longhorn-setup.sh
+++ b/pipelines/argocd/scripts/longhorn-setup.sh
@@ -6,6 +6,7 @@ source pipelines/utilities/kubeconfig.sh
 source pipelines/utilities/selinux_workaround.sh
 source pipelines/utilities/install_csi_snapshotter.sh
 source pipelines/utilities/create_aws_secret.sh
+source pipelines/utilities/create_registry_secret.sh
 source pipelines/utilities/install_backupstores.sh
 source pipelines/utilities/create_longhorn_namespace.sh
 source pipelines/utilities/argocd.sh
@@ -32,6 +33,12 @@ main(){
   create_longhorn_namespace
   install_backupstores
   install_csi_snapshotter
+
+  # set debugging mode off to avoid leaking docker secrets to the logs.
+  # DON'T REMOVE!
+  set +x
+  create_registry_secret
+  set -x
 
   install_argocd
   init_argocd

--- a/pipelines/e2e/Jenkinsfile
+++ b/pipelines/e2e/Jenkinsfile
@@ -24,9 +24,7 @@ if (params.DISTRO == "sles") {
 
 def CIS_HARDENING = params.CIS_HARDENING ? params.CIS_HARDENING : false
 def CUSTOM_SSH_PUBLIC_KEY = params.CUSTOM_SSH_PUBLIC_KEY ? params.CUSTOM_SSH_PUBLIC_KEY : ""
-def REGISTRY_URL
-def REGISTRY_USERNAME
-def REGISTRY_PASSWORD
+def REGISTRY_URL = ""
 
 // parameter for v2 test
 def RUN_V2_TEST = params.RUN_V2_TEST ? params.RUN_V2_TEST : true
@@ -38,7 +36,7 @@ node {
 
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
-        string(credentialsId: 'DO_CREDS', variable: 'DO_TOKEN'),
+        usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
         usernamePassword(credentialsId: 'LAB_API_KEY', passwordVariable: 'LAB_SECRET_KEY', usernameVariable: 'LAB_ACCESS_KEY'),
         string(credentialsId: 'LAB_URL', variable: 'LAB_URL'),

--- a/pipelines/e2e/scripts/longhorn-setup.sh
+++ b/pipelines/e2e/scripts/longhorn-setup.sh
@@ -7,6 +7,7 @@ source pipelines/utilities/selinux_workaround.sh
 source pipelines/utilities/install_csi_snapshotter.sh
 source pipelines/utilities/create_aws_secret.sh
 source pipelines/utilities/create_harvester_secret.sh
+source pipelines/utilities/create_registry_secret.sh
 source pipelines/utilities/install_backupstores.sh
 source pipelines/utilities/install_metrics_server.sh
 source pipelines/utilities/create_longhorn_namespace.sh
@@ -69,6 +70,12 @@ main(){
   fi
 
   generate_longhorn_yaml_manifest
+  # set debugging mode off to avoid leaking docker secrets to the logs.
+  # DON'T REMOVE!
+  set +x
+  create_registry_secret
+  set -x
+  customize_longhorn_manifest_registry
   install_longhorn_by_manifest
 
   setup_longhorn_ui_nodeport

--- a/pipelines/fleet/Jenkinsfile
+++ b/pipelines/fleet/Jenkinsfile
@@ -9,12 +9,8 @@ def SELINUX_MODE = params.SELINUX_MODE ? params.SELINUX_MODE : ""
 def CREDS_ID = JOB_BASE_NAME == "longhorn-tests-regression" ? "AWS_CREDS_RANCHER_QA" : "AWS_CREDS"
 def REGISTRATION_CODE_ID = params.ARCH == "amd64" ? "REGISTRATION_CODE" : "REGISTRATION_CODE_ARM64"
 
-// parameters for air gap installation
-def AIR_GAP_INSTALLATION = params.AIR_GAP_INSTALLATION ? params.AIR_GAP_INSTALLATION : false
 def CIS_HARDENING = params.CIS_HARDENING ? params.CIS_HARDENING : false
-def REGISTRY_URL
-def REGISTRY_USERNAME
-def REGISTRY_PASSWORD
+def REGISTRY_URL = ""
 
 // parameter for hdd test
 def USE_HDD = params.USE_HDD ? params.USE_HDD : false
@@ -23,6 +19,7 @@ node {
 
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
+        usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
     ]) {
 

--- a/pipelines/fleet/scripts/longhorn-setup.sh
+++ b/pipelines/fleet/scripts/longhorn-setup.sh
@@ -6,6 +6,7 @@ source pipelines/utilities/kubeconfig.sh
 source pipelines/utilities/selinux_workaround.sh
 source pipelines/utilities/install_csi_snapshotter.sh
 source pipelines/utilities/create_aws_secret.sh
+source pipelines/utilities/create_registry_secret.sh
 source pipelines/utilities/install_backupstores.sh
 source pipelines/utilities/create_longhorn_namespace.sh
 source pipelines/utilities/fleet.sh
@@ -32,6 +33,12 @@ main(){
   create_longhorn_namespace
   install_backupstores
   install_csi_snapshotter
+
+  # set debugging mode off to avoid leaking docker secrets to the logs.
+  # DON'T REMOVE!
+  set +x
+  create_registry_secret
+  set -x
 
   install_fleet
 

--- a/pipelines/flux/Jenkinsfile
+++ b/pipelines/flux/Jenkinsfile
@@ -9,12 +9,8 @@ def SELINUX_MODE = params.SELINUX_MODE ? params.SELINUX_MODE : ""
 def CREDS_ID = JOB_BASE_NAME == "longhorn-tests-regression" ? "AWS_CREDS_RANCHER_QA" : "AWS_CREDS"
 def REGISTRATION_CODE_ID = params.ARCH == "amd64" ? "REGISTRATION_CODE" : "REGISTRATION_CODE_ARM64"
 
-// parameters for air gap installation
-def AIR_GAP_INSTALLATION = params.AIR_GAP_INSTALLATION ? params.AIR_GAP_INSTALLATION : false
 def CIS_HARDENING = params.CIS_HARDENING ? params.CIS_HARDENING : false
-def REGISTRY_URL
-def REGISTRY_USERNAME
-def REGISTRY_PASSWORD
+def REGISTRY_URL = ""
 
 // parameter for hdd test
 def USE_HDD = params.USE_HDD ? params.USE_HDD : false
@@ -23,7 +19,7 @@ node {
 
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
-        string(credentialsId: 'DO_CREDS', variable: 'DO_TOKEN'),
+        usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
     ]) {
 
@@ -35,46 +31,13 @@ node {
 
         try {
 
-            if (params.AIR_GAP_INSTALLATION) {
-
-                stage('airgap build') {
-                    sh "airgap/scripts/build.sh"
-                    sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
-                                           --env TF_VAR_longhorn_version=${LONGHORN_INSTALL_VERSION} \
-                                           --env TF_VAR_do_token=${DO_TOKEN} \
-                                           --env TF_VAR_aws_access_key=${AWS_ACCESS_KEY} \
-                                           --env TF_VAR_aws_secret_key=${AWS_SECRET_KEY} \
-                                           airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}
-                    """
-                }
-
-                stage ('airgap setup') {
-                    sh "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} ./airgap/scripts/terraform-setup.sh"
-                    REGISTRY_URL = sh (
-                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_url",
-                        returnStdout: true
-                    )
-                    println REGISTRY_URL
-                    REGISTRY_USERNAME = sh (
-                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_username",
-                        returnStdout: true
-                    )
-                    REGISTRY_PASSWORD = sh (
-                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_password",
-                        returnStdout: true
-                    )
-                }
-
-            }
-
             stage('build') {
 
                 echo "Using credentials: $CREDS_ID"
-                echo "Using registration coce: $REGISTRATION_CODE_ID"
+                echo "Using registration code: $REGISTRATION_CODE_ID"
 
                 sh "pipelines/flux/scripts/build.sh"
                 sh """ docker run -itd --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
-                                       --env AIR_GAP_INSTALLATION=${AIR_GAP_INSTALLATION} \
                                        --env REGISTRY_URL=${REGISTRY_URL} \
                                        --env REGISTRY_USERNAME=${REGISTRY_USERNAME} \
                                        --env REGISTRY_PASSWORD=${REGISTRY_PASSWORD} \

--- a/pipelines/flux/scripts/longhorn-setup.sh
+++ b/pipelines/flux/scripts/longhorn-setup.sh
@@ -6,6 +6,7 @@ source pipelines/utilities/kubeconfig.sh
 source pipelines/utilities/selinux_workaround.sh
 source pipelines/utilities/install_csi_snapshotter.sh
 source pipelines/utilities/create_aws_secret.sh
+source pipelines/utilities/create_registry_secret.sh
 source pipelines/utilities/install_backupstores.sh
 source pipelines/utilities/create_longhorn_namespace.sh
 source pipelines/utilities/flux.sh
@@ -37,6 +38,12 @@ main(){
   create_longhorn_namespace
   install_backupstores
   install_csi_snapshotter
+
+  # set debugging mode off to avoid leaking docker secrets to the logs.
+  # DON'T REMOVE!
+  set +x
+  create_registry_secret
+  set -x
 
   init_flux
 

--- a/pipelines/gke/Jenkinsfile
+++ b/pipelines/gke/Jenkinsfile
@@ -1,12 +1,17 @@
 def imageName = "${JOB_BASE_NAME}-${env.BUILD_NUMBER}"
 def summary
+def WORKSPACE = "/src/longhorn-tests"
 def BUILD_TRIGGER_BY = "\n${currentBuild.getBuildCauses()[0].shortDescription}"
+def LONGHORN_TEST_CLOUDPROVIDER = "gcp"
+def K8S_DISTRO_NAME = "gke"
+def REGISTRY_URL = ""
 
 node {
 
     withCredentials([
         file(credentialsId: 'GCP_CREDS', variable: 'GCP_CREDS_FILE'),
         string(credentialsId: 'GCP_PROJECT', variable: 'GCP_PROJECT'),
+        usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
     ]) {
 
         if (params.SEND_SLACK_NOTIFICATION) {
@@ -21,6 +26,9 @@ node {
 
                 sh "pipelines/gke/scripts/build.sh"
                 sh """ docker run -itd --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
+                                       --env REGISTRY_URL=${REGISTRY_URL} \
+                                       --env REGISTRY_USERNAME=${REGISTRY_USERNAME} \
+                                       --env REGISTRY_PASSWORD=${REGISTRY_PASSWORD} \
                                        --env LONGHORN_REPO_URI=${LONGHORN_REPO_URI} \
                                        --env LONGHORN_REPO_BRANCH=${LONGHORN_REPO_BRANCH} \
                                        --env CUSTOM_LONGHORN_MANAGER_IMAGE=${CUSTOM_LONGHORN_MANAGER_IMAGE} \
@@ -30,10 +38,11 @@ node {
                                        --env CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE=${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE} \
                                        --env LONGHORN_TESTS_CUSTOM_IMAGE=${LONGHORN_TESTS_CUSTOM_IMAGE} \
                                        --env LONGHORN_STABLE_VERSION=${LONGHORN_STABLE_VERSION} \
+                                       --env LONGHORN_TEST_CLOUDPROVIDER=${LONGHORN_TEST_CLOUDPROVIDER} \
+                                       --env TF_VAR_k8s_distro_name=${K8S_DISTRO_NAME} \
                                        --env LONGHORN_UPGRADE_TEST=${LONGHORN_UPGRADE_TEST} \
                                        --env PYTEST_CUSTOM_OPTIONS="${PYTEST_CUSTOM_OPTIONS}" \
                                        --env BACKUP_STORE_TYPE="${BACKUP_STORE_TYPE}" \
-                                       --env TF_VAR_tf_workspace=${TF_VAR_tf_workspace} \
                                        --env TF_VAR_gcp_project=${GCP_PROJECT} \
                                        --env TF_VAR_gcp_auth_file=/src/longhorn-tests/gcp_creds.json \
                                        --env TF_VAR_distro=${DISTRO} \
@@ -45,42 +54,30 @@ node {
 
             timeout(60) {
                 stage ('terraform') {
-                    sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/terraform-setup.sh"
+                    sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/gke/scripts/terraform-setup.sh"
                 }
 			}
 
             stage ('longhorn setup & tests') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/longhorn-setup.sh"
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/gke/scripts/longhorn-setup.sh"
             }
 
             stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/download-support-bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${TF_VAR_tf_workspace}/../../${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/gke/scripts/download-support-bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
 				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
 			}
 
             stage ('report generation') {
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${TF_VAR_tf_workspace}/longhorn-test-junit-report.xml ."
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-junit-report.xml ."
 
                 if(params.LONGHORN_UPGRADE_TEST) {
-                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${TF_VAR_tf_workspace}/longhorn-test-upgrade-junit-report.xml ."
+                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-upgrade-junit-report.xml ."
                     summary = junit 'longhorn-test-upgrade-junit-report.xml, longhorn-test-junit-report.xml'
                 }
                 else {
                     summary = junit 'longhorn-test-junit-report.xml'
                 }
-
-                sh 'docker pull ${CUSTOM_LONGHORN_MANAGER_IMAGE}'
-                LONGHORN_MANAGER_VERSION = sh (
-                    script: "docker inspect --format '{{ index .Config.Labels \"org.opencontainers.image.revision\" }}' ${CUSTOM_LONGHORN_MANAGER_IMAGE}",
-                    returnStdout: true
-                )
-                sh 'docker pull ${CUSTOM_LONGHORN_ENGINE_IMAGE}'
-                LONGHORN_ENGINE_VERSION = sh (
-                    script: "docker inspect --format '{{ index .Config.Labels \"org.opencontainers.image.revision\" }}' ${CUSTOM_LONGHORN_ENGINE_IMAGE}",
-                    returnStdout: true
-                )
-                manager.createSummary("info.gif").appendText("<p>longhorn-manager version: $LONGHORN_MANAGER_VERSION</p><p>longhorn-engine version: $LONGHORN_ENGINE_VERSION</p>", false, false, false, "black")
             }
 
         } catch (e) {

--- a/pipelines/gke/scripts/cleanup.sh
+++ b/pipelines/gke/scripts/cleanup.sh
@@ -11,4 +11,4 @@ fi
 # wait 30 seconds for graceful terraform termination
 sleep 30
 
-terraform -chdir=${TF_VAR_tf_workspace}/terraform destroy -auto-approve -no-color
+terraform -chdir=pipelines/gke/terraform destroy -auto-approve -no-color

--- a/pipelines/gke/scripts/download-support-bundle.sh
+++ b/pipelines/gke/scripts/download-support-bundle.sh
@@ -7,7 +7,7 @@ SUPPORT_BUNDLE_ISSUE_URL=${2:-""}
 SUPPORT_BUNDLE_ISSUE_DESC=${3:-"Auto-generated support buundle"}
 
 set_kubeconfig_envvar(){
-    gcloud container clusters get-credentials `terraform -chdir=${TF_VAR_tf_workspace}/terraform output -raw cluster_name` --zone `terraform -chdir=${TF_VAR_tf_workspace}/terraform output -raw cluster_zone` --project ${TF_VAR_gcp_project}
+    gcloud container clusters get-credentials `terraform -chdir=${PWD}/pipelines/gke/terraform output -raw cluster_name` --zone `terraform -chdir=${PWD}/pipelines/gke/terraform output -raw cluster_zone` --project ${TF_VAR_gcp_project}
 }
 
 set_kubeconfig_envvar

--- a/pipelines/gke/scripts/longhorn-setup.sh
+++ b/pipelines/gke/scripts/longhorn-setup.sh
@@ -2,32 +2,30 @@
 
 set -x
 
+source pipelines/utilities/install_csi_snapshotter.sh
+source pipelines/utilities/create_aws_secret.sh
+source pipelines/utilities/create_registry_secret.sh
+source pipelines/utilities/install_backupstores.sh
+source pipelines/utilities/create_longhorn_namespace.sh
+source pipelines/utilities/longhorn_manifest.sh
+source pipelines/utilities/longhorn_ui.sh
+source pipelines/utilities/run_longhorn_test.sh
+
 # create and clean tmpdir
 TMPDIR="/tmp/longhorn"
 mkdir -p ${TMPDIR}
 rm -rf "${TMPDIR}/"
 
-LONGHORN_NAMESPACE="longhorn-system"
-
-# Longhorn version tag (e.g v1.1.0), use "master" for latest stable
-# we will use this version as the base for upgrade
-LONGHORN_STABLE_VERSION=${LONGHORN_STABLE_VERSION:-master}
-LONGHORN_STABLE_MANIFEST_URL="https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_STABLE_VERSION}/deploy/longhorn.yaml"
-
-# for install Longhorn by manifest
-LONGHORN_MANIFEST_URL="https://raw.githubusercontent.com/longhorn/longhorn/${LONGHORN_INSTALL_VERSION}/deploy/longhorn.yaml"
-
-# for install Longhorn by helm chart
-LONGHORN_REPO_URL="https://github.com/longhorn/longhorn"
-LONGHORN_REPO_DIR="${TMPDIR}/longhorn"
-
+export LONGHORN_NAMESPACE="longhorn-system"
+export LONGHORN_REPO_DIR="${TMPDIR}/longhorn"
+export LONGHORN_INSTALL_METHOD="manifest"
 
 set_kubeconfig_envvar(){
-    gcloud container clusters get-credentials `terraform -chdir=${TF_VAR_tf_workspace}/terraform output -raw cluster_name` --zone `terraform -chdir=${TF_VAR_tf_workspace}/terraform output -raw cluster_zone` --project ${TF_VAR_gcp_project}
+    gcloud container clusters get-credentials `terraform -chdir=${PWD}/pipelines/gke/terraform output -raw cluster_name` --zone `terraform -chdir=${PWD}/pipelines/gke/terraform output -raw cluster_zone` --project ${TF_VAR_gcp_project}
 }
 
 print_out_cluster_info(){
-  gcloud container clusters describe `terraform -chdir=${TF_VAR_tf_workspace}/terraform output -raw cluster_name` --zone `terraform -chdir=${TF_VAR_tf_workspace}/terraform output -raw cluster_zone` --format="value(currentNodeVersion)"
+  gcloud container clusters describe `terraform -chdir=${PWD}/pipelines/gke/terraform output -raw cluster_name` --zone `terraform -chdir=${PWD}/pipelines/gke/terraform output -raw cluster_zone` --format="value(currentNodeVersion)"
   kubectl create -f - <<EOF
 apiVersion: v1
 kind: Pod
@@ -52,238 +50,6 @@ EOF
   kubectl delete pod/print-os-release
 }
 
-
-install_csi_snapshotter_crds(){
-    CSI_SNAPSHOTTER_REPO_URL="https://github.com/kubernetes-csi/external-snapshotter.git"
-    CSI_SNAPSHOTTER_REPO_BRANCH="v6.2.1"
-    CSI_SNAPSHOTTER_REPO_DIR="${TMPDIR}/k8s-csi-external-snapshotter"
-
-    git clone --single-branch \
-              --branch "${CSI_SNAPSHOTTER_REPO_BRANCH}" \
-            "${CSI_SNAPSHOTTER_REPO_URL}" \
-            "${CSI_SNAPSHOTTER_REPO_DIR}"
-
-    kubectl apply -f ${CSI_SNAPSHOTTER_REPO_DIR}/client/config/crd \
-                  -f ${CSI_SNAPSHOTTER_REPO_DIR}/deploy/kubernetes/snapshot-controller
-}
-
-
-wait_longhorn_status_running(){
-  local RETRY_COUNTS=10 # in minutes
-  local RETRY_INTERVAL="1m"
-
-  RETRIES=0
-  while [[ -n `kubectl get pods -n ${LONGHORN_NAMESPACE} --no-headers 2>&1 | awk '{print $3}' | grep -v Running` ]]; do
-    echo "Longhorn is still installing ... re-checking in 1m"
-    sleep ${RETRY_INTERVAL}
-    RETRIES=$((RETRIES+1))
-
-    if [[ ${RETRIES} -eq ${RETRY_COUNTS} ]]; then echo "Error: longhorn installation timeout"; exit 1 ; fi
-  done
-
-}
-
-
-get_longhorn_manifest(){
-  wget ${LONGHORN_MANIFEST_URL} -P ${TF_VAR_tf_workspace}
-  sed -i ':a;N;$!ba;s/---\n---/---/g' "${TF_VAR_tf_workspace}/longhorn.yaml"
-}
-
-
-generate_longhorn_yaml_manifest() {
-  MANIFEST_BASEDIR="${1}"
-
-  LONGHORN_REPO_URI=${LONGHORN_REPO_URI:-"https://github.com/longhorn/longhorn.git"}
-  LONGHORN_REPO_BRANCH=${LONGHORN_REPO_BRANCH:-"master"}
-  LONGHORN_REPO_DIR="${TMPDIR}/longhorn"
-
-  CUSTOM_LONGHORN_MANAGER_IMAGE=${CUSTOM_LONGHORN_MANAGER_IMAGE:-"longhornio/longhorn-manager:master-head"}
-  CUSTOM_LONGHORN_ENGINE_IMAGE=${CUSTOM_LONGHORN_ENGINE_IMAGE:-"longhornio/longhorn-engine:master-head"}
-
-  CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE=${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE:-""}
-  CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE=${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE:-""}
-  CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE=${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE:-""}
-
-  git clone --single-branch \
-            --branch ${LONGHORN_REPO_BRANCH} \
-            ${LONGHORN_REPO_URI} \
-            ${LONGHORN_REPO_DIR}
-
-  cat "${LONGHORN_REPO_DIR}/deploy/longhorn.yaml" > "${MANIFEST_BASEDIR}/longhorn.yaml"
-  sed -i ':a;N;$!ba;s/---\n---/---/g' "${MANIFEST_BASEDIR}/longhorn.yaml"
-
-  # get longhorn default images from yaml manifest
-  LONGHORN_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-manager:.*$" "${MANIFEST_BASEDIR}/longhorn.yaml"| head -1 | sed -e 's/^"//' -e 's/"$//'`
-  LONGHORN_ENGINE_IMAGE=`grep -io "longhornio\/longhorn-engine:.*$" "${MANIFEST_BASEDIR}/longhorn.yaml"| head -1 | sed -e 's/^"//' -e 's/"$//'`
-  LONGHORN_INSTANCE_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-instance-manager:.*$" "${MANIFEST_BASEDIR}/longhorn.yaml"| head -1 | sed -e 's/^"//' -e 's/"$//'`
-  LONGHORN_SHARE_MANAGER_IMAGE=`grep -io "longhornio\/longhorn-share-manager:.*$" "${MANIFEST_BASEDIR}/longhorn.yaml"| head -1 | sed -e 's/^"//' -e 's/"$//'`
-  LONGHORN_BACKING_IMAGE_MANAGER_IMAGE=`grep -io "longhornio\/backing-image-manager:.*$" "${MANIFEST_BASEDIR}/longhorn.yaml"| head -1 | sed -e 's/^"//' -e 's/"$//'`
-
-  # replace longhorn images with custom images
-  sed -i 's#'${LONGHORN_MANAGER_IMAGE}'#'${CUSTOM_LONGHORN_MANAGER_IMAGE}'#' "${MANIFEST_BASEDIR}/longhorn.yaml"
-  sed -i 's#'${LONGHORN_ENGINE_IMAGE}'#'${CUSTOM_LONGHORN_ENGINE_IMAGE}'#' "${MANIFEST_BASEDIR}/longhorn.yaml"
-
-  # replace images if custom image is specified.
-  if [[ ! -z ${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE} ]]; then
-    sed -i 's#'${LONGHORN_INSTANCE_MANAGER_IMAGE}'#'${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE}'#' "${MANIFEST_BASEDIR}/longhorn.yaml"
-  else
-    # use instance-manager image specified in yaml file if custom image is not specified
-    CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE=${LONGHORN_INSTANCE_MANAGER_IMAGE}
-  fi
-
-  if [[ ! -z ${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE} ]]; then
-    sed -i 's#'${LONGHORN_SHARE_MANAGER_IMAGE}'#'${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE}'#' "${MANIFEST_BASEDIR}/longhorn.yaml"
-  else
-    # use share-manager image specified in yaml file if custom image is not specified
-    CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE=${LONGHORN_SHARE_MANAGER_IMAGE}
-  fi
-
-  if [[ ! -z ${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE} ]]; then
-    sed -i 's#'${LONGHORN_BACKING_IMAGE_MANAGER_IMAGE}'#'${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE}'#' "${MANIFEST_BASEDIR}/longhorn.yaml"
-  else
-    # use backing-image-manager image specified in yaml file if custom image is not specified
-    CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE=${LONGHORN_BACKING_IMAGE_MANAGER_IMAGE}
-  fi
-}
-
-
-install_longhorn_by_manifest(){
-  LONGHORN_MANIFEST_FILE_PATH="${1}"
-  kubectl apply -f "${LONGHORN_MANIFEST_FILE_PATH}"
-  wait_longhorn_status_running
-}
-
-
-install_longhorn_stable(){
-  install_longhorn_by_manifest "${LONGHORN_STABLE_MANIFEST_URL}"
-}
-
-
-create_longhorn_namespace(){
-  kubectl create ns ${LONGHORN_NAMESPACE}
-}
-
-
-install_backupstores(){
-  MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml"
-  NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/nfs-backupstore.yaml"
-  kubectl create -f ${MINIO_BACKUPSTORE_URL} \
-               -f ${NFS_BACKUPSTORE_URL}
-}
-
-
-run_longhorn_upgrade_test(){
-  LONGHORN_TESTS_CUSTOM_IMAGE=${LONGHORN_TESTS_CUSTOM_IMAGE:-"longhornio/longhorn-manager-test:master-head"}
-
-  LONGHORN_TESTS_MANIFEST_FILE_PATH="${WORKSPACE}/manager/integration/deploy/test.yaml"
-  LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH="${WORKSPACE}/manager/integration/deploy/upgrade_test.yaml"
-
-  LONGHORN_JUNIT_REPORT_PATH=`yq e '.spec.containers[0].env[] | select(.name == "LONGHORN_JUNIT_REPORT_PATH").value' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"`
-
-  local PYTEST_COMMAND_ARGS='''"-s",
-                                 "--junitxml='${LONGHORN_JUNIT_REPORT_PATH}'",
-                                 "--include-upgrade-test",
-                                 "-k", "test_upgrade",
-                                 "--upgrade-lh-repo-url", "'${UPGRADE_LH_REPO_URL}'",
-                                 "--upgrade-lh-repo-branch", "'${UPGRADE_LH_REPO_BRANCH}'",
-                                 "--upgrade-lh-manager-image", "'${UPGRADE_LH_MANAGER_IMAGE}'",
-                                 "--upgrade-lh-engine-image", "'${UPGRADE_LH_ENGINE_IMAGE}'",
-                                 "--upgrade-lh-instance-manager-image", "'${UPGRADE_LH_INSTANCE_MANAGER_IMAGE}'",
-                                 "--upgrade-lh-share-manager-image", "'${UPGRADE_LH_SHARE_MANAGER_IMAGE}'",
-                                 "--upgrade-lh-backing-image-manager-image", "'${UPGRADE_LH_BACKING_IMAGE_MANAGER_IMAGE}'"
-                              '''
-
-  ## generate upgrade_test pod manifest
-  yq e 'select(.spec.containers[0] != null).spec.containers[0].args=['"${PYTEST_COMMAND_ARGS}"']' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}" > ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].image="'${LONGHORN_TESTS_CUSTOM_IMAGE}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-  yq e -i 'select(.spec.containers[0] != null).metadata.name="'${LONGHORN_UPGRADE_TEST_POD_NAME}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-
-  if [[ $BACKUP_STORE_TYPE = "s3" ]]; then
-    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $1}' | sed 's/ *//'`
-    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-  elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
-    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
-    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-  fi
-
-  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[4].value="'${LONGHORN_UPGRADE_TYPE}'"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-
-  kubectl apply -f ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
-
-  # wait upgrade test pod to start running
-  while [[ -n "`kubectl get pod ${LONGHORN_UPGRADE_TEST_POD_NAME} -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' | grep -v \"running\|terminated\"`"  ]]; do
-    echo "waiting upgrade test pod to be in running state ... rechecking in 10s"
-    sleep 10s
-  done
-
-    # wait upgrade test to complete
-  while [[ -n "`kubectl get pod ${LONGHORN_UPGRADE_TEST_POD_NAME} -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' | grep \"running\"`"  ]]; do
-    kubectl logs ${LONGHORN_UPGRADE_TEST_POD_NAME} -c longhorn-test -f --since=10s
-  done
-
-  # get upgrade test junit xml report
-  kubectl cp ${LONGHORN_UPGRADE_TEST_POD_NAME}:${LONGHORN_JUNIT_REPORT_PATH} "${TF_VAR_tf_workspace}/${LONGHORN_UPGRADE_TEST_POD_NAME}-junit-report.xml" -c longhorn-test-report
-}
-
-
-run_longhorn_tests(){
-
-  LONGHORN_TESTS_CUSTOM_IMAGE=${LONGHORN_TESTS_CUSTOM_IMAGE:-"longhornio/longhorn-manager-test:master-head"}
-
-  LONGHORN_TESTS_MANIFEST_FILE_PATH="${WORKSPACE}/manager/integration/deploy/test.yaml"
-
-  LONGHORN_JUNIT_REPORT_PATH=`yq e '.spec.containers[0].env[] | select(.name == "LONGHORN_JUNIT_REPORT_PATH").value' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"`
-
-  local PYTEST_COMMAND_ARGS='"-s", "--junitxml='${LONGHORN_JUNIT_REPORT_PATH}'"'
-  if [[ -n ${PYTEST_CUSTOM_OPTIONS} ]]; then
-    PYTEST_CUSTOM_OPTIONS=(${PYTEST_CUSTOM_OPTIONS})
-    for OPT in "${PYTEST_CUSTOM_OPTIONS[@]}"; do
-      PYTEST_COMMAND_ARGS=${PYTEST_COMMAND_ARGS}', "'${OPT}'"'
-    done
-  fi
-
-  ## generate test pod manifest
-  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].args=['"${PYTEST_COMMAND_ARGS}"']' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
-  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].image="'${LONGHORN_TESTS_CUSTOM_IMAGE}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
-
-  if [[ $BACKUP_STORE_TYPE = "s3" ]]; then
-    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $1}' | sed 's/ *//'`
-    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
-  elif [[ $BACKUP_STORE_TYPE = "nfs" ]]; then
-    BACKUP_STORE_FOR_TEST=`yq e 'select(.spec.containers[0] != null).spec.containers[0].env[1].value' ${LONGHORN_TESTS_MANIFEST_FILE_PATH} | awk -F ',' '{print $2}' | sed 's/ *//'`
-    yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[1].value="'${BACKUP_STORE_FOR_TEST}'"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
-  fi
-
-  # set MANAGED_K8S_CLUSTER to true
-  yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[6].value="true"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
-
-  ## inject cloudprovider
-  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "CLOUDPROVIDER", "value": "gke"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
-
-  LONGHORN_TEST_POD_NAME=`yq e 'select(.spec.containers[0] != null).metadata.name' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}`
-
-  kubectl apply -f ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
-
-  local RETRY_COUNTS=60
-  local RETRIES=0
-  # wait longhorn tests pod to start running
-  while [[ -n "`kubectl get pod longhorn-test -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' | grep -v \"running\|terminated\"`"  ]]; do
-    echo "waiting longhorn test pod to be in running state ... rechecking in 10s"
-    sleep 10s
-    RETRIES=$((RETRIES+1))
-
-    if [[ ${RETRIES} -eq ${RETRY_COUNTS} ]]; then echo "Error: longhorn test pod start timeout"; exit 1 ; fi
-  done
-
-  # wait longhorn tests to complete
-  while [[ "`kubectl get pod longhorn-test -o=jsonpath='{.status.containerStatuses[?(@.name=="longhorn-test")].state}' 2>&1 | grep -v \"terminated\"`"  ]]; do
-    kubectl logs ${LONGHORN_TEST_POD_NAME} -c longhorn-test -f --since=10s
-  done
-
-  kubectl cp ${LONGHORN_TEST_POD_NAME}:${LONGHORN_JUNIT_REPORT_PATH} "${TF_VAR_tf_workspace}/longhorn-test-junit-report.xml" -c longhorn-test-report
-}
-
-
 main(){
   set_kubeconfig_envvar
   print_out_cluster_info
@@ -297,11 +63,20 @@ main(){
   if [[ ${PYTEST_CUSTOM_OPTIONS} != *"--include-cluster-autoscaler-test"* ]]; then
     install_backupstores
   fi
-  install_csi_snapshotter_crds
+  install_csi_snapshotter
+
+  # set debugging mode off to avoid leaking docker secrets to the logs.
+  # DON'T REMOVE!
+  set +x
+  create_registry_secret
+  set -x
 
   if [[ "${LONGHORN_UPGRADE_TEST}" == true ]]; then
-    generate_longhorn_yaml_manifest "${TF_VAR_tf_workspace}"
+    generate_longhorn_yaml_manifest
+    customize_longhorn_chart_registry
     install_longhorn_stable
+    setup_longhorn_ui_nodeport
+    export_longhorn_ui_url
     LONGHORN_UPGRADE_TEST_POD_NAME="longhorn-test-upgrade"
     UPGRADE_LH_TRANSIENT_VERSION="${LONGHORN_TRANSIENT_VERSION}"
     UPGRADE_LH_REPO_URL="${LONGHORN_REPO_URI}"
@@ -312,11 +87,14 @@ main(){
     UPGRADE_LH_SHARE_MANAGER_IMAGE="${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE}"
     UPGRADE_LH_BACKING_IMAGE_MANAGER_IMAGE="${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE}"
     run_longhorn_upgrade_test
-    run_longhorn_tests
+    run_longhorn_test
   else
-    generate_longhorn_yaml_manifest "${TF_VAR_tf_workspace}"
-    install_longhorn_by_manifest "${TF_VAR_tf_workspace}/longhorn.yaml"
-    run_longhorn_tests
+    generate_longhorn_yaml_manifest
+    customize_longhorn_chart_registry
+    install_longhorn_by_manifest
+    setup_longhorn_ui_nodeport
+    export_longhorn_ui_url
+    run_longhorn_test
   fi
 }
 

--- a/pipelines/gke/scripts/terraform-setup.sh
+++ b/pipelines/gke/scripts/terraform-setup.sh
@@ -5,7 +5,7 @@ set -x
 gcloud auth activate-service-account --project=${TF_VAR_gcp_project} --key-file=${TF_VAR_gcp_auth_file}
 gcloud auth list
 
-terraform -chdir=${TF_VAR_tf_workspace}/terraform init
-terraform -chdir=${TF_VAR_tf_workspace}/terraform apply -auto-approve -no-color
+terraform -chdir=pipelines/gke/terraform init
+terraform -chdir=pipelines/gke/terraform apply -auto-approve -no-color
 
 exit $?

--- a/pipelines/gke/templates/aws_cred_secrets.yml
+++ b/pipelines/gke/templates/aws_cred_secrets.yml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: aws-cred-secret
-type: Opaque
-data:
-  AWS_ACCESS_KEY_ID: "set aws-access-key-id base64 encoded"
-  AWS_SECRET_ACCESS_KEY: "set aws-secret-key base64 encoded"
-  AWS_DEFAULT_REGION: "set aws-default-region base64 encoded "

--- a/pipelines/gke/terraform/main.tf
+++ b/pipelines/gke/terraform/main.tf
@@ -42,7 +42,7 @@ resource "google_container_cluster" "cluster" {
   network            = google_compute_network.vpc_network.id
   subnetwork         = google_compute_subnetwork.subnetwork.id
   location           = data.google_compute_zones.available.names[0]
-  min_master_version = "1.31.4-gke.1183000"
+  min_master_version = "1.32.1-gke.1357001"
   remove_default_node_pool = true
   deletion_protection = false
   initial_node_count       = 1

--- a/pipelines/helm/Jenkinsfile
+++ b/pipelines/helm/Jenkinsfile
@@ -14,9 +14,7 @@ def AIR_GAP_INSTALLATION = params.AIR_GAP_INSTALLATION ? params.AIR_GAP_INSTALLA
 def LONGHORN_INSTALL_VERSION = params.LONGHORN_INSTALL_VERSION ? params.LONGHORN_INSTALL_VERSION : "master"
 def LONGHORN_TRANSIENT_VERSION = params.LONGHORN_TRANSIENT_VERSION ? params.LONGHORN_TRANSIENT_VERSION : ""
 def CIS_HARDENING = params.CIS_HARDENING ? params.CIS_HARDENING : false
-def REGISTRY_URL
-def REGISTRY_USERNAME
-def REGISTRY_PASSWORD
+def REGISTRY_URL = ""
 
 // parameter for hdd test
 def USE_HDD = params.USE_HDD ? params.USE_HDD : false
@@ -25,7 +23,7 @@ node {
 
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
-        string(credentialsId: 'DO_CREDS', variable: 'DO_TOKEN'),
+        usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
     ]) {
 
@@ -43,7 +41,8 @@ node {
                     sh "airgap/scripts/build.sh"
                     sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
                                            --env TF_VAR_longhorn_version=${LONGHORN_INSTALL_VERSION} \
-                                           --env TF_VAR_do_token=${DO_TOKEN} \
+                                           --env TF_VAR_docker_hub_username=${REGISTRY_USERNAME} \
+                                           --env TF_VAR_docker_hub_password=${REGISTRY_PASSWORD} \
                                            --env TF_VAR_aws_access_key=${AWS_ACCESS_KEY} \
                                            --env TF_VAR_aws_secret_key=${AWS_SECRET_KEY} \
                                            airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}

--- a/pipelines/rancher/Jenkinsfile
+++ b/pipelines/rancher/Jenkinsfile
@@ -9,12 +9,8 @@ def SELINUX_MODE = params.SELINUX_MODE ? params.SELINUX_MODE : ""
 def CREDS_ID = JOB_BASE_NAME == "longhorn-tests-regression" ? "AWS_CREDS_RANCHER_QA" : "AWS_CREDS"
 def REGISTRATION_CODE_ID = params.ARCH == "amd64" ? "REGISTRATION_CODE" : "REGISTRATION_CODE_ARM64"
 
-// parameters for air gap installation
-def AIR_GAP_INSTALLATION = params.AIR_GAP_INSTALLATION ? params.AIR_GAP_INSTALLATION : false
 def CIS_HARDENING = params.CIS_HARDENING ? params.CIS_HARDENING : false
-def REGISTRY_URL
-def REGISTRY_USERNAME
-def REGISTRY_PASSWORD
+def REGISTRY_URL = ""
 
 // parameter for hdd test
 def USE_HDD = params.USE_HDD ? params.USE_HDD : false
@@ -25,7 +21,7 @@ node {
 
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
-        string(credentialsId: 'DO_CREDS', variable: 'DO_TOKEN'),
+        usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
         string(credentialsId: 'RANCHER_PRIME_CHART_URL', variable: 'RANCHER_PRIME_CHART_URL'),
     ]) {
@@ -38,46 +34,13 @@ node {
 
         try {
 
-            if (params.AIR_GAP_INSTALLATION) {
-
-                stage('airgap build') {
-                    sh "airgap/scripts/build.sh"
-                    sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
-                                           --env TF_VAR_longhorn_version=${LONGHORN_INSTALL_VERSION} \
-                                           --env TF_VAR_do_token=${DO_TOKEN} \
-                                           --env TF_VAR_aws_access_key=${AWS_ACCESS_KEY} \
-                                           --env TF_VAR_aws_secret_key=${AWS_SECRET_KEY} \
-                                           airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}
-                    """
-                }
-
-                stage ('airgap setup') {
-                    sh "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} ./airgap/scripts/terraform-setup.sh"
-                    REGISTRY_URL = sh (
-                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_url",
-                        returnStdout: true
-                    )
-                    println REGISTRY_URL
-                    REGISTRY_USERNAME = sh (
-                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_username",
-                        returnStdout: true
-                    )
-                    REGISTRY_PASSWORD = sh (
-                        script: "docker exec airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} terraform -chdir=./airgap/terraform output -raw registry_password",
-                        returnStdout: true
-                    )
-                }
-
-            }
-
             stage('build') {
 
                 echo "Using credentials: $CREDS_ID"
-                echo "Using registration coce: $REGISTRATION_CODE_ID"
+                echo "Using registration code: $REGISTRATION_CODE_ID"
 
                 sh "pipelines/rancher/scripts/build.sh"
                 sh """ docker run -itd --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
-                                       --env AIR_GAP_INSTALLATION=${AIR_GAP_INSTALLATION} \
                                        --env REGISTRY_URL=${REGISTRY_URL} \
                                        --env REGISTRY_USERNAME=${REGISTRY_USERNAME} \
                                        --env REGISTRY_PASSWORD=${REGISTRY_PASSWORD} \

--- a/pipelines/rancher/scripts/longhorn-setup.sh
+++ b/pipelines/rancher/scripts/longhorn-setup.sh
@@ -6,6 +6,7 @@ source pipelines/utilities/kubeconfig.sh
 source pipelines/utilities/selinux_workaround.sh
 source pipelines/utilities/install_csi_snapshotter.sh
 source pipelines/utilities/create_aws_secret.sh
+source pipelines/utilities/create_registry_secret.sh
 source pipelines/utilities/install_backupstores.sh
 source pipelines/utilities/create_longhorn_namespace.sh
 source pipelines/utilities/longhorn_rancher_chart.sh
@@ -36,6 +37,12 @@ main(){
   create_longhorn_namespace
   install_backupstores
   install_csi_snapshotter
+
+  # set debugging mode off to avoid leaking docker secrets to the logs.
+  # DON'T REMOVE!
+  set +x
+  create_registry_secret
+  set -x
 
   install_rancher
   get_rancher_api_key

--- a/pipelines/storage_network/Jenkinsfile
+++ b/pipelines/storage_network/Jenkinsfile
@@ -12,6 +12,7 @@ def REGISTRATION_CODE_ID = params.ARCH == "amd64" ? "REGISTRATION_CODE" : "REGIS
 def LONGHORN_INSTALL_VERSION = params.LONGHORN_INSTALL_VERSION ? params.LONGHORN_INSTALL_VERSION : "master"
 def LONGHORN_TRANSIENT_VERSION = params.LONGHORN_TRANSIENT_VERSION ? params.LONGHORN_TRANSIENT_VERSION : ""
 def CIS_HARDENING = params.CIS_HARDENING ? params.CIS_HARDENING : false
+def REGISTRY_URL = ""
 
 // parameter for hdd test
 def USE_HDD = params.USE_HDD ? params.USE_HDD : false
@@ -20,6 +21,7 @@ node {
 
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
+        usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
     ]) {
 
@@ -38,6 +40,9 @@ node {
 
                 sh "pipelines/storage_network/scripts/build.sh"
                 sh """ docker run -itd --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
+                                       --env REGISTRY_URL=${REGISTRY_URL} \
+                                       --env REGISTRY_USERNAME=${REGISTRY_USERNAME} \
+                                       --env REGISTRY_PASSWORD=${REGISTRY_PASSWORD} \
                                        --env LONGHORN_INSTALL_VERSION=${LONGHORN_INSTALL_VERSION} \
                                        --env CUSTOM_LONGHORN_ENGINE_IMAGE=${CUSTOM_LONGHORN_ENGINE_IMAGE} \
                                        --env CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE=${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE} \

--- a/pipelines/storage_network/scripts/longhorn-setup.sh
+++ b/pipelines/storage_network/scripts/longhorn-setup.sh
@@ -5,6 +5,7 @@ set -x
 source pipelines/utilities/selinux_workaround.sh
 source pipelines/utilities/install_csi_snapshotter.sh
 source pipelines/utilities/create_aws_secret.sh
+source pipelines/utilities/create_registry_secret.sh
 source pipelines/utilities/install_backupstores.sh
 source pipelines/utilities/storage_network.sh
 source pipelines/utilities/create_longhorn_namespace.sh
@@ -47,7 +48,14 @@ main(){
   install_backupstores
   install_csi_snapshotter
 
+  # set debugging mode off to avoid leaking docker secrets to the logs.
+  # DON'T REMOVE!
+  set +x
+  create_registry_secret
+  set -x
+
   generate_longhorn_yaml_manifest
+  customize_longhorn_manifest_registry
   install_longhorn_by_manifest
 
   update_storage_network_setting

--- a/pipelines/utilities/argocd.sh
+++ b/pipelines/utilities/argocd.sh
@@ -50,6 +50,10 @@ spec:
         values: |
           preUpgradeChecker:
             jobEnabled: false
+          privateRegistry:
+            createSecret: false
+            registryUrl: ${REGISTRY_URL}
+            registrySecret: docker-registry-secret
   destination:
     server: https://kubernetes.default.svc
     namespace: ${LONGHORN_NAMESPACE}

--- a/pipelines/utilities/create_registry_secret.sh
+++ b/pipelines/utilities/create_registry_secret.sh
@@ -1,3 +1,11 @@
 create_registry_secret(){
-  kubectl -n ${LONGHORN_NAMESPACE} create secret docker-registry docker-registry-secret --docker-server=${REGISTRY_URL} --docker-username=${REGISTRY_USERNAME} --docker-password=${REGISTRY_PASSWORD}
+  if [[ -z "${REGISTRY_URL}" ]]; then
+    kubectl -n default create secret docker-registry docker-registry-secret --docker-username=${REGISTRY_USERNAME} --docker-password=${REGISTRY_PASSWORD}
+    kubectl -n ${LONGHORN_NAMESPACE} create secret docker-registry docker-registry-secret --docker-username=${REGISTRY_USERNAME} --docker-password=${REGISTRY_PASSWORD}
+  else
+    kubectl -n default create secret docker-registry docker-registry-secret --docker-server=${REGISTRY_URL} --docker-username=${REGISTRY_USERNAME} --docker-password=${REGISTRY_PASSWORD}
+    kubectl -n ${LONGHORN_NAMESPACE} create secret docker-registry docker-registry-secret --docker-server=${REGISTRY_URL} --docker-username=${REGISTRY_USERNAME} --docker-password=${REGISTRY_PASSWORD}
+  fi
+  kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"docker-registry-secret"}]}' -n default
+  kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"docker-registry-secret"}]}' -n longhorn-system
 }

--- a/pipelines/utilities/flux.sh
+++ b/pipelines/utilities/flux.sh
@@ -14,6 +14,11 @@ create_flux_helm_repo(){
 
 create_flux_helm_release(){
   CHART_VERSION="${1:-${HELM_CHART_VERSION}}"
-  flux create helmrelease longhorn --chart longhorn --source HelmRepository/longhorn --chart-version "${CHART_VERSION}" --namespace "${LONGHORN_NAMESPACE}"
+  cat << EOF > /tmp/values.yaml
+privateRegistry:
+  createSecret: false
+  registrySecret: docker-registry-secret
+EOF
+  flux create helmrelease longhorn --chart longhorn --source HelmRepository/longhorn --chart-version "${CHART_VERSION}" --namespace "${LONGHORN_NAMESPACE}" --values "/tmp/values.yaml"
   wait_longhorn_status_running
 }

--- a/pipelines/utilities/longhorn_helm_chart.sh
+++ b/pipelines/utilities/longhorn_helm_chart.sh
@@ -11,12 +11,12 @@ get_longhorn_chart(){
 
 
 customize_longhorn_chart_registry(){
-  # specify private registry secret in chart/values.yaml
-  yq -i '.privateRegistry.createSecret=true' "${LONGHORN_REPO_DIR}/chart/values.yaml"
-  yq -i ".privateRegistry.registryUrl=\"${REGISTRY_URL}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
-  yq -i ".privateRegistry.registryUser=\"${REGISTRY_USERNAME}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
-  yq -i ".privateRegistry.registryPasswd=\"${REGISTRY_PASSWORD}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  # specify custom registry secret in chart/values.yaml
+  yq -i '.privateRegistry.createSecret=false' "${LONGHORN_REPO_DIR}/chart/values.yaml"
   yq -i '.privateRegistry.registrySecret="docker-registry-secret"' "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  if [[ ! -z "${REGISTRY_URL}" ]]; then
+    yq -i ".privateRegistry.registryUrl=\"${REGISTRY_URL}\"" "${LONGHORN_REPO_DIR}/chart/values.yaml"
+  fi
 }
 
 

--- a/pipelines/utilities/longhorn_rancher_chart.sh
+++ b/pipelines/utilities/longhorn_rancher_chart.sh
@@ -54,8 +54,6 @@ install_longhorn_rancher_chart() {
             -var="rancher_chart_install_version=${CHART_VERSION}" \
             -var="longhorn_repo=${LONGHORN_REPO}" \
             -var="registry_url=${REGISTRY_URL}" \
-            -var="registry_user=${REGISTRY_USERNAME}" \
-            -var="registry_passwd=${REGISTRY_PASSWORD}" \
             -var="registry_secret=docker-registry-secret" \
             -auto-approve -no-color
   wait_longhorn_status_running

--- a/pipelines/utilities/longhorn_status.sh
+++ b/pipelines/utilities/longhorn_status.sh
@@ -1,5 +1,5 @@
 wait_longhorn_status_running(){
-  local RETRY_COUNTS=10 # in minutes
+  local RETRY_COUNTS=60 # in minutes
   local RETRY_INTERVAL="1m"
 
   # csi and engine image components are installed after longhorn components.

--- a/pipelines/utilities/rancher/terraform_install/main.tf
+++ b/pipelines/utilities/rancher/terraform_install/main.tf
@@ -41,6 +41,10 @@ resource "rancher2_app_v2" "longhorn_app" {
   chart_name = "longhorn"
   chart_version = var.rancher_chart_install_version
   values = <<-EOF
+privateRegistry:
+  createSecret: false
+  registryUrl: ${var.registry_url}
+  registrySecret: ${var.registry_secret}
 image:
   csi:
     attacher:

--- a/pipelines/utilities/rancher/terraform_install/variable.tf
+++ b/pipelines/utilities/rancher/terraform_install/variable.tf
@@ -30,14 +30,6 @@ variable "registry_url" {
   type = string
 }
 
-variable "registry_user" {
-  type = string
-}
-
-variable "registry_passwd" {
-  type = string
-}
-
 variable "registry_secret" {
   type = string
 }

--- a/pipelines/utilities/run_longhorn_e2e_test.sh
+++ b/pipelines/utilities/run_longhorn_e2e_test.sh
@@ -34,7 +34,7 @@ run_longhorn_e2e_test(){
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[3].value="hdd"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 
-  if [[ "${TF_VAR_k8s_distro_name}" == "eks" ]] || [[ "${TF_VAR_k8s_distro_name}" == "aks" ]]; then
+  if [[ "${TF_VAR_k8s_distro_name}" == "eks" ]] || [[ "${TF_VAR_k8s_distro_name}" == "aks" ]] || [[ "${TF_VAR_k8s_distro_name}" == "gke" ]]; then
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[5].value="true"' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
   fi
 
@@ -52,6 +52,8 @@ run_longhorn_e2e_test(){
   yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env += {"name": "LONGHORN_STABLE_VERSION", "value": "'${LONGHORN_STABLE_VERSION}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
 
   LONGHORN_TEST_POD_NAME=`yq e 'select(.spec.containers[0] != null).metadata.name' ${LONGHORN_TESTS_MANIFEST_FILE_PATH}`
+
+  yq e -i 'select(.kind == "Pod" and .metadata.name == "longhorn-test").spec.imagePullSecrets[0].name="docker-registry-secret"' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
 
   kubectl apply -f ${LONGHORN_TESTS_MANIFEST_FILE_PATH}
 

--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -19,9 +19,7 @@ def RANCHER_CHART_INSTALL_VERSION = params.RANCHER_CHART_INSTALL_VERSION ? param
 def LONGHORN_TRANSIENT_VERSION = params.LONGHORN_TRANSIENT_VERSION ? params.LONGHORN_TRANSIENT_VERSION : ""
 def CIS_HARDENING = params.CIS_HARDENING ? params.CIS_HARDENING : false
 def CUSTOM_SSH_PUBLIC_KEY = params.CUSTOM_SSH_PUBLIC_KEY ? params.CUSTOM_SSH_PUBLIC_KEY : ""
-def REGISTRY_URL
-def REGISTRY_USERNAME
-def REGISTRY_PASSWORD
+def REGISTRY_URL = ""
 
 // parameter for mTls
 def ENABLE_MTLS = params.ENABLE_MTLS ? params.ENABLE_MTLS : false
@@ -33,6 +31,7 @@ node {
 
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
+        usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
         string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
         file(credentialsId: 'AZURE_CRT_FILE', variable: 'AZURE_CRT_FILE'),
@@ -56,6 +55,8 @@ node {
                     sh "airgap/scripts/build.sh"
                     sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
                                            --env TF_VAR_longhorn_version=${LONGHORN_INSTALL_VERSION} \
+                                           --env TF_VAR_docker_hub_username=${REGISTRY_USERNAME} \
+                                           --env TF_VAR_docker_hub_password=${REGISTRY_PASSWORD} \
                                            --env TF_VAR_aws_access_key=${AWS_ACCESS_KEY} \
                                            --env TF_VAR_aws_secret_key=${AWS_SECRET_KEY} \
                                            airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}
@@ -178,90 +179,8 @@ node {
                     summary = junit 'longhorn-test-junit-report.xml'
                 }
 
-                if(JOB_BASE_NAME != "longhorn-tests-regression") {
+                if(JOB_BASE_NAME == "longhorn-tests-sles-amd64") {
                     sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/junit_to_qase.py ${TF_VAR_tf_workspace}/longhorn-test-junit-report.xml ${BUILD_URL}"
-                }
-
-                if(LONGHORN_INSTALL_METHOD == "custom") {
-                    sh 'docker pull ${CUSTOM_LONGHORN_MANAGER_IMAGE}'
-                    LONGHORN_MANAGER_VERSION = sh (
-                        script: "docker inspect --format '{{ index .Config.Labels \"org.opencontainers.image.revision\" }}' ${CUSTOM_LONGHORN_MANAGER_IMAGE}",
-                        returnStdout: true
-                    )
-                    sh 'docker pull ${CUSTOM_LONGHORN_ENGINE_IMAGE}'
-                    LONGHORN_ENGINE_VERSION = sh (
-                        script: "docker inspect --format '{{ index .Config.Labels \"org.opencontainers.image.revision\" }}' ${CUSTOM_LONGHORN_ENGINE_IMAGE}",
-                        returnStdout: true
-                    )
-                    manager.createSummary("info.gif").appendText("<p>longhorn-manager version: $LONGHORN_MANAGER_VERSION</p><p>longhorn-engine version: $LONGHORN_ENGINE_VERSION</p>", false, false, false, "black")
-                }
-            }
-
-            stage ('longhorn coverage') {
-                if(!params.LONGHORN_UPGRADE_TEST && !params.AIR_GAP_INSTALLATION && JOB_BASE_NAME != "longhorn-tests-regression" && DISTRO == "sles") {
-                    sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} test_framework/scripts/longhorn-coverage.sh"
-
-                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:/src/longhorn-tests/longhorn-manager-profile.html ."
-                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:/src/longhorn-tests/longhorn-engine-profile.html ."
-                    // sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:/src/longhorn-tests/longhorn-spdk-engine-profile.html ."
-                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:/src/longhorn-tests/longhorn-instance-manager-profile.html ."
-                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:/src/longhorn-tests/longhorn-share-manager-profile.html ."
-                    sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:/src/longhorn-tests/backing-image-manager-profile.html ."
-
-                    publishHTML (target: [
-                        allowMissing: true,
-                        alwaysLinkToLastBuild: true,
-                        keepAll: false,
-                        reportDir: '.',
-                        reportFiles: 'longhorn-manager-profile.html',
-                        reportName: "longhorn-manager coverage profile"
-                    ])
-
-                    publishHTML (target: [
-                        allowMissing: true,
-                        alwaysLinkToLastBuild: true,
-                        keepAll: false,
-                        reportDir: '.',
-                        reportFiles: 'longhorn-engine-profile.html',
-                        reportName: "longhorn-engine coverage profile"
-                    ])
-
-                    // publishHTML (target: [
-                    //    allowMissing: true,
-                    //    alwaysLinkToLastBuild: true,
-                    //    keepAll: false,
-                    //     reportDir: '.',
-                    //     reportFiles: 'longhorn-spdk-engine-profile.html',
-                    //     reportName: "longhorn-spdk-engine coverage profile"
-                    // ])
-
-                    publishHTML (target: [
-                        allowMissing: true,
-                        alwaysLinkToLastBuild: true,
-                        keepAll: false,
-                        reportDir: '.',
-                        reportFiles: 'longhorn-instance-manager-profile.html',
-                        reportName: "longhorn-instance-manager coverage profile"
-                    ])
-
-
-                    publishHTML (target: [
-                        allowMissing: true,
-                        alwaysLinkToLastBuild: true,
-                        keepAll: false,
-                        reportDir: '.',
-                        reportFiles: 'longhorn-share-manager-profile.html',
-                        reportName: "longhorn-share-manager coverage profile"
-                    ])
-
-                    publishHTML (target: [
-                        allowMissing: true,
-                        alwaysLinkToLastBuild: true,
-                        keepAll: false,
-                        reportDir: '.',
-                        reportFiles: 'backing-image-manager-profile.html',
-                        reportName: "backing-image-manager coverage profile"
-                    ])
                 }
             }
         } catch (e) {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10542

#### What this PR does / why we need it:

provide docker credentials when pulling Longhorn components images

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced support for private registry configurations across multiple pipelines.
	- Introduced Docker Hub credential handling for improved image retrieval processes.

- **Refactor**
	- Streamlined registry credential management by removing unused variables and updating retrieval methods.
	- Modularized scripts for secret creation to enhance security and maintainability.

- **Chore**
	- Increased retry limits for service health checks to improve stability.
	- Updated Terraform configurations for better compatibility and removed obsolete settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->