### PR TITLE
chore(backupstore/nfs): align image with longhorn/nfs-backupstore

### DIFF
--- a/manager/integration/deploy/backupstores/nfs-backupstore.yaml
+++ b/manager/integration/deploy/backupstores/nfs-backupstore.yaml
@@ -48,7 +48,7 @@ spec:
         emptyDir: {}
       containers:
       - name: longhorn-test-nfs-container
-        image: longhornio/nfs-ganesha:latest
+        image: longhornio/nfs-backupstore:latest
         imagePullPolicy: Always
         env:
         - name: EXPORT_ID


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn-10878
Cherry-pick the changes from https://github.com/longhorn/longhorn/pull/10901 to the `nfs-backupstore.yaml` file in the https://github.com/longhorn/longhorn-tests/blob/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml#L51](https://github.com/longhorn/longhorn-tests/blob/master/manager/integration/deploy/backupstores/nfs-backupstore.yaml#L51.


#### What this PR does / why we need it:
Previously, Longhorn did not maintain a repository for the NFS backupstore image build. Now that we've introduced the [longhornio/nfs-backupstore](https://github.com/longhorn/nfs-backupstore), the image name will be aligned with the project name.



#### Special notes for your reviewer:

#### Additional documentation or context
https://github.com/longhorn/longhorn/pull/10901
https://github.com/longhorn/longhorn/pull/10878