### PR TITLE
test(robot): enable v2 data engine and add block disks only when required

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -39,7 +39,10 @@ Set disk path based on host provider and architecture
         Set Test Variable    ${DISK_PATH}    /dev/vdc
     END
 
-Set up v2 environment
+Enable v2 data engine and add block disks
+    ${V2_DATA_ENGINE_ENABLED}=    get_setting    v2-data-engine
+    # if it's already configured, no need to do it again
+    Return From Keyword If    "${V2_DATA_ENGINE_ENABLED}" == "true"
     set_disk_path_based_on_host_provider_and_architecture
     update_setting    v2-data-engine    true
     ${worker_nodes}=    get_worker_nodes
@@ -47,11 +50,13 @@ Set up v2 environment
         add_disk    block-disk    ${worker_node}    block    ${DISK_PATH}
     END
 
-Set test environment
+Set up test environment
     init_k8s_api_client
     setup_control_plane_network_latency
     set_backupstore
-    set_up_v2_environment
+    IF     "${DATA_ENGINE}" == "v2"
+        Enable v2 data engine and add block disks
+    END
 
 Cleanup test resources
     FOR    ${powered_off_node}    IN    @{powered_off_nodes}

--- a/e2e/libs/keywords/setting_keywords.py
+++ b/e2e/libs/keywords/setting_keywords.py
@@ -9,6 +9,9 @@ class setting_keywords:
     def update_setting(self, key, value, retry=True):
         self.setting.update_setting(key, value, retry)
 
+    def get_setting(self, key):
+        return self.setting.get_setting(key)
+
     def set_backupstore(self):
         self.setting.set_backupstore()
 

--- a/e2e/tests/negative/cluster_restart.robot
+++ b/e2e/tests/negative/cluster_restart.robot
@@ -16,7 +16,7 @@ Resource    ../keywords/snapshot.resource
 Resource    ../keywords/setting.resource
 Resource    ../keywords/metrics.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/component_resilience.robot
+++ b/e2e/tests/negative/component_resilience.robot
@@ -16,7 +16,7 @@ Resource    ../keywords/setting.resource
 Resource    ../keywords/longhorn.resource
 Resource    ../keywords/sharemanager.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Keywords ***

--- a/e2e/tests/negative/ha_volume_migration.robot
+++ b/e2e/tests/negative/ha_volume_migration.robot
@@ -11,7 +11,7 @@ Resource    ../keywords/longhorn.resource
 Resource    ../keywords/k8s.resource
 Resource    ../keywords/migration.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 

--- a/e2e/tests/negative/instance_manager_crash.robot
+++ b/e2e/tests/negative/instance_manager_crash.robot
@@ -12,7 +12,7 @@ Resource    ../keywords/deployment.resource
 Resource    ../keywords/workload.resource
 Resource    ../keywords/longhorn.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/kubelet_restart.robot
+++ b/e2e/tests/negative/kubelet_restart.robot
@@ -12,7 +12,7 @@ Resource    ../keywords/workload.resource
 Resource    ../keywords/k8s.resource
 Resource    ../keywords/setting.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/network_disconnect.robot
+++ b/e2e/tests/negative/network_disconnect.robot
@@ -12,7 +12,7 @@ Resource    ../keywords/common.resource
 Resource    ../keywords/network.resource
 Resource    ../keywords/setting.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/node_delete.robot
+++ b/e2e/tests/negative/node_delete.robot
@@ -13,7 +13,7 @@ Resource    ../keywords/workload.resource
 Resource    ../keywords/k8s.resource
 Resource    ../keywords/setting.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/node_down.robot
+++ b/e2e/tests/negative/node_down.robot
@@ -15,7 +15,7 @@ Resource    ../keywords/volume.resource
 Resource    ../keywords/workload.resource
 Resource    ../keywords/setting.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Keywords ***

--- a/e2e/tests/negative/node_drain.robot
+++ b/e2e/tests/negative/node_drain.robot
@@ -16,7 +16,7 @@ Resource    ../keywords/volume.resource
 Resource    ../keywords/host.resource
 Resource    ../keywords/node.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/node_reboot.robot
+++ b/e2e/tests/negative/node_reboot.robot
@@ -17,7 +17,7 @@ Resource    ../keywords/volume.resource
 Resource    ../keywords/workload.resource
 Resource    ../keywords/setting.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/node_reboot_with_different_anti_affinity.robot
+++ b/e2e/tests/negative/node_reboot_with_different_anti_affinity.robot
@@ -23,7 +23,7 @@ Resource    ../keywords/volume.resource
 Resource    ../keywords/setting.resource
 
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 Test Template    Power Off Node With Anti-Affinity Settings
 

--- a/e2e/tests/negative/pull_backup_from_another_longhorn.robot
+++ b/e2e/tests/negative/pull_backup_from_another_longhorn.robot
@@ -16,7 +16,7 @@ Resource    ../keywords/backupstore.resource
 Resource    ../keywords/longhorn.resource
 Library     ../libs/keywords/setting_keywords.py
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***
@@ -60,7 +60,7 @@ Pull Backup Created By Another Longhorn System
     Then Install Longhorn
     And Set setting deleting-confirmation-flag to true
     And Set backupstore
-    And Set up v2 environment
+    And Enable v2 data engine and add block disks
     And Check backup synced from backupstore
     And Create volume 1 from backup 0 in another cluster
     And Wait for volume 1 detached
@@ -74,7 +74,7 @@ Pull Backup Created By Another Longhorn System
     # Install previous version and create backup
     Then Install Longhorn stable version
     And Set backupstore
-    And Set up v2 environment
+    And Enable v2 data engine and add block disks
     And Create volume 2 with    dataEngine=${DATA_ENGINE}
     And Attach volume 2
     And Wait for volume 2 healthy
@@ -89,7 +89,7 @@ Pull Backup Created By Another Longhorn System
      # Install current version then pull backup and verify data
     Then Install Longhorn
     And Set backupstore
-    And Set up v2 environment
+    And Enable v2 data engine and add block disks
     And Check backup synced from backupstore
     And Create volume 3 from backup 1 in another cluster
     And Wait for volume 3 detached

--- a/e2e/tests/negative/replica_rebuilding.robot
+++ b/e2e/tests/negative/replica_rebuilding.robot
@@ -12,7 +12,7 @@ Resource    ../keywords/persistentvolumeclaim.resource
 Resource    ../keywords/deployment.resource
 Resource    ../keywords/workload.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/stress_cpu.robot
+++ b/e2e/tests/negative/stress_cpu.robot
@@ -11,7 +11,7 @@ Resource    ../keywords/stress.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/workload.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/stress_filesystem.robot
+++ b/e2e/tests/negative/stress_filesystem.robot
@@ -11,7 +11,7 @@ Resource    ../keywords/stress.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/workload.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/stress_memory.robot
+++ b/e2e/tests/negative/stress_memory.robot
@@ -11,7 +11,7 @@ Resource    ../keywords/stress.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/workload.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/negative/test_backup_listing.robot
+++ b/e2e/tests/negative/test_backup_listing.robot
@@ -23,7 +23,7 @@ Resource    ../keywords/snapshot.resource
 Resource    ../keywords/backup.resource
 
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Variables ***

--- a/e2e/tests/negative/test_dr_volume.robot
+++ b/e2e/tests/negative/test_dr_volume.robot
@@ -17,7 +17,7 @@ Resource    ../keywords/persistentvolumeclaim.resource
 Resource    ../keywords/workload.resource
 
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 

--- a/e2e/tests/negative/test_restore_volume_node_reboot.robot
+++ b/e2e/tests/negative/test_restore_volume_node_reboot.robot
@@ -17,7 +17,7 @@ Resource    ../keywords/backup.resource
 Resource    ../keywords/k8s.resource
 
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 Test Template    Restore volume attached node is down
 

--- a/e2e/tests/negative/uninstallation_checks.robot
+++ b/e2e/tests/negative/uninstallation_checks.robot
@@ -16,7 +16,7 @@ Resource    ../keywords/backupstore.resource
 Resource    ../keywords/longhorn.resource
 Library     ../libs/keywords/setting_keywords.py
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***
@@ -46,20 +46,14 @@ Uninstallation Checks
     ...       - CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE (if not using master-head)
     ...       - CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE (if not using master-head)
 
-    Given Create volume 0 with    dataEngine=v1
+    Given Create volume 0 with    dataEngine=${DATA_ENGINE}
     And Attach volume 0
     And Wait for volume 0 healthy
     And Write data 0 to volume 0
-    And Create volume 1 with    dataEngine=v2
-    And Attach volume 1
-    And Wait for volume 1 healthy
 
     When Create backup 0 for volume 0
-    And Create backup 1 for volume 1
     Then Verify backup list contains no error for volume 0
-    And Verify backup list contains no error for volume 1
     And Verify backup list contains backup 0 of volume 0
-    And Verify backup list contains backup 1 of volume 1
 
     Then Set setting deleting-confirmation-flag to true
     And Uninstall Longhorn

--- a/e2e/tests/prerelease_checks.robot
+++ b/e2e/tests/prerelease_checks.robot
@@ -24,7 +24,7 @@ Resource    ../keywords/engine_image.resource
 Resource    ../keywords/longhorn.resource
 Resource    ../keywords/setting.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***
@@ -50,7 +50,7 @@ Pre-release Checks
 
         And Install Longhorn stable version
         And Set backupstore
-        And Set up v2 environment
+        And Enable v2 data engine and add block disks
     END
 
     # after correct version of Longhorn is installed, start the test

--- a/e2e/tests/regression/test_backing_image.robot
+++ b/e2e/tests/regression/test_backing_image.robot
@@ -10,7 +10,7 @@ Resource    ../keywords/backing_image.resource
 Resource    ../keywords/setting.resource
 Resource    ../keywords/longhorn.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_backup.robot
+++ b/e2e/tests/regression/test_backup.robot
@@ -15,7 +15,7 @@ Resource    ../keywords/snapshot.resource
 Resource    ../keywords/backupstore.resource
 Resource    ../keywords/longhorn.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Keywords ***
@@ -111,24 +111,17 @@ Test Incremental Restore
 Test Uninstallation With Backups
     [Tags]    uninstall
     [Documentation]    Test uninstall Longhorn with normal and failed backups
-    Given Create volume 0 with    dataEngine=v1
+    Given Create volume 0 with    dataEngine=${DATA_ENGINE}
     And Attach volume 0
     And Wait for volume 0 healthy
     And Write data 0 to volume 0
-    And Create volume 1 with    dataEngine=v2
-    And Attach volume 1
-    And Wait for volume 1 healthy
-    And Write data 1 to volume 1
 
     # create failed backups by resetting backupstore and create backups without available backup targets
     And Reset Backupstore
     And Create backup 0 for volume 0    wait=False
-    And Create backup 1 for volume 1    wait=False
     And Verify backup list contains errors for volume 0
-    And Verify backup list contains errors for volume 1
     And Set Backupstore
-    And Create backup 2 for volume 0
-    And Create backup 3 for volume 1
+    And Create backup 1 for volume 0
 
     When Set setting deleting-confirmation-flag to true
     And Uninstall Longhorn

--- a/e2e/tests/regression/test_encrypted_volume.robot
+++ b/e2e/tests/regression/test_encrypted_volume.robot
@@ -11,7 +11,7 @@ Resource    ../keywords/persistentvolumeclaim.resource
 Resource    ../keywords/deployment.resource
 Resource    ../keywords/workload.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_engine_image.robot
+++ b/e2e/tests/regression/test_engine_image.robot
@@ -8,7 +8,7 @@ Resource    ../keywords/common.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/engine_image.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_ha.robot
+++ b/e2e/tests/regression/test_ha.robot
@@ -12,7 +12,7 @@ Resource    ../keywords/network.resource
 Resource    ../keywords/storageclass.resource
 Resource    ../keywords/statefulset.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_migration.robot
+++ b/e2e/tests/regression/test_migration.robot
@@ -13,7 +13,7 @@ Resource    ../keywords/volume.resource
 Resource    ../keywords/migration.resource
 Resource    ../keywords/snapshot.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_persistentvolumeclaim.robot
+++ b/e2e/tests/regression/test_persistentvolumeclaim.robot
@@ -10,7 +10,7 @@ Resource    ../keywords/setting.resource
 Resource    ../keywords/workload.resource
 Resource    ../keywords/variables.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Variables ***

--- a/e2e/tests/regression/test_recurringjob.robot
+++ b/e2e/tests/regression/test_recurringjob.robot
@@ -9,7 +9,7 @@ Resource    ../keywords/longhorn.resource
 Resource    ../keywords/recurringjob.resource
 Resource    ../keywords/volume.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_replica.robot
+++ b/e2e/tests/regression/test_replica.robot
@@ -11,7 +11,7 @@ Resource    ../keywords/deployment.resource
 Resource    ../keywords/persistentvolumeclaim.resource
 Resource    ../keywords/workload.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_scheduling.robot
+++ b/e2e/tests/regression/test_scheduling.robot
@@ -14,7 +14,7 @@ Resource    ../keywords/workload.resource
 Resource    ../keywords/k8s.resource
 Resource    ../keywords/node.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_settings.robot
+++ b/e2e/tests/regression/test_settings.robot
@@ -13,7 +13,7 @@ Resource    ../keywords/workload.resource
 Resource    ../keywords/longhorn.resource
 Resource    ../keywords/sharemanager.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_snapshot.robot
+++ b/e2e/tests/regression/test_snapshot.robot
@@ -12,7 +12,7 @@ Resource    ../keywords/snapshot.resource
 Resource    ../keywords/node.resource
 Resource    ../keywords/longhorn.resource
 
-Test Setup   Set test environment
+Test Setup   Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***

--- a/e2e/tests/regression/test_system_backup.robot
+++ b/e2e/tests/regression/test_system_backup.robot
@@ -10,7 +10,7 @@ Resource    ../keywords/volume.resource
 Resource    ../keywords/system_backup.resource
 Resource    ../keywords/longhorn.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Test Cases ***
@@ -38,14 +38,10 @@ Test System Backup And Restore
 Test Uninstallation With System Backup
     [Tags]    uninstall
     [Documentation]    Test uninstall Longhorn with system backup
-    Given Create volume 0 with    dataEngine=v1
+    Given Create volume 0 with    dataEngine=${DATA_ENGINE}
     And Attach volume 0
     And Wait for volume 0 healthy
     And Write data 0 to volume 0
-    And Create volume 1 with    dataEngine=v2
-    And Attach volume 1
-    And Wait for volume 1 healthy
-    And Write data 1 to volume 1
 
     And Create system backup 0
 

--- a/e2e/tests/regression/test_v2.robot
+++ b/e2e/tests/regression/test_v2.robot
@@ -12,13 +12,19 @@ Resource    ../keywords/workload.resource
 Resource    ../keywords/volume.resource
 Resource    ../keywords/backing_image.resource
 Resource    ../keywords/setting.resource
+Resource    ../keywords/snapshot.resource
 Resource    ../keywords/node.resource
 Resource    ../keywords/host.resource
 Resource    ../keywords/longhorn.resource
 Resource    ../keywords/k8s.resource
 
-Test Setup    Set test environment
+Test Setup    Set up v2 test environment
 Test Teardown    Cleanup test resources
+
+*** Keywords ***
+Set up v2 test environment
+    Set up test environment
+    Enable v2 data engine and add block disks
 
 *** Test Cases ***
 Test V2 Volume Basic
@@ -32,6 +38,79 @@ Test V2 Volume Basic
     And Detach volume 0
     And Wait for volume 0 detached
     And Delete volume 0
+
+Test V2 Snapshot
+    [Tags]    coretest
+    [Documentation]    Test snapshot operations
+    Given Create volume 0 with    dataEngine=v2
+    When Attach volume 0
+    And Wait for volume 0 healthy
+
+    And Create snapshot 0 of volume 0
+
+    And Write data 1 to volume 0
+    And Create snapshot 1 of volume 0
+
+    And Write data 2 to volume 0
+    And Create snapshot 2 of volume 0
+
+    Then Validate snapshot 0 is parent of snapshot 1 in volume 0 snapshot list
+    And Validate snapshot 1 is parent of snapshot 2 in volume 0 snapshot list
+    And Validate snapshot 2 is parent of volume-head in volume 0 snapshot list
+    # cannot delete snapshot 2 since it is the parent of volume head
+    And Delete snapshot 2 of volume 0 will fail
+
+    When Detach volume 0
+    And Wait for volume 0 detached
+    And Attach volume 0 in maintenance mode
+    And Wait for volume 0 healthy
+
+    And Revert volume 0 to snapshot 1
+    And Detach volume 0
+    And Wait for volume 0 detached
+    And Attach volume 0
+    And Wait for volume 0 healthy
+    Then Check volume 0 data is data 1
+    And Validate snapshot 1 is parent of volume-head in volume 0 snapshot list
+
+    # cannot delete snapshot 1 since it is the parent of volume head
+    When Delete snapshot 1 of volume 0 will fail
+    And Delete snapshot 2 of volume 0
+    And Delete snapshot 0 of volume 0
+
+    # delete a snapshot won't mark the snapshot as removed
+    # but directly remove it from the snapshot list without purge
+    Then Validate snapshot 2 is not in volume 0 snapshot list
+    And Validate snapshot 0 is not in volume 0 snapshot list
+
+    And Check volume 0 data is data 1
+
+Test V2 Replica Rebuilding
+    Given Create volume 0 with    size=10Gi    numberOfReplicas=3    dataEngine=v2
+    And Attach volume 0 to node 0
+    And Wait for volume 0 healthy
+    And Write 1 GB data to volume 0
+
+    When Disable node 1 scheduling
+    And Disable disk block-disk scheduling on node 1
+    And Delete instance-manager on node 1
+
+    # for a v2 volume, when a replica process crashed or an instance manager deleted,
+    # the corresponding replica running state won't be set to false,
+    # but the replica will be directly deleted
+    Then Wait for volume 0 replica on node 1 to be deleted
+    And Wait for volume 0 degraded
+
+    When Enable disk block-disk scheduling on node 1
+    Then Check volume 0 kept in degraded
+
+    When Enable node 1 scheduling
+    # since the replica has been deleted, no replica will be reused on node 1
+    Then Wait until volume 0 replica rebuilding started on node 1
+    And Wait for volume 0 healthy
+
+    And Check volume 0 data is intact
+    And Check volume 0 works
 
 Degraded Volume Replica Rebuilding
     [Tags]    coretest

--- a/e2e/tests/regression/test_volume.robot
+++ b/e2e/tests/regression/test_volume.robot
@@ -14,7 +14,7 @@ Resource    ../keywords/node.resource
 Resource    ../keywords/snapshot.resource
 Resource    ../keywords/volume.resource
 
-Test Setup    Set test environment
+Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Keywords ***


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10908

#### What this PR does / why we need it:

enable v2 data engine and add block disks only when required

#### Special notes for your reviewer:

#### Additional documentation or context
