### PR TITLE
test(robot): fix power_off_node_name not defined when rebooting nodes on hal

### DIFF
--- a/e2e/libs/host/harvester.py
+++ b/e2e/libs/host/harvester.py
@@ -88,7 +88,7 @@ class Harvester(Base):
             time.sleep(self.retry_interval)
         assert stopped, f"Expected vm {vm_id} to be stopped but it's not"
 
-        self.node.wait_for_node_down(power_off_node_name)
+        self.node.wait_for_node_down(vm_id)
 
     def power_on_node(self, node_name):
         vm_id = self.mapping[node_name]
@@ -118,4 +118,4 @@ class Harvester(Base):
             time.sleep(self.retry_interval)
         assert started, f"Expected vm {vm_id} to be started but it's not"
 
-        self.node.wait_for_node_up(power_on_node_name)
+        self.node.wait_for_node_up(vm_id)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/6742

#### What this PR does / why we need it:

fix power_off_node_name not defined when rebooting nodes on hal

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the consistency of virtual machine power state verification during power on/off operations, ensuring more reliable status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->