### PR TITLE
test: tolerate v2 data engine enable fail for managed k8s cluster

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3785,7 +3785,11 @@ def reset_settings(client):
         if setting_name == "v2-data-engine":
             if v2_data_engine_cr_supported(client):
                 setting = client.by_id_setting(SETTING_V2_DATA_ENGINE)
-                client.update(setting, value="true")
+                try:
+                    client.update(setting, value="true")
+                except Exception as e:
+                    print(f"\nException setting {setting_name} to true")
+                    print(e)
                 continue
 
         s = client.by_id_setting(setting_name)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Tolerate v2 data engine enable fail for managed k8s cluster

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context

