### PR TITLE
Revert "fix(pytest): NFS backupstore not working on Talos v1.9.x"

### DIFF
--- a/manager/integration/tests/backupstore.py
+++ b/manager/integration/tests/backupstore.py
@@ -325,10 +325,7 @@ def mount_nfs_backupstore(client, mount_path="/mnt/nfs"):
     nfs_backuptarget = backupstore_get_backup_target(client)
     nfs_url = urlparse(nfs_backuptarget).netloc + \
         urlparse(nfs_backuptarget).path
-
-    # NFSv4.1 and NFSv4.2 are currently not working on Talos version later than
-    # v1.9.0. As a workaround, use NFSv4.0 until the issue is resolved.
-    cmd = ["mount", "-t", "nfs", "-o", "nfsvers=4.0", nfs_url, mount_path]
+    cmd = ["mount", "-t", "nfs", "-o", "nfsvers=4.2", nfs_url, mount_path]
     subprocess.check_output(cmd)
 
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10878

#### What this PR does / why we need it:

- Revert commit 309655b6bde562f491b04716c67ff3ea814e2875.
- NFS should work after updating the nfs-ganesha version in the nfs-backupstore image.

#### Special notes for your reviewer:

- Dependent on https://github.com/longhorn/nfs-backupstore/pull/2

#### Additional documentation or context

`None`
