### PR TITLE
test(pytest): refine test_settings.py by count instance manager based on data engine

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3781,7 +3781,6 @@ def reset_settings(client):
         if setting_name == "registry-secret":
             continue
 
-        # enable_v2 = os.environ.get('RUN_V2_TEST') == "true"
         if setting_name == "v2-data-engine":
             if v2_data_engine_cr_supported(client):
                 setting = client.by_id_setting(SETTING_V2_DATA_ENGINE)
@@ -6499,12 +6498,16 @@ def get_instance_manager_names(client, data_engine=DATA_ENGINE):
 
 def wait_for_instance_manager_count(client, number, retry_counts=120):
     for _ in range(retry_counts):
+        im_counts = 0
         ims = client.list_instance_manager()
-        if len(ims) == number:
+        for im in ims:
+            if im.dataEngine == DATA_ENGINE:
+                im_counts = im_counts + 1
+
+        if im_counts == number:
             break
         time.sleep(RETRY_INTERVAL_LONG)
-
-    return len(ims)
+    return im_counts
 
 
 def create_deployment_and_write_data(client, # NOQA

--- a/manager/integration/tests/test_settings.py
+++ b/manager/integration/tests/test_settings.py
@@ -80,7 +80,9 @@ def check_workload_update(core_api, apps_api, count):  # NOQA
 
     im_pod_list = core_api.list_namespaced_pod(
         LONGHORN_NAMESPACE,
-        label_selector="longhorn.io/component=instance-manager").items
+        label_selector="longhorn.io/component=instance-manager, \
+                        longhorn.io/data-engine={}".format(DATA_ENGINE)).items
+
     if len(im_pod_list) != count:
         return False
 
@@ -484,11 +486,12 @@ def guaranteed_instance_manager_cpu_setting_check(  # NOQA
         for im in instance_managers:
             pod = core_api.read_namespaced_pod(name=im.name,
                                                namespace=LONGHORN_NAMESPACE)
-            if cpu_val:
-                assert (pod.spec.containers[0].resources.requests['cpu'] ==
-                        cpu_val)
-            else:
-                assert (not pod.spec.containers[0].resources.requests)
+            if pod.metadata.labels["longhorn.io/data-engine"] == "v1":
+                if cpu_val:
+                    assert (pod.spec.containers[0].resources.requests['cpu'] ==
+                            cpu_val)
+                else:
+                    assert (not pod.spec.containers[0].resources.requests)
 
 
 @pytest.mark.v2_volume_test  # NOQA


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Refine `test_settings.py` by counting instance manager based on the data engine

#### What this PR does / why we need it:

#### Special notes for your reviewer:

Test result:  https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8389/testReport/tests/test_settings/

#### Additional documentation or context
