### PR TITLE
ci: talos support setting a specific K8S version

### DIFF
--- a/test_framework/terraform/aws/talos/main.tf
+++ b/test_framework/terraform/aws/talos/main.tf
@@ -195,6 +195,7 @@ data "talos_machine_configuration" "controlplane" {
   machine_secrets    = talos_machine_secrets.machine_secrets.machine_secrets
   docs               = false
   examples           = false
+  kubernetes_version = "${var.k8s_distro_version}"
   config_patches = [
     file("${path.module}/talos-patch.yaml")
   ]
@@ -210,6 +211,7 @@ data "talos_machine_configuration" "worker" {
   machine_secrets    = talos_machine_secrets.machine_secrets.machine_secrets
   docs               = false
   examples           = false
+  kubernetes_version = "${var.k8s_distro_version}"
   config_patches = [
     file("${path.module}/talos-patch-worker.yaml")
   ]


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/10756

#### What this PR does / why we need it:
This enhancement allows users to define and manage the Kubernetes version explicitly, ensuring better control and compatibility in Talos environments.

#### Special notes for your reviewer:

#### Additional documentation or context
