### PR TITLE
Add elapsed_time tracking in wait_for_snapshot_checksums_generate v1.7.x (backport #2496)

### DIFF
--- a/manager/integration/tests/test_snapshot.py
+++ b/manager/integration/tests/test_snapshot.py
@@ -670,17 +670,18 @@ def check_per_volume_hash_disable(client, volume_name, snapshot_data_integrity):
 def wait_for_snapshot_checksums_generate(volume_name):   # NOQA
     snapshot_checksums_generate = False
 
-    count = 0
-    for count in range(RETRY_WAIT_CHECKSUM_COUNTS):
+    start_time = time.time()
+    for _ in range(RETRY_WAIT_CHECKSUM_COUNTS):
         if check_snapshot_checksums_set(volume_name):
-            print(f'All checksums are set in {count} sec')
+            elapsed_time = int(time.time() - start_time)
+            print(f'All checksums are set in {elapsed_time} sec')
             snapshot_checksums_generate = True
             break
         else:
             time.sleep(RETRY_INTERVAL)
 
     assert snapshot_checksums_generate
-    return count
+    return elapsed_time
 
 
 def test_snapshot_cr(client, volume_name, settings_reset):  # NOQA


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/10886

#### What this PR does / why we need it:
This PR enhances `wait_for_snapshot_checksums_generate` by adding `elapsed_time` tracking, providing more accurate timing information.

#### Special notes for your reviewer:

#### Additional documentation or context
private image test result: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/8561/testReport/
https://github.com/longhorn/longhorn-tests/pull/2496
