### PR TITLE
test: update GKE pipeline use longhorn repo backupstores

### DIFF
--- a/pipelines/gke/scripts/longhorn-setup.sh
+++ b/pipelines/gke/scripts/longhorn-setup.sh
@@ -50,6 +50,7 @@ EOF
   kubectl delete pod/print-os-release
 }
 
+
 main(){
   set_kubeconfig_envvar
   print_out_cluster_info
@@ -61,7 +62,7 @@ main(){
   fi
 
   if [[ ${CUSTOM_TEST_OPTIONS} != *"--include-cluster-autoscaler-test"* ]]; then
-    install_backupstores
+    install_backupstores_from_lh_repo
     setup_azurite_backup_store
   fi
   install_csi_snapshotter

--- a/pipelines/utilities/install_backupstores.sh
+++ b/pipelines/utilities/install_backupstores.sh
@@ -13,6 +13,17 @@ install_backupstores(){
                  -f ${AZURITE_BACKUPSTORE_URL}
 }
 
+install_backupstores_from_lh_repo(){
+  MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml"
+  NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/nfs-backupstore.yaml"
+  CIFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml"
+  AZURITE_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/azurite-backupstore.yaml"
+  kubectl create -f ${MINIO_BACKUPSTORE_URL} \
+                 -f ${NFS_BACKUPSTORE_URL} \
+                 -f ${CIFS_BACKUPSTORE_URL} \
+                 -f ${AZURITE_BACKUPSTORE_URL}
+}
+
 setup_azurite_backup_store(){
   RETRY=0
   MAX_RETRY=60

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -49,18 +49,6 @@ enable_mtls(){
 }
 
 
-install_backupstores_from_lh_repo(){
-  MINIO_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml"
-  NFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/nfs-backupstore.yaml"
-  CIFS_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml"
-  AZURITE_BACKUPSTORE_URL="https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/azurite-backupstore.yaml"
-  kubectl create -f ${MINIO_BACKUPSTORE_URL} \
-                 -f ${NFS_BACKUPSTORE_URL} \
-                 -f ${CIFS_BACKUPSTORE_URL} \
-                 -f ${AZURITE_BACKUPSTORE_URL}
-}
-
-
 main(){
   if [[ ${LONGHORN_TEST_CLOUDPROVIDER} == "harvester" ]]; then
     sleep 300s


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

#### What this PR does / why we need it:

Use longhorn repo backupstores on GKE pipeline to avoid backupstore pods not scheduled

```
138950374eed:/src/longhorn-tests# k get pods
NAME                                    READY   STATUS    RESTARTS   AGE
longhorn-test                           2/2     Running   0          19m
longhorn-test-azblob-76454445df-qhdbb   1/1     Running   0          3m1s
longhorn-test-cifs-5975587fc8-wpxbp     1/1     Running   0          3m1s
longhorn-test-minio-6cf745556b-q8sdh    0/1     Pending   0          22m
longhorn-test-nfs-8dc6fdf45-vv2vd       0/1     Pending   0          22m
```
Pod events:
```
 Normal   NotTriggerScaleUp  3m4s (x237 over 23m)  cluster-autoscaler                     pod didn't trigger scale-up: 1 node(s) didn't match Pod's node affinity/selector
```

#### Special notes for your reviewer:

N/A

#### Additional documentation or context

N/A