### PR TITLE
ci: add option to tag resource owner for e2e test jobs

### DIFF
--- a/pipelines/e2e/Jenkinsfile
+++ b/pipelines/e2e/Jenkinsfile
@@ -33,6 +33,9 @@ def RUN_V2_TEST = params.RUN_V2_TEST ? params.RUN_V2_TEST : true
 // parameter for running test as a pod or a container
 def OUT_OF_CLUSTER = params.OUT_OF_CLUSTER ? params.OUT_OF_CLUSTER : false
 
+def TAG_RESOURCE_OWNER = params.TAG_RESOURCE_OWNER ? params.TAG_RESOURCE_OWNER : false
+def RESOURCE_OWNER = "longhorn-infra"
+
 node {
 
     withCredentials([
@@ -56,6 +59,10 @@ node {
 
                 echo "Using credentials: $CREDS_ID"
                 echo "Using registration code: $REGISTRATION_CODE_ID"
+
+                if (TAG_RESOURCE_OWNER) {
+                    RESOURCE_OWNER = BUILD_TRIGGER_BY.replace("\nStarted by user ", "")
+                }
 
                 sh "pipelines/e2e/scripts/build.sh"
                 sh """ docker run -itd --cap-add=NET_ADMIN \
@@ -98,6 +105,7 @@ node {
                                        --env TF_VAR_registration_code=${REGISTRATION_CODE} \
                                        --env TF_VAR_cis_hardening=${CIS_HARDENING} \
                                        --env TF_VAR_custom_ssh_public_key="${CUSTOM_SSH_PUBLIC_KEY}" \
+                                       --env TF_VAR_resources_owner="${RESOURCE_OWNER}" \
                                        --env TF_VAR_extra_block_device=${RUN_V2_TEST} \
                                        --env TF_VAR_lab_url=${LAB_URL} \
                                        --env TF_VAR_lab_access_key=${LAB_ACCESS_KEY} \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10623

#### What this PR does / why we need it:

add option to tag resource owner for e2e test jobs

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Pipeline enhancements now dynamically assign build ownership based on the triggering user.
	- Ownership context is automatically passed to container processes during execution, ensuring improved tracking and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->