### PR TITLE
ci: fix setuptools lisence issue for pyyaml

### DIFF
--- a/manager/integration/tests/requirements.txt
+++ b/manager/integration/tests/requirements.txt
@@ -9,6 +9,6 @@ pytest-repeat==0.9.1
 pytest-order==1.0.1
 six==1.12.0
 minio==5.0.10
-pyyaml==6.0
+pyyaml==6.0.2
 pandas
 prometheus_client


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #10688

#### What this PR does / why we need it:

Upgrade PyYAML to bypass [setuptools PEP639 check](https://github.com/pypa/setuptools/issues/4938), and fix our CI.

#### Special notes for your reviewer:

#### Additional documentation or context
