### PR TITLE
ci: add dev-longhorn qa-longhorn as hal cluster owner

### DIFF
--- a/test_framework/terraform/harvester/sles/main.tf
+++ b/test_framework/terraform/harvester/sles/main.tf
@@ -198,6 +198,20 @@ EOF
   }
 }
 
+resource "rancher2_cluster_role_template_binding" "dev-longhorn" {
+  name = "dev-longhorn-binding"
+  cluster_id = rancher2_cluster_v2.e2e-cluster.cluster_v1_id
+  role_template_id = "cluster-owner"
+  group_principal_id = "github_team://3300040"  
+}
+
+resource "rancher2_cluster_role_template_binding" "qa-longhorn" {
+  name = "qa-longhorn-binding"
+  cluster_id = rancher2_cluster_v2.e2e-cluster.cluster_v1_id
+  role_template_id = "cluster-owner"
+  group_principal_id = "github_team://10714512"  
+}
+
 output "kube_config" {
   value = rancher2_cluster_v2.e2e-cluster.kube_config
   sensitive = true


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Grant dev-longhorn and qa-longhorn teams cluster-owner access to HAL clusters created by pipeline. for easily access clusters for debugging if necessary.

#### What this PR does / why we need it:

As above

#### Special notes for your reviewer:

Tested and it is working.

#### Additional documentation or context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new cluster access control configurations for enhanced security and streamlined team permissions.
  - These improvements enable dedicated settings for both development and quality assurance groups, ensuring that appropriate access levels are maintained for secure operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->