### PR TITLE
test(robot): fix test suite node_delete not find varibale DISK_PATH

### DIFF
--- a/e2e/keywords/k8s.resource
+++ b/e2e/keywords/k8s.resource
@@ -31,7 +31,9 @@ Delete volume of ${workload_kind} ${workload_id} replica node
 
 Add deleted node back
     reboot_node_by_name    ${deleted_node}
-    add_disk    block-disk    ${deleted_node}    block    ${DISK_PATH}
+    IF     "${DATA_ENGINE}" == "v2"
+        add_disk    block-disk    ${deleted_node}    block    ${DISK_PATH}
+    END
 
 Force drain volume of ${workload_kind} ${workload_id} volume node
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

#### What this PR does / why we need it:

https://ci.longhorn.io/job/private/job/longhorn-e2e-test/3183/robot/report/log.html#s1-s1-s1-t1
![image](https://github.com/user-attachments/assets/77890b98-3b88-4e66-8f66-8c924a9657c5)

Fix varibale `DISK_PATH` not find when data engine is v1

#### Special notes for your reviewer:

Test result
- [v1 data engine](https://ci.longhorn.io/job/private/job/longhorn-e2e-test/3194/)
- [v2 data engine](https://ci.longhorn.io/job/private/job/longhorn-e2e-test/3195/)

#### Additional documentation or context
