### PR TITLE
test(robot): automate manual test case Physical node down

### DIFF
--- a/e2e/keywords/longhorn.resource
+++ b/e2e/keywords/longhorn.resource
@@ -101,3 +101,7 @@ Upgrade Longhorn to transient version
 
 Upgrade Longhorn to custom version
     upgrade_longhorn
+
+Check Longhorn node ${type} state on power off node is ${expect_state}
+    ${status} =    get_longhorn_node_condition_status    ${last_volume_node}    ${type}
+    Should Be Equal    ${status}    ${expect_state}

--- a/e2e/keywords/workload.resource
+++ b/e2e/keywords/workload.resource
@@ -200,7 +200,7 @@ Check ${workload_kind} ${workload_id} pod is ${expect_state} on the original nod
     ${node_name} =    get_pod_node    ${pod}
     Should Be Equal    ${node_name}    ${last_volume_node}
 
-Check ${workload_kind} ${workload_id} pod is ${expect_state} on another node
+Wait for ${workload_kind} ${workload_id} pod is ${expect_state} on another node
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${pod} =     wait_for_pod_kept_in_state    ${workload_name}    ${expect_state}
     ${node_name} =    get_pod_node    ${pod}
@@ -233,6 +233,10 @@ Delete Longhorn ${workload_kind} ${workload_name} pod
     ${pod_name} =    get_workload_pod_name    ${workload_name}    longhorn-system
     Log    ${pod_name}
     delete_pod    ${pod_name}     longhorn-system
+
+Force delete ${workload_kind} ${workload_id} pod on the original node
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    delete_workload_pod_on_node    ${workload_name}    ${last_volume_node}    default
 
 Check volume of ${workload_kind} ${workload_id} replica on node ${node_id} disk ${disk_name}
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}

--- a/e2e/libs/k8s/k8s.py
+++ b/e2e/libs/k8s/k8s.py
@@ -32,6 +32,13 @@ async def restart_kubelet(node_name, downtime_in_sec=10):
 
     delete_pod(pod_name)
 
+def get_longhorn_node_condition_status(node_name, type):
+    jsonpath = f"jsonpath={{.status.conditions[?(@.type=='{type}')].status}}"
+    exec_cmd = [
+        "kubectl", "-n", "longhorn-system", "get",
+        "nodes.longhorn.io", node_name, "-o", jsonpath]
+    return subprocess_exec_cmd(exec_cmd).decode('utf-8')
+
 def delete_node(node_name):
     exec_cmd = ["kubectl", "delete", "node", node_name]
     res = subprocess_exec_cmd(exec_cmd)

--- a/e2e/libs/keywords/k8s_keywords.py
+++ b/e2e/libs/keywords/k8s_keywords.py
@@ -13,6 +13,7 @@ from k8s.k8s import is_node_ready
 from k8s.k8s import get_instance_manager_on_node
 from k8s.k8s import check_instance_manager_pdb_not_exist
 from k8s.k8s import wait_for_namespace_pods_running
+from k8s.k8s import get_longhorn_node_condition_status
 
 from node import Node
 
@@ -94,3 +95,6 @@ class k8s_keywords:
 
     def wait_for_namespace_pods_running(self, namespace):
         return wait_for_namespace_pods_running(namespace)
+
+    def get_longhorn_node_condition_status(self, node_name, type):
+        return get_longhorn_node_condition_status(node_name, type)

--- a/e2e/tests/negative/node_down.robot
+++ b/e2e/tests/negative/node_down.robot
@@ -1,0 +1,127 @@
+*** Settings ***
+Documentation    Negative Test Cases
+
+Test Tags    negative
+
+Resource    ../keywords/variables.resource
+Resource    ../keywords/common.resource
+Resource    ../keywords/deployment.resource
+Resource    ../keywords/longhorn.resource
+Resource    ../keywords/host.resource
+Resource    ../keywords/storageclass.resource
+Resource    ../keywords/persistentvolumeclaim.resource
+Resource    ../keywords/statefulset.resource
+Resource    ../keywords/volume.resource
+Resource    ../keywords/workload.resource
+Resource    ../keywords/setting.resource
+
+Test Setup    Set test environment
+Test Teardown    Cleanup test resources
+
+*** Keywords ***
+Power Off Node And Longhorn Not Force Delete Terminating Statefulset Pod
+    [Arguments]    ${node_down_pod_deletion_policy}
+    Given Set setting default-replica-count to 2
+    And Set setting node-down-pod-deletion-policy to ${node_down_pod_deletion_policy}
+    And Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}
+    And Create statefulset 0 using RWO volume with longhorn-test storageclass
+    And Write 100 MB data to file data in statefulset 0
+    
+    When Power off volume node of statefulset 0
+    And Sleep    300
+    Then Check Longhorn node Ready state on power off node is False
+    And Wait for statefulset 0 pod stuck in Terminating on the original node
+
+    When Power on off nodes
+    Then Wait for longhorn ready
+    And Wait for statefulset 0 pods stable
+    And Check statefulset 0 data in file data is intact
+    And Cleanup test resources
+
+Power Off Node And Longhorn Force Delete Terminating Statefulset Pod
+    [Arguments]    ${node_down_pod_deletion_policy}
+    Given Set setting default-replica-count to 2
+    And Set setting node-down-pod-deletion-policy to ${node_down_pod_deletion_policy}
+    And Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}
+    And Create statefulset 0 using RWO volume with longhorn-test storageclass
+    And Write 100 MB data to file data in statefulset 0
+
+    When Power off volume node of statefulset 0
+    And Sleep    300
+    Then Check Longhorn node Ready state on power off node is False
+    And Wait for statefulset 0 pod is Running on another node
+    And Wait for statefulset 0 pods stable
+    And Check statefulset 0 data in file data is intact
+
+    When Power on off nodes
+    Then Wait for longhorn ready
+    And Cleanup test resources
+
+Power Off Node And Longhorn Not Force Delete Terminating Deployment Pod
+    [Arguments]    ${node_down_pod_deletion_policy}
+    Given Set setting default-replica-count to 2
+    And Set setting node-down-pod-deletion-policy to ${node_down_pod_deletion_policy}
+    And Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}    numberOfReplicas=2
+    And Create persistentvolumeclaim 0 using RWO volume with longhorn-test storageclass
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Write 100 MB data to file data in deployment 0
+    
+    When Power off volume node of deployment 0
+    And Sleep    300
+    Then Check Longhorn node Ready state on power off node is False
+    And Wait for deployment 0 pod stuck in Terminating on the original node
+    And Wait for deployment 0 pod stuck In ContainerCreating on another node
+
+    When Force delete deployment 0 pod on the original node
+    Then Wait for deployment 0 pod is Running on another node
+    And Wait for deployment 0 pods stable
+    And Check deployment 0 data in file data is intact
+
+    When Power on off nodes
+    Then Wait for longhorn ready
+    And Cleanup test resources
+
+Power Off Node And Longhorn Force Delete Terminating Deployment Pod
+    [Arguments]    ${node_down_pod_deletion_policy}
+    Given Set setting default-replica-count to 2
+    And Set setting node-down-pod-deletion-policy to ${node_down_pod_deletion_policy}
+    And Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}    numberOfReplicas=2
+    And Create persistentvolumeclaim 0 using RWO volume with longhorn-test storageclass
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Write 100 MB data to file data in deployment 0
+
+    When Power off volume node of deployment 0
+    And Sleep    300
+    Then Check Longhorn node Ready state on power off node is False
+    And Wait for deployment 0 pod is Running on another node
+    And Wait for deployment 0 pods stable
+    And Check deployment 0 data in file data is intact
+
+    When Power on off nodes
+    Then Wait for longhorn ready
+    And Cleanup test resources
+
+*** Test Cases ***    NODE-DOWN-POD-DELETION-POLICY
+Node Down And Longhorn Not Force Delete Terminating StatefulSet Pod
+    [Tags]    node-down
+    [Template]    Power Off Node And Longhorn Not Force Delete Terminating Statefulset Pod
+        do-nothing
+        delete-deployment-pod
+
+Node Down And Longhorn Force Delete Terminating StatefulSet Pod
+    [Tags]    node-down
+    [Template]    Power Off Node And Longhorn Force Delete Terminating Statefulset Pod
+        delete-statefulset-pod
+        delete-both-statefulset-and-deployment-pod
+
+Node Down And Longhorn Not Force Delete Terminating Deployment Pod
+    [Tags]    node-down
+    [Template]    Power Off Node And Longhorn Not Force Delete Terminating Deployment Pod
+        do-nothing
+        delete-statefulset-pod
+
+Node Down And Longhorn Force Delete Terminating Deployment Pod
+    [Tags]    node-down
+    [Template]    Power Off Node And Longhorn Force Delete Terminating Deployment Pod
+        delete-deployment-pod
+        delete-both-statefulset-and-deployment-pod


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #9759

#### What this PR does / why we need it:

Implement manual test case [Physical node down](https://longhorn.github.io/longhorn-tests/manual/pre-release/node-not-ready/node-down/physical-node-down/)

#### Special notes for your reviewer:


Test result: https://ci.longhorn.io/job/private/job/longhorn-e2e-test/2467/, not include below test cases 
due to https://github.com/longhorn/longhorn/issues/10689 validate first
- `Physical Node Down Deployment Deletion Policy Delete Statefulset Pod`
- `Physical Node Down Deployment Deletion Policy Do Nothing`

#### Additional documentation or context
