### PR TITLE
Update `SETTING_ORPHAN_RESOURCE_AUTO_DELETION` value to `replica-data`

### DIFF
--- a/manager/integration/tests/test_orphan.py
+++ b/manager/integration/tests/test_orphan.py
@@ -754,7 +754,7 @@ def test_orphan_auto_deletion(client, volume_name, request):  # NOQA
 
     # Step 6: enable orphan auto deletion
     setting = client.by_id_setting(SETTING_ORPHAN_RESOURCE_AUTO_DELETION)
-    client.update(setting, value="replicaData")
+    client.update(setting, value="replica-data")
 
     # Step 7
     assert wait_for_orphan_count(client, 0, 180) == 0


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#6764

#### What this PR does / why we need it:
The regression test for `v1.9.0-rc3` failed at https://ci.longhorn.io/job/public/job/master/job/ubuntu/job/amd64/job/longhorn-tests-ubuntu-amd64/611/testReport/junit/tests/test_orphan/test_orphan_auto_deletion/

This PR addresses the issue by updating the test case to ensure compatibility and resolve the failure.


#### Special notes for your reviewer:
@COLDTURNIP @derekbit 

#### Additional documentation or context

![Screenshot_20250521_121320](https://github.com/user-attachments/assets/822ee435-d19b-44e1-b488-bdf5f4b736c6)

