### PR TITLE
ci: refine HAL pipeline flow

### DIFF
--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -62,6 +62,10 @@ install_backupstores_from_lh_repo(){
 
 
 main(){
+  if [[ ${LONGHORN_TEST_CLOUDPROVIDER} == "harvester" ]]; then
+    sleep 300s
+  fi
+
   set_kubeconfig
 
   create_longhorn_namespace

--- a/test_framework/terraform/harvester/sles/main.tf
+++ b/test_framework/terraform/harvester/sles/main.tf
@@ -123,9 +123,12 @@ ssh_authorized_keys:
   - >-
     ${file(var.ssh_public_key_file_path)}
 write_files:
-  - path: /tmp/SUSE_Trust_Root_encoded.crt
-    content: |
-      ${filebase64("/usr/local/share/ca-certificates/suse/SUSE_Trust_Root.crt")}
+  - path: "/tmp/SUSE_Trust_Root_encoded.crt"
+    encoding: "b64"
+    content: >-
+      ${fileexists("/usr/local/share/ca-certificates/suse/SUSE_Trust_Root.crt")
+      ? filebase64("/usr/local/share/ca-certificates/suse/SUSE_Trust_Root.crt")
+      : ""}
 runcmd:
   - SUSEConnect -r ${var.registration_code}
   - zypper install -y qemu-guest-agent iptables open-iscsi nfs-client cryptsetup device-mapper


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #10597

#### What this PR does / why we need it:

`test_framework/scripts/longhorn-setup.sh`
- We have a `shutdown -r +5`([ref](https://github.com/longhorn/longhorn-tests/blob/master/test_framework/terraform/harvester/sles/main.tf#L150-L152)) in the harvester worker node provisioning process. IIRC, this command schedules a system reboot after 5 minutes, which allows time for all running packages to complete their tasks before the node restarts. To avoid the risk of a node reboot occurring while Longhorn is still installing, I added a sleep 300s delay to ensure the shutdown happens after Longhorn's installation is complete.


`test_framework/terraform/harvester/sles/main.tf`
- When building the `longhorn-test-regression` job container (which uses the same harvester terraform script as the alternative AppCo [container](https://github.com/longhorn/longhorn-tests/blob/cc7876d5556b85b66f1f2e27c818f641f6952ee2/pipelines/appco/Dockerfile.setup#L17)), `SUSE_Trust_Root_encoded.crt` file is not exist. To prevent errors during Terraform provisioning on HAL, add code  handles the file absence.

#### Special notes for your reviewer:

N/A

#### Additional documentation or context

N/A