### PR TITLE
ci: prevent cloud credential from being deleted before harvester cluster is deleted on hal

### DIFF
--- a/pipelines/utilities/cleanup.sh
+++ b/pipelines/utilities/cleanup.sh
@@ -11,4 +11,9 @@ fi
 # wait 30 seconds for graceful terraform termination
 sleep 30
 
-terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -auto-approve -no-color
+if [[ ${LONGHORN_TEST_CLOUDPROVIDER} == "harvester" ]]; then
+  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -target=rancher2_cluster_v2.e2e-cluster -auto-approve -no-color
+  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -auto-approve -no-color
+else
+  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -auto-approve -no-color
+fi


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10849

#### What this PR does / why we need it:

prevent cloud credential from being deleted before harvester cluster is deleted on hal by a 2-stage `terraform destroy`, the 1st stage deletes the cluster only, and the 2nd stage deletes the remaining resources, including the credential.

#### Special notes for your reviewer:

#### Additional documentation or context
