### PR TITLE
ci: add environment variable RUN_V2_TEST back into longhorn-test pod

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -87,7 +87,7 @@ ISCSI_DEV_PATH = "/dev/disk/by-path"
 ISCSI_PROCESS = "iscsid"
 
 if os.uname().machine == "x86_64":
-    if os.environ.get("LONGHORN_TEST_CLOUDPROVIDER") == "harvester":
+    if os.environ.get("CLOUDPROVIDER") == "harvester":
         BLOCK_DEV_PATH = "/dev/vdc"
     else:
         BLOCK_DEV_PATH = "/dev/xvdh"

--- a/pipelines/utilities/run_longhorn_test.sh
+++ b/pipelines/utilities/run_longhorn_test.sh
@@ -43,6 +43,9 @@ run_longhorn_test(){
   ## inject cloudprovider
   yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "CLOUDPROVIDER", "value": "'${LONGHORN_TEST_CLOUDPROVIDER}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
 
+  ## for v2 volume test
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "RUN_V2_TEST", "value": "'${RUN_V2_TEST}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
+
   set +x
   if [[ "${TF_VAR_k8s_distro_name}" != "gke" ]] && [[ "${TF_VAR_k8s_distro_name}" != "aks" ]]; then
     ## inject aws credentials env variables from created secret
@@ -116,6 +119,9 @@ run_longhorn_upgrade_test(){
   if [[ "${TF_VAR_k8s_distro_name}" == "eks" ]] || [[ "${TF_VAR_k8s_distro_name}" == "aks" ]] || [[ "${TF_VAR_k8s_distro_name}" == "gke" ]]; then
     yq e -i 'select(.spec.containers[0] != null).spec.containers[0].env[6].value="true"' ${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}
   fi
+
+  ## for v2 volume test
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "RUN_V2_TEST", "value": "'${RUN_V2_TEST}'"}' "${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}"
 
   # environment variables for upgrade test
   # install method can be manifest, helm, rancher, flux, fleet and argocd


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Add the environment variable `RUN_V2_TEST` back into the `longhorn-test` pod after recent test code refinements.

#### What this PR does / why we need it:

N/A

#### Special notes for your reviewer:

N/A

#### Additional documentation or context

N/A