### PR TITLE
ci: fix x509 certificate signed by unknown authority error when pulling images from registry.suse.de

### DIFF
--- a/pipelines/appco/scripts/longhorn-setup.sh
+++ b/pipelines/appco/scripts/longhorn-setup.sh
@@ -70,7 +70,7 @@ install_csi_snapshotter_crds(){
 
 
 wait_longhorn_status_running(){
-  local RETRY_COUNTS=10 # in minutes
+  local RETRY_COUNTS=60 # in minutes
   local RETRY_INTERVAL="1m"
 
   # csi and engine image components are installed after longhorn components.

--- a/test_framework/terraform/harvester/sles/main.tf
+++ b/test_framework/terraform/harvester/sles/main.tf
@@ -124,7 +124,6 @@ ssh_authorized_keys:
     ${file(var.ssh_public_key_file_path)}
 write_files:
   - path: "/tmp/SUSE_Trust_Root_encoded.crt"
-    encoding: "b64"
     content: >-
       ${fileexists("/usr/local/share/ca-certificates/suse/SUSE_Trust_Root.crt")
       ? filebase64("/usr/local/share/ca-certificates/suse/SUSE_Trust_Root.crt")


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/rancher/suse-storage/issues/4

#### What this PR does / why we need it:

fix x509 certificate signed by unknown authority error when pulling images from registry.suse.de

#### Special notes for your reviewer:

#### Additional documentation or context
