### PR TITLE
fix(tests): add `dataEngine` parameter to storage class in `test_provisioner_tags`

### DIFF
--- a/manager/integration/tests/test_provisioner.py
+++ b/manager/integration/tests/test_provisioner.py
@@ -204,6 +204,7 @@ def test_provisioner_tags(client, core_api, node_default_tags, storage_class, pv
     ]
     pvc['spec']['storageClassName'] = DEFAULT_STORAGECLASS_NAME
     storage_class['metadata']['name'] = DEFAULT_STORAGECLASS_NAME
+    storage_class['parameters']['dataEngine'] = DATA_ENGINE
     storage_class['parameters']['diskSelector'] = 'ssd,nvme'
     storage_class['parameters']['nodeSelector'] = 'storage,main'
     volume_size = DEFAULT_VOLUME_SIZE * Gi


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/10974

#### What this PR does / why we need it:
- Added the `dataEngine` parameter to the storage class configuration in the `test_provisioner_tags` test case.
- Ensures that the test aligns with the updated storage class requirements.

#### Special notes for your reviewer:
@chriscchien 

#### Additional documentation or context
