### PR TITLE
test(robot): add test case for deleting snapshot after backup completed

### DIFF
--- a/e2e/keywords/backup.resource
+++ b/e2e/keywords/backup.resource
@@ -58,3 +58,7 @@ Volume ${volume_id} backup ${backup_id} should be able to create
     Create backup ${backup_id} for volume ${volume_id}
     Verify backup list contains no error for volume ${volume_id}
     Verify backup list contains backup ${backup_id} of volume ${volume_id}
+
+Check snapshot for backup ${backup_id} of volume ${volume_id} exists ${exists}
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    check_snapshot_exists_for_backup    ${volume_name}    ${backup_id}    ${exists}

--- a/e2e/libs/backup/backup.py
+++ b/e2e/libs/backup/backup.py
@@ -83,3 +83,14 @@ class Backup(Base):
 
     def cleanup_backups(self):
         return self.backup.cleanup_backups()
+
+    def check_snapshot_exists_for_backup(self, volume_name, backup_id, exists=True):
+        backup = self.backup.get(backup_id, volume_name)
+        if not backup or not backup.snapshotName:
+            raise ValueError(f"Backup {backup_id} not found or missing snapshot name")
+
+        snap_name = backup.snapshotName
+        snapshot_id = self.backup.snapshot.get_snapshot_id(snap_name)
+        snap = self.backup.snapshot.get(volume_name, snapshot_id)
+        snap_exists = not snap.removed
+        assert snap_exists == exists, f"Snapshot {snap_name} exists: {snap_exists}, expected: {exists}"

--- a/e2e/libs/keywords/backup_keywords.py
+++ b/e2e/libs/keywords/backup_keywords.py
@@ -61,3 +61,6 @@ class backup_keywords:
 
     def assert_all_backups_before_uninstall_exist(self, backups_before_uninstall):
         self.backup.assert_all_backups_before_uninstall_exist(backups_before_uninstall)
+
+    def check_snapshot_exists_for_backup(self, volume_name, backup_id, exists=True):
+        self.backup.check_snapshot_exists_for_backup(volume_name, backup_id, exists)

--- a/e2e/tests/regression/test_backup.robot
+++ b/e2e/tests/regression/test_backup.robot
@@ -135,3 +135,19 @@ Test Uninstallation With Backups
     And Check Longhorn CRD removed
 
     Then Install Longhorn
+
+Test Cleanup Snapshot With The Global Setting After Backup Completed
+    [Documentation]    Test cleanup snapshot with the global setting after backup completed
+    Given Create volume 0 with    dataEngine=${DATA_ENGINE}
+    And Attach volume 0
+    And Wait for volume 0 healthy
+
+    When Write data 0 to volume 0
+    And Create backup 0 for volume 0
+    And Check snapshot for backup 0 of volume 0 exists True
+
+    When Set setting auto-cleanup-snapshot-after-on-demand-backup-completed to true
+    And Write data 1 to volume 0
+    And Create backup 1 for volume 0
+    And Check snapshot for backup 1 of volume 0 exists False
+    And Set setting auto-cleanup-snapshot-after-on-demand-backup-completed to false


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn 9213

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new keyword to verify backup snapshot existence based on specific backup and volume parameters.

- **Tests**
	- Added an end-to-end regression test that validates the snapshot cleanup behavior when a global auto-cleanup setting is toggled after backup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->