### PR TITLE
ci: disable the `multipathd` on aws ubuntu cluster

### DIFF
--- a/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -3,6 +3,11 @@
 apt-get update
 apt-get install -y nfs-common cryptsetup dmsetup samba linux-modules-extra-`uname -r`
 
+systemctl stop multipathd.socket
+systemctl disable multipathd.socket
+systemctl stop multipathd.service
+systemctl disable multipathd.service
+
 modprobe uio
 modprobe uio_pci_generic
 modprobe vfio_pci

--- a/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_k3s_server.sh.tpl
@@ -5,6 +5,11 @@ set -e
 apt-get update
 apt-get install -y nfs-common jq
 
+systemctl stop multipathd.socket
+systemctl disable multipathd.socket
+systemctl stop multipathd.service
+systemctl disable multipathd.service
+
 until (curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-taint "node-role.kubernetes.io/master=true:NoExecute" --node-taint "node-role.kubernetes.io/master=true:NoSchedule" --tls-san ${k3s_server_public_ip} --write-kubeconfig-mode 644 --token ${k3s_cluster_secret}" INSTALL_K3S_VERSION="${k3s_version}" sh -); do
   echo 'k3s server did not install correctly'
   sleep 2

--- a/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -42,7 +42,10 @@ server: ${rke2_server_url}
 token: ${rke2_cluster_secret}
 
 EOF
-
+systemctl stop multipathd.socket
+systemctl disable multipathd.socket
+systemctl stop multipathd.service
+systemctl disable multipathd.service
 systemctl enable rke2-agent.service
 systemctl start rke2-agent.service
 

--- a/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_rke2_server.sh.tpl
@@ -18,6 +18,10 @@ node-taint:
   - "node-role.kubernetes.io/control-plane=true:NoSchedule"
 EOF
 
+systemctl stop multipathd.socket
+systemctl disable multipathd.socket
+systemctl stop multipathd.service
+systemctl disable multipathd.service
 systemctl enable rke2-server.service
 systemctl start rke2-server.service
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/10838

#### What this PR does / why we need it:
Test case `test_multiple_volumes_creation_with_degraded_availability` is failing on `ubuntu upgrade test job` due to the pod failed to mount the volume. The issue was caused by the `multipathd.socket` and `multipathd.service` not being stopped on the worker nodes.

#### Special notes for your reviewer:
@james-munson @yangchiu 

#### Additional documentation or context
https://longhorn.io/kb/troubleshooting-volume-with-multipath/