### PR TITLE
ci: use upstream Talos AMI

### DIFF
--- a/test_framework/Dockerfile.setup
+++ b/test_framework/Dockerfile.setup
@@ -8,6 +8,8 @@ ARG TERRAFORM_VERSION=1.3.5
 
 ARG YQ_VERSION=v4.24.2
 
+ARG TALOS_VERSION=v1.9.5
+
 ENV WORKSPACE /src/longhorn-tests
 
 WORKDIR $WORKSPACE
@@ -27,6 +29,9 @@ RUN wget -q https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_V
     chmod +x /usr/local/bin/yq && \
     apk add openssl openssh-client ca-certificates git rsync bash curl jq python3 py3-pip moreutils && \
     apk add py3-beautifulsoup4 py3-requests py3-lxml && \
+    curl -Lo talosctl https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64 && \
+    mv talosctl /usr/bin/talosctl && \
+    chmod +x /usr/bin/talosctl && \
     ssh-keygen -t rsa -b 4096 -N "" -f ~/.ssh/id_rsa && \
     curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 get_helm.sh && \

--- a/test_framework/terraform/aws/talos/README.md
+++ b/test_framework/terraform/aws/talos/README.md
@@ -1,0 +1,100 @@
+# Talos Kubernetes Cluster Provisioning with Longhorn
+
+This guide provides step-by-step instructions to provision a Kubernetes cluster using Talos and set up Longhorn for distributed storage.
+
+---
+
+## Table of Contents
+
+- [Talos Kubernetes Cluster Provisioning with Longhorn](#talos-kubernetes-cluster-provisioning-with-longhorn)
+  - [Table of Contents](#table-of-contents)
+  - [Prerequisites](#prerequisites)
+  - [How to Change Parameters](#how-to-change-parameters)
+  - [Commands for Provisioning a Cluster](#commands-for-provisioning-a-cluster)
+    - [Option 1: Using Terraform](#option-1-using-terraform)
+    - [Option 2: Using `longhorn-tests` Repository](#option-2-using-longhorn-tests-repository)
+  - [Commands for Destroying a Cluster](#commands-for-destroying-a-cluster)
+  - [How to Bootstrap a Longhorn Cluster](#how-to-bootstrap-a-longhorn-cluster)
+    - [Step 1: Create Namespace and Apply Security Labels](#step-1-create-namespace-and-apply-security-labels)
+    - [Step 2: Deploy Longhorn](#step-2-deploy-longhorn)
+
+---
+
+## Prerequisites
+
+Before proceeding, ensure the following requirements are met:
+
+- **Install `talosctl`**  
+  - Download and install `talosctl` by following the official [installation guide](https://www.talos.dev/v1.9/talos-guides/install/).
+  - Make sure `talosctl` is accessible from your system's PATH.
+
+---
+
+## How to Change Parameters
+
+The cluster parameters can be customized by modifying the `variables.tf` file. Below are the key parameters you can adjust:
+
+- **`aws_region`**: The AWS region where resources will be created.
+- **`lh_aws_instance_count_controlplane`**: Number of control plane instances.
+- **`lh_aws_instance_count_worker`**: Number of worker instances.
+- **`lh_aws_instance_type_controlplane`**: Instance type for control plane nodes.
+- **`lh_aws_instance_type_worker`**: Instance type for worker nodes.
+
+---
+
+## Commands for Provisioning a Cluster
+
+### Option 1: Using Terraform
+
+To provision the cluster using Terraform, run the following commands:
+
+```bash
+terraform init
+terraform apply -auto-approve
+```
+
+### Option 2: Using `longhorn-tests` Repository
+
+Alternatively, you can build the Talos cluster by cloning the `longhorn-tests` repository and running the setup script:
+
+```bash
+git clone https://github.com/longhorn/longhorn-tests
+cd longhorn-tests
+TF_VAR_k8s_distro_name=k3s LONGHORN_TEST_CLOUDPROVIDER=aws DISTRO=talos ./pipelines/utilities/terraform_setup.sh
+```
+
+---
+
+## Commands for Destroying a Cluster
+
+To destroy the cluster and remove all associated resources, execute:
+
+```bash
+terraform destroy -auto-approve
+```
+
+---
+
+## How to Bootstrap a Longhorn Cluster
+
+### Step 1: Create Namespace and Apply Security Labels
+
+Run the following commands to create the `longhorn-system` namespace and apply necessary security labels:
+
+```bash
+kubectl create ns longhorn-system
+kubectl label ns longhorn-system pod-security.kubernetes.io/enforce=privileged
+kubectl label ns longhorn-system pod-security.kubernetes.io/enforce-version=latest
+kubectl label ns longhorn-system pod-security.kubernetes.io/audit=privileged
+kubectl label ns longhorn-system pod-security.kubernetes.io/audit-version=latest
+kubectl label ns longhorn-system pod-security.kubernetes.io/warn=privileged
+kubectl label ns longhorn-system pod-security.kubernetes.io/warn-version=latest
+```
+
+### Step 2: Deploy Longhorn
+
+Deploy Longhorn into the cluster by running the following command:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+```

--- a/test_framework/terraform/aws/talos/data.tf
+++ b/test_framework/terraform/aws/talos/data.tf
@@ -2,7 +2,7 @@ data "aws_ami" "talos" {
   most_recent = true
   filter {
     name   = "name"
-    values = ["talos-v${var.os_distro_version}-${var.arch}"]
+    values = ["talos-v${var.os_distro_version}-${var.aws_region}-${var.arch}"]
   }
   owners = [var.aws_ami_talos_account_number]
 }

--- a/test_framework/terraform/aws/talos/longhorn-talos.yaml
+++ b/test_framework/terraform/aws/talos/longhorn-talos.yaml
@@ -1,0 +1,5 @@
+customization:
+  systemExtensions:
+    officialExtensions:
+      - siderolabs/iscsi-tools
+      - siderolabs/util-linux-tools

--- a/test_framework/terraform/aws/talos/variables.tf
+++ b/test_framework/terraform/aws/talos/variables.tf
@@ -31,12 +31,12 @@ variable "arch" {
 
 variable "os_distro_version" {
   type        = string
-  default     = "1.8.3"
+  default     = "1.9.5"
 }
 
 variable "aws_ami_talos_account_number" {
   type        = string
-  default     = "641769369267"
+  default     = "540036508848"
 }
 
 variable "lh_aws_instance_count_controlplane" {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/9932

#### What this PR does / why we need it:
- ci: use upstream Talos AMI
- Updated `variables.tf` to change the default OS distribution version from 1.8.3 to 1.9.5.
- Added a new resource in `main.tf` to upload the Talos schematic
- Handle upgrades for control and worker nodes.
- Add README.md

#### Special notes for your reviewer:
@yangchiu @chriscchien 

#### Additional documentation or context
