### PR TITLE
test(robot): Add case `The node the restore volume attached to is down`

### DIFF
--- a/docs/content/manual/pre-release/node-not-ready/node-down/restore-volume-node-down.md
+++ b/docs/content/manual/pre-release/node-not-ready/node-down/restore-volume-node-down.md
@@ -2,6 +2,9 @@
 title: "[#1355](https://github.com/longhorn/longhorn/issues/1355) The node the restore volume attached to is down"
 ---
 
+## Precondition
+- https://longhorn.io/docs/1.8.1/best-practices/#coredns-setup
+
 ### Case 1:
 1. Create a backup.
 2. Restore the above backup.

--- a/e2e/keywords/host.resource
+++ b/e2e/keywords/host.resource
@@ -25,6 +25,34 @@ Reboot node ${idx}
 Restart all worker nodes
     reboot_all_worker_nodes
 
+Power off volume ${volume_id} volume node
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${node_name} =    get_volume_node    ${volume_name}
+    ${powered_off_node} =    Set Variable    ${node_name}
+    Append to list    ${powered_off_nodes}    ${powered_off_node}
+    power_off_node_by_name    ${node_name}
+
+Power off volume ${volume_id} replica node
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${node_name} =    get_replica_node    ${volume_name}
+    ${powered_off_node} =    Set Variable    ${node_name}
+    Append to list    ${powered_off_nodes}    ${powered_off_node}
+    power_off_node_by_name    ${node_name}
+
+Power off volume ${volume_id} volume node without waiting
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${node_name} =    get_volume_node    ${volume_name}
+    ${powered_off_node} =    Set Variable    ${node_name}
+    Append to list    ${powered_off_nodes}    ${powered_off_node}
+    power_off_node_by_name    ${node_name}    waiting=False
+
+Power off volume ${volume_id} replica node without waiting
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${node_name} =    get_replica_node    ${volume_name}
+    ${powered_off_node} =    Set Variable    ${node_name}
+    Append to list    ${powered_off_nodes}    ${powered_off_node}
+    power_off_node_by_name    ${node_name}    waiting=False
+
 Power off node ${idx} for ${power_off_time_in_min} mins
     reboot_node_by_index    ${idx}    ${power_off_time_in_min}
 

--- a/e2e/keywords/k8s.resource
+++ b/e2e/keywords/k8s.resource
@@ -97,6 +97,23 @@ Check node ${node_id} cordoned
     ${node_name} =    get_node_by_index    ${node_id}
     check_node_cordoned    ${node_name}
 
+Get node ${node_id} status
+    ${node_id}=  Convert To String  ${node_id}
+    ${node_name}=  get_node_by_index  ${node_id}
+    ${is_ready}=  is_node_ready  ${node_name}
+    Log    Node ${node_name} ready status is ${is_ready}
+    ${node_status}=  Create Dictionary    node_id=${node_id}    node_name=${node_name}    node_ready=${is_ready}
+    [Return]  ${node_status}
+
+Get healthy node names
+    @{healthy_node_names}=    Create List
+    FOR    ${i}    IN RANGE    0    3
+        ${node_status}=    Get node ${i} status
+        Run Keyword If    ${node_status["node_ready"]} == True
+        ...    Append To List    ${healthy_node_names}    ${node_status["node_name"]}
+    END
+    [Return]    ${healthy_node_names}
+
 Force drain node ${node_id} and expect failure
     ${drained_node} =    get_node_by_index    ${node_id}
     ${instance_manager_name} =     get_instance_manager_on_node    ${drained_node}

--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -23,6 +23,13 @@ Create DR volume ${volume_id} from backup ${backup_id} of volume ${source_volume
     ${backup_url} =    get_backup_url    ${backup_id}    ${source_volume_name}
     create_volume   ${volume_name}    frontend=    Standby=True    fromBackup=${backup_url}    &{config}
 
+Create volume ${volume_id} from backup ${backup_id} of volume ${source_volume_id}
+    [Arguments]    &{config}
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${source_volume_name} =    generate_name_with_suffix    volume    ${source_volume_id}
+    ${backup_url} =    get_backup_url    ${backup_id}    ${source_volume_name}
+    create_volume   ${volume_name}    numberOfReplicas=3    fromBackup=${backup_url}    &{config}
+
 Create volume ${volume_id} from ${workload_kind} ${workload_id} volume backup ${backup_id}
     ${workload_name}=   generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${workload_volume_name}=    get_workload_volume_name    ${workload_name}
@@ -74,6 +81,17 @@ Attach volume ${volume_id} to ${workload_kind} ${workload_id} node
 Attach volume ${volume_id} in maintenance mode
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     attach_volume_in_maintenance_mode    ${volume_name}
+
+Attach volume ${volume_id} to healthy node
+    ${volume_name}=  generate_name_with_suffix  volume  ${volume_id}
+    ${healthy_node_names}=  Get healthy node names
+
+    Run Keyword If    ${healthy_node_names} == []
+    ...    Fail    No healthy nodes available to attach volume!
+
+    ${healthy_node_name}=  Get From List  ${healthy_node_names}  0
+    Log    Attaching volume ${volume_id} to node ${healthy_node_name}
+    attach_volume  ${volume_name}  ${healthy_node_name}
 
 Detach volume ${volume_id}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}

--- a/e2e/libs/k8s/k8s.py
+++ b/e2e/libs/k8s/k8s.py
@@ -80,6 +80,15 @@ def wait_all_pods_evicted(node_name):
 
     assert evicted, 'failed to evict pods'
 
+def is_node_ready(node_name):
+    api = client.CoreV1Api()
+    node = api.read_node(node_name)
+    conditions = node.status.conditions
+    for condition in conditions:
+        if condition.type == "Ready" and condition.status == "True":
+            return True
+    return False
+
 def check_node_cordoned(node_name):
     api = client.CoreV1Api()
     node = api.read_node(node_name)

--- a/e2e/libs/keywords/host_keywords.py
+++ b/e2e/libs/keywords/host_keywords.py
@@ -54,5 +54,5 @@ class host_keywords:
     def power_on_node_by_name(self, node_name):
         self.host.power_on_node(node_name)
 
-    def power_off_node_by_name(self, node_name):
-        self.host.power_off_node(node_name)
+    def power_off_node_by_name(self, node_name, waiting=True):
+        self.host.power_off_node(node_name, waiting)

--- a/e2e/libs/keywords/k8s_keywords.py
+++ b/e2e/libs/keywords/k8s_keywords.py
@@ -9,6 +9,7 @@ from k8s.k8s import cordon_node, uncordon_node
 from k8s.k8s import wait_all_pods_evicted
 from k8s.k8s import get_all_pods_on_node
 from k8s.k8s import check_node_cordoned
+from k8s.k8s import is_node_ready
 from k8s.k8s import get_instance_manager_on_node
 from k8s.k8s import check_instance_manager_pdb_not_exist
 from k8s.k8s import wait_for_namespace_pods_running
@@ -78,6 +79,9 @@ class k8s_keywords:
 
     def get_all_pods_on_node(self, node_name):
         return get_all_pods_on_node(node_name)
+
+    def is_node_ready(self, node_name):
+        return is_node_ready(node_name)
 
     def check_node_cordoned(self, node_name):
         check_node_cordoned(node_name)

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -31,9 +31,9 @@ class volume_keywords:
         for volume in volumes:
             self.delete_volume(volume['metadata']['name'])
 
-    def create_volume(self, volume_name, size="2Gi", numberOfReplicas=3, frontend="blockdev", migratable=False, dataLocality="disabled", accessMode="RWO", dataEngine="v1", backingImage="", Standby=False, fromBackup=""):
+    def create_volume(self, volume_name, size="2Gi", numberOfReplicas=3, frontend="blockdev", migratable=False, dataLocality="disabled", accessMode="RWO", dataEngine="v1", backingImage="", Standby=False, fromBackup="", encrypted=False):
         logging(f'Creating volume {volume_name}')
-        self.volume.create(volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup)
+        self.volume.create(volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted)
 
     def delete_volume(self, volume_name):
         logging(f'Deleting volume {volume_name}')

--- a/e2e/libs/volume/base.py
+++ b/e2e/libs/volume/base.py
@@ -15,7 +15,7 @@ class Base(ABC):
         return NotImplemented
 
     @abstractmethod
-    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, accessMode, dataEngine, backingImage, Standby, fromBackup):
+    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted):
         return NotImplemented
 
     def set_data_checksum(self, volume_name, data_id, checksum):

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -66,11 +66,12 @@ class CRD(Base):
                 plural="volumes",
                 body=body
             )
-            if not Standby:
-                self.wait_for_volume_state(volume_name, "detached")
-            else:
+            if fromBackup or Standby:
                 self.wait_for_volume_state(volume_name, "attached")
-            self.wait_for_restore_required_status(volume_name, Standby)
+                self.wait_for_restore_required_status(volume_name, True)
+            else:
+                self.wait_for_volume_state(volume_name, "detached")
+                self.wait_for_restore_required_status(volume_name, False)
             volume = self.get(volume_name)
             assert volume['metadata']['name'] == volume_name, f"expect volume name is {volume_name}, but it's {volume['metadata']['name']}"
             assert volume['spec']['size'] == size, f"expect volume size is {size}, but it's {volume['spec']['size']}"

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -26,7 +26,7 @@ class CRD(Base):
         self.retry_count, self.retry_interval = get_retry_count_and_interval()
         self.engine = Engine()
 
-    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup):
+    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted):
         size_suffix = size[-2:]
         size_number = size[:-2]
         size_unit = MEBIBYTE if size_suffix == "Mi" else GIBIBYTE
@@ -42,6 +42,7 @@ class CRD(Base):
                 }
             },
             "spec": {
+                "encrypted": encrypted,
                 "frontend": frontend,
                 "replicaAutoBalance": "ignored",
                 "size": size,
@@ -81,6 +82,7 @@ class CRD(Base):
             assert volume['spec']['backingImage'] == backingImage, f"expect volume backingImage is {backingImage}, but it's {volume['spec']['backingImage']}"
             assert volume['spec']['Standby'] == Standby, f"expect volume Standby is {Standby}, but it's {volume['spec']['Standby']}"
             assert volume['spec']['fromBackup'] == fromBackup, f"expect volume fromBackup is {fromBackup}, but it's {volume['spec']['fromBackup']}"
+            assert volume['spec']['encrypted'] == encrypted, f"expect volume encrypted is {encrypted}, but it's {volume['spec']['encrypted']}"
         except ApiException as e:
             logging(e)
 

--- a/e2e/libs/volume/rest.py
+++ b/e2e/libs/volume/rest.py
@@ -48,7 +48,7 @@ class Rest(Base):
             time.sleep(self.retry_interval)
         return vol_list
 
-    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup):
+    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted):
         return NotImplemented
 
     def attach(self, volume_name, node_name, disable_frontend):

--- a/e2e/libs/volume/volume.py
+++ b/e2e/libs/volume/volume.py
@@ -15,8 +15,8 @@ class Volume(Base):
         else:
             self.volume = Rest()
 
-    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup):
-        return self.volume.create(volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup)
+    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted):
+        return self.volume.create(volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted)
 
     def delete(self, volume_name):
         return self.volume.delete(volume_name)

--- a/e2e/tests/negative/test_restore_volume_node_reboot.robot
+++ b/e2e/tests/negative/test_restore_volume_node_reboot.robot
@@ -1,0 +1,68 @@
+*** Settings ***
+Documentation    The node the restore volume attached to is down
+...              - Issue: https://github.com/longhorn/longhorn/issues/1355
+...              - Issue: https://github.com/longhorn/longhorn/issues/9865
+...              - Test the restoration process of a Longhorn volume when the attached node goes down.
+...              - Includes verification for both encrypted and non-encrypted volumes.
+
+Test Tags    manual    negative    longhorn-9865
+
+Resource    ../keywords/variables.resource
+Resource    ../keywords/common.resource
+Resource    ../keywords/longhorn.resource
+Resource    ../keywords/host.resource
+Resource    ../keywords/volume.resource
+Resource    ../keywords/snapshot.resource
+Resource    ../keywords/backup.resource
+Resource    ../keywords/k8s.resource
+
+
+Test Setup    Set test environment
+Test Teardown    Cleanup test resources
+Test Template    Restore volume attached node is down
+
+*** Keywords ***
+Restore volume attached node is down
+    [Arguments]    ${description}    ${encrypted}
+    [Documentation]    Test the behavior of restoring a Longhorn volume when the attached node goes down.
+    ...                Arguments:
+    ...                - ${description}: Description of the test case.
+    ...                - ${encrypted}: Boolean to specify if the volume is encrypted (true/false).  
+    Given Create volume 0 with    dataEngine=${DATA_ENGINE}    encrypted=${encrypted}
+    And Attach volume 0
+    And Wait for volume 0 healthy
+    And Write data 0 to volume 0
+    And Create backup 0 for volume 0
+    And Verify backup list contains backup 0 of volume 0
+
+    FOR    ${i}    IN RANGE    ${LOOP_COUNT}
+        When Create volume 1 from backup 0 of volume 0  dataEngine=${DATA_ENGINE}  encrypted=${encrypted}
+        And Wait for volume 1 restoration from backup 0 of volume 0 start
+        And Power off volume 1 volume node without waiting
+        Then Wait for volume 1 restoration to complete
+
+        When Attach volume 1 to healthy node
+        Then Wait for volume 1 degraded
+        And Check volume 1 data is backup 0 of volume 0
+        And Detach volume 1 from attached node
+        And Delete volume 1
+        And Power on off nodes
+    END
+
+    And Detach volume 0 from attached node
+    And Delete volume 0
+
+*** Test Cases ***    DESCRIPTION    ENCRYPTED
+The Restore Volume Attached Node is Down
+    [Documentation]    - Manual Test Plan
+    ...                - Given Create a volume 0 with 3 replicas.
+    ...                - And Attach the volume 0 to a node.
+    ...                - And Write data 0 to the volume 0.
+    ...                - Then Create a backup of the volume 0.
+    ...                - When Restore the backup to volume 1.
+    ...                - And During the restoration, power off the node where the volume 1 is attached.
+    ...                - And Wait for the restoration to complete.
+    ...                - Then Attach the restored volume 1 to a healthy node.
+    ...                - Then Verify the restored data matches the backup.
+    Test Restore Non-encrypted Volume Node Down    false
+    Test Restore Encrypted Volume Node Down    true


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#9865
Implement manual test case [The node the restore volume attached to is down](https://longhorn.github.io/longhorn-tests/manual/pre-release/node-not-ready/node-down/restore-volume-node-down/) in robot

#### What this PR does / why we need it:
Implement manual test case `The node the restore volume attached to is down` in robot

#### Special notes for your reviewer:

#### Additional documentation or context
https://github.com/longhorn/longhorn/issues/7211
- PR test log : 
  - 
[9865-log.tar.gz](https://github.com/user-attachments/files/19261850/9865-log.tar.gz)

- Here's how to execute test case: ` ./run.sh -i 'longhorn-9865'`

![Screenshot_20250315_204951](https://github.com/user-attachments/assets/b003afd1-daa4-4d86-ac08-a2309ed550b5)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the user manual with a new precondition section linking to CoreDNS best practices.

- **New Features**
  - Introduced enhanced node and volume management capabilities, including improved controls for powering off nodes, checking their health, creating volumes from backups, and attaching volumes with optional encryption and attachment waiting parameters.

- **Tests**
  - Added a restoration test scenario to validate volume recovery when a node is down for both encrypted and non-encrypted volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->