### PR TITLE
test(robot): add test case Test Snapshot Purge Rejection While Migration

### DIFF
--- a/e2e/keywords/snapshot.resource
+++ b/e2e/keywords/snapshot.resource
@@ -37,6 +37,10 @@ Purge volume ${volume_id} snapshot
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     purge_snapshot    ${volume_name}
 
+Purge volume ${volume_id} snapshot should fail
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    Run Keyword And Expect Error    *    purge_snapshot    ${volume_name}
+
 Validate snapshot ${parent_id} is parent of snapshot ${child_id} in volume ${volume_id} snapshot list
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     is_parent_of   ${volume_name}    ${parent_id}    ${child_id}

--- a/e2e/tests/regression/test_migration.robot
+++ b/e2e/tests/regression/test_migration.robot
@@ -11,6 +11,7 @@ Resource    ../keywords/recurringjob.resource
 Resource    ../keywords/statefulset.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/migration.resource
+Resource    ../keywords/snapshot.resource
 
 Test Setup    Set test environment
 Test Teardown    Cleanup test resources
@@ -68,3 +69,16 @@ Test Migration Rollback
     And Volume 0 migration should fail or rollback
     And Wait for volume 0 healthy
     And Check volume 0 data is intact
+
+Test Snapshot Purge Rejection While Migration
+    [Tags]    coretest    migration
+    [Documentation]    Test that a snapshot purge request is rejected while migration is in progress.
+
+    Given Create volume 0 with    migratable=True    accessMode=RWX    dataEngine=${DATA_ENGINE}
+    When Attach volume 0 to node 0
+    And Wait for volume 0 healthy
+    And Get volume 0 engine and replica names
+    And Write data to volume 0
+    And Attach volume 0 to node 1
+    And Wait for volume 0 migration to be ready
+    Then Purge volume 0 snapshot should fail

--- a/e2e/tests/regression/test_migration.robot
+++ b/e2e/tests/regression/test_migration.robot
@@ -20,17 +20,7 @@ Test Teardown    Cleanup test resources
 Test Migration Confirm
     [Tags]    coretest    migration
     [Documentation]    Test that a migratable RWX volume can be live migrated from one node to another.
-    ...
-    ...                1. Create a new RWX migratable volume.
-    ...                2. Attach to test node to write some test data on it.
-    ...                3. Detach from test node.
-    ...                4. Get set of nodes excluding the test node
-    ...                5. Attach volume to node 1 (initial node)
-    ...                6. Attach volume to node 2 (migration target)
-    ...                7. Wait for migration ready (engine running on node 2)
-    ...                8. Detach volume from node 1
-    ...                9. Observe volume migrated to node 2 (single active engine)
-    ...                10. Validate initially written test data
+
     Given Create volume 0 with    migratable=True    accessMode=RWX    dataEngine=${DATA_ENGINE}
     When Attach volume 0 to node 0
     And Wait for volume 0 healthy
@@ -46,17 +36,7 @@ Test Migration Confirm
 Test Migration Rollback
     [Tags]    coretest    migration
     [Documentation]    Test that a migratable RWX volume can be rolled back to initial node.
-    ...
-    ...                1. Create a new RWX migratable volume.
-    ...                2. Attach to test node to write some test data on it.
-    ...                3. Detach from test node.
-    ...                4. Get set of nodes excluding the test node
-    ...                5. Attach volume to node 1 (initial node)
-    ...                6. Attach volume to node 2 (migration target)
-    ...                7. Wait for migration ready (engine running on node 2)
-    ...                8. Detach volume from node 2
-    ...                9. Observe volume stayed on node 1 (single active engine)
-    ...                10. Validate initially written test data
+
     Given Create volume 0 with    migratable=True    accessMode=RWX    dataEngine=${DATA_ENGINE}
     When Attach volume 0 to node 0
     And Wait for volume 0 healthy


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue 
Longhorn/longhorn#10495
Longhorn/longhorn#10496

#### What this PR does / why we need it:

Reject snapshot purge when volume is being live migration. If snapshot purge is executed while live migrating a volume, the disk files will be changed. The new engine and replicas are unable to be aware of the change and cannot list the new disk files, resulting in ERR replicas.


#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a negative test to confirm that volume snapshot purge operations fail gracefully when error conditions occur.
  - Introduced a new scenario to verify that purge requests are properly rejected during active migrations, ensuring robust volume management safeguards.
  - Added a new keyword for testing failure cases in snapshot purges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->