### PR TITLE
ci: AppCo pipeline authenticate AppCo OCI registry pull images(airgap)

### DIFF
--- a/pipelines/appco/Jenkinsfile
+++ b/pipelines/appco/Jenkinsfile
@@ -16,6 +16,7 @@ node {
     withCredentials([
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
         usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
+        usernamePassword(credentialsId: 'APPCO_CREDS', passwordVariable: 'APPCO_PASSWORD', usernameVariable: 'APPCO_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
         usernamePassword(credentialsId: 'LAB_API_KEY', passwordVariable: 'LAB_SECRET_KEY', usernameVariable: 'LAB_ACCESS_KEY'),
         string(credentialsId: 'LAB_URL', variable: 'LAB_URL'),
@@ -80,6 +81,8 @@ node {
                             --env REGISTRY_URL=${REGISTRY_URL} \
                             --env REGISTRY_USERNAME=${REGISTRY_USERNAME} \
                             --env REGISTRY_PASSWORD=${REGISTRY_PASSWORD} \
+                            --env APPCO_USERNAME=${APPCO_USERNAME} \
+                            --env APPCO_PASSWORD=${APPCO_PASSWORD} \
                             airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} ./pipelines/appco/scripts/prepare-airgap-appco-images.sh
                     """
                 }

--- a/pipelines/appco/scripts/prepare-airgap-appco-images.sh
+++ b/pipelines/appco/scripts/prepare-airgap-appco-images.sh
@@ -17,6 +17,9 @@ IMAGES=(
   "${CUSTOM_LONGHORN_CSI_LIVENESSPROBE_IMAGE}"
 )
 
+# Login to AppCo
+echo "${APPCO_PASSWORD}" | docker login dp.apps.rancher.io --username "${APPCO_USERNAME}" --password-stdin
+
 # Delete images if exist
 for image in "${IMAGES[@]}"; do
   echo "Deleting ${image} if exists"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #10859

#### What this PR does / why we need it:

AppCo v1.8.1 images have new registry `dp.apps.rancher.io`. Add authentication for `dp.apps.rancher.io` for airgap installation for pulling correspond images

#### Special notes for your reviewer:

N/A

#### Additional documentation or context

`APPCO_USERNAME`: okta user name
`APPCO_PASSWORD`:  token create under https://apps.rancher.io/settings/access-tokens ([ref](https://docs.apps.rancher.io/get-started/first-steps/))
