### PR TITLE
Improve error message for `check_volume_replica_names_recorded`

### DIFF
--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -355,6 +355,7 @@ class volume_keywords:
         actual_replica_names = sorted(actual_replica_names)
 
         assert actual_replica_names == expected_replica_names, \
+            f"The volume should reuse the failed replica to rebuild instead of creating a new one.\n" \
             f"Volume {volume_name} replica names mismatched:\n" \
             f"Want: {expected_replica_names}\n" \
             f"Got: {actual_replica_names}"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Improve error message for `check_volume_replica_names_recorded` to provide more informative feedback when test assertions fail, making it easier to identify and resolve issues.
longhorn/longhorn#10828

#### What this PR does / why we need it:
> (@roger-ryao I found these test cases are quite difficult to interpret in the test report, I had to refer back to the test source code in longhorn-tests repo to understand the expected behavior. It would be helpful if they can be refined to be more straightforward)

After discussing with @yangchiu  today, we documented the discussion through this PR:

1. **Current benefits of using Test Templates**:  
   It reduces the repetition of `Set test environment`, saving approximately 2 minutes per Test Template. For one CASE with four Test Templates, it saves about 6 minutes. The `node_reboot_with_different_anti_affinity.robot` has four Test Cases, saving approximately 24 minutes in execution time.

2. **First drawback**:  
   If one of the tests fails without executing Cleanup Test Resources, it could cause issues with the test environment, affecting subsequent CASES.

3. **Second drawback**:  
   When a Test Template within a CASE encounters an issue, the current design does not allow running a single Test Template independently within that CASE. As a result, reproducing issues becomes cumbersome and less intuitive for QA and developers.

4. **Report readability issue**:  
   Users find it difficult to quickly understand why a test failed from the report. (This issue has been addressed in this PR.)


#### Special notes for your reviewer:
@yangchiu 

#### Additional documentation or context
https://github.com/longhorn/longhorn/issues/10828#issue-3035344268

![Screenshot_20250507_153547](https://github.com/user-attachments/assets/752600f4-cd99-4fd4-ae05-2c918172bfad)

