### PR TITLE
test: fix orphan auto deletion settings

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -203,6 +203,7 @@ SETTING_BACKING_IMAGE_CLEANUP_WAIT_INTERVAL = \
     "backing-image-cleanup-wait-interval"
 SETTING_DISABLE_REVISION_COUNTER = "disable-revision-counter"
 SETTING_ORPHAN_AUTO_DELETION = "orphan-auto-deletion"
+SETTING_ORPHAN_RESOURCE_AUTO_DELETION = "orphan-resource-auto-deletion"
 SETTING_FAILED_BACKUP_TTL = "failed-backup-ttl"
 SETTING_CONCURRENT_AUTO_ENGINE_UPGRADE_NODE_LIMIT = \
     "concurrent-automatic-engine-upgrade-per-node-limit"

--- a/manager/integration/tests/test_orphan.py
+++ b/manager/integration/tests/test_orphan.py
@@ -8,7 +8,7 @@ import shutil
 from common import core_api, client # NOQA
 from common import Gi, SIZE
 from common import volume_name # NOQA
-from common import SETTING_ORPHAN_AUTO_DELETION
+from common import SETTING_ORPHAN_RESOURCE_AUTO_DELETION
 from common import RETRY_COUNTS, RETRY_INTERVAL_LONG
 from common import get_self_host_id
 from common import get_update_disks, wait_for_disk_update, cleanup_node_disks
@@ -728,7 +728,7 @@ def test_orphan_auto_deletion(client, volume_name, request):  # NOQA
     4. Clean up volume
     5. Verify orphan list contains the orphan CRs for replica
        directories
-    6. Enable the orphan-auto-deletion setting
+    6. Enable the replica data cleanup in orphan-resource-auto-deletion setting
     7. Verify orphan list is empty and the orphaned directory is
        deleted in background
     8. Clean up disk
@@ -753,8 +753,8 @@ def test_orphan_auto_deletion(client, volume_name, request):  # NOQA
     assert wait_for_orphan_count(client, 1, 180) == 1
 
     # Step 6: enable orphan auto deletion
-    setting = client.by_id_setting(SETTING_ORPHAN_AUTO_DELETION)
-    client.update(setting, value="true")
+    setting = client.by_id_setting(SETTING_ORPHAN_RESOURCE_AUTO_DELETION)
+    client.update(setting, value="replicaData")
 
     # Step 7
     assert wait_for_orphan_count(client, 0, 180) == 0


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10802

#### What this PR does / why we need it:

The orphan auto deletion settings is moved:

- old `orphan-auto-deletion`: deprecated, read-only
- new `orphan-resource-auto-deletion`: enable replica data cleanup by list `replicaData` in this semi-colon list string

#### Special notes for your reviewer:

#### Additional documentation or context
