### PR TITLE
test: refine metric test cases

### DIFF
--- a/manager/integration/tests/test_metric.py
+++ b/manager/integration/tests/test_metric.py
@@ -160,8 +160,6 @@ def examine_metric_value(found_metric, metric_labels, expected_value=None):
     for key, value in metric_labels.items():
         assert found_metric.labels[key] == value
 
-    assert isinstance(found_metric.value, float)
-
     if expected_value is not None:
         assert found_metric.value == expected_value
     else:
@@ -216,8 +214,6 @@ def check_metric_sum_on_all_nodes(client, core_api, metric_name, expected_labels
             continue
 
         filtered_metric = filter_metric_by_labels(metrics, expected_labels)
-
-        assert isinstance(filtered_metric.value, float)
 
         for key, value in expected_labels.items():
             value_type = type(value)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10957

#### What this PR does / why we need it:

Remove `assert isinstance(found_metric.value, float)` for some metric value changed to `int`

We still utilize `found_metric.value == expected_value` to check metric value

![image](https://github.com/user-attachments/assets/07b6e729-eebb-43ae-ad28-386462b8fc29)


#### Special notes for your reviewer:

#### Additional documentation or context
