### PR TITLE
test(robot): Add ${test_v2_only} condition to enhance prerelease_checks for v2 volume testing

### DIFF
--- a/e2e/tests/prerelease_checks.robot
+++ b/e2e/tests/prerelease_checks.robot
@@ -27,6 +27,9 @@ Resource    ../keywords/setting.resource
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
+*** Variables ***
+${test_v2_only}    false
+
 *** Test Cases ***
 Pre-release Checks
     [Documentation]    Pre-release Checks
@@ -58,99 +61,103 @@ Pre-release Checks
     # (0) disable auto salvage to allow faulted volumes to be revealed
     Given Set setting auto-salvage to false
 
-    # (1) create a volume with revision counter enabled
-    When Set setting disable-revision-counter to false
-    And Create volume vol-revision-enabled with    dataEngine=v1
-    And Attach volume vol-revision-enabled
-    And Wait for volume vol-revision-enabled healthy
-    And Write data data-vol-revision-enabled to volume vol-revision-enabled
+    IF    '${test_v2_only}' == 'false'
 
-    # (2) create a volume with revision counter disabled
-    When Set setting disable-revision-counter to true
-    And Create volume vol-revision-disabled with    dataEngine=v1
-    And Attach volume vol-revision-disabled
-    And Wait for volume vol-revision-disabled healthy
-    And Write data data-vol-revision-disabled to volume vol-revision-disabled
+        # (1) create a volume with revision counter enabled
+        When Set setting disable-revision-counter to false
+        And Create volume vol-revision-enabled with    dataEngine=v1
+        And Attach volume vol-revision-enabled
+        And Wait for volume vol-revision-enabled healthy
+        And Write data data-vol-revision-enabled to volume vol-revision-enabled
 
-    # (3) create a volume used by a pod
-    Given Create volume vol-pod with    size=3Gi    dataEngine=v1
-    And Create persistentvolume for volume vol-pod
-    And Create persistentvolumeclaim for volume vol-pod
-    And Create pod vol-pod using volume vol-pod
-    And Wait for pod vol-pod running
-    And Write 1024 MB data to file data.txt in pod vol-pod
+        # (2) create a volume with revision counter disabled
+        When Set setting disable-revision-counter to true
+        And Create volume vol-revision-disabled with    dataEngine=v1
+        And Attach volume vol-revision-disabled
+        And Wait for volume vol-revision-disabled healthy
+        And Write data data-vol-revision-disabled to volume vol-revision-disabled
 
-    # (4) create a volume used by a statefulset
-    When Create storageclass longhorn-test with    dataEngine=v1
-    And Create statefulset ss-upgrade using RWO volume with longhorn-test storageclass
-    And Wait for volume of statefulset ss-upgrade healthy
-    And Write 1024 MB data to file data.txt in statefulset ss-upgrade
+        # (3) create a volume used by a pod
+        Given Create volume vol-pod with    size=3Gi    dataEngine=v1
+        And Create persistentvolume for volume vol-pod
+        And Create persistentvolumeclaim for volume vol-pod
+        And Create pod vol-pod using volume vol-pod
+        And Wait for pod vol-pod running
+        And Write 1024 MB data to file data.txt in pod vol-pod
 
-    # (5) create a strict-local volume
-    When Create volume vol-strict-local with    dataEngine=v1
-    And Attach volume vol-strict-local
-    And Wait for volume vol-strict-local healthy
-    And Write data data-vol-strict-local to volume vol-strict-local
+        # (4) create a volume used by a statefulset
+        When Create storageclass longhorn-test with    dataEngine=v1
+        And Create statefulset ss-upgrade using RWO volume with longhorn-test storageclass
+        And Wait for volume of statefulset ss-upgrade healthy
+        And Write 1024 MB data to file data.txt in statefulset ss-upgrade
 
-    # (6) create a rwx workload
-    When Create persistentvolumeclaim 0    volume_type=RWX    sc_name=longhorn-test
-    And Create deployment deploy-upgrade with persistentvolumeclaim 0
-    And Wait for volume of deployment deploy-upgrade attached and healthy
-    And Write 1024 MB data to file data.txt in deployment deploy-upgrade
+        # (5) create a strict-local volume
+        When Create volume vol-strict-local with    dataEngine=v1
+        And Attach volume vol-strict-local
+        And Wait for volume vol-strict-local healthy
+        And Write data data-vol-strict-local to volume vol-strict-local
+    
+        # (6) create a rwx workload
+        When Create persistentvolumeclaim 0    volume_type=RWX    sc_name=longhorn-test
+        And Create deployment deploy-upgrade with persistentvolumeclaim 0
+        And Wait for volume of deployment deploy-upgrade attached and healthy
+        And Write 1024 MB data to file data.txt in deployment deploy-upgrade
 
-    # (7) create a volume with a backing image
-    When Create backing image bi-v1 with    url=https://longhorn-backing-image.s3-us-west-1.amazonaws.com/parrot.qcow2    dataEngine=v1
-    And Create volume vol-bi with    size=3Gi    backingImage=bi-v1
-    And Create persistentvolume for volume vol-bi
-    And Create persistentvolumeclaim for volume vol-bi
-    And Create pod vol-pod-bi using volume vol-bi
-    And Wait for pod vol-pod-bi running
-    And Check file guests/catparrot.gif exists in pod vol-pod-bi
-    And Write 1024 MB data to file data.txt in pod vol-pod-bi
+        # (7) create a volume with a backing image
+        When Create backing image bi-v1 with    url=https://longhorn-backing-image.s3-us-west-1.amazonaws.com/parrot.qcow2    dataEngine=v1
+        And Create volume vol-bi with    size=3Gi    backingImage=bi-v1
+        And Create persistentvolume for volume vol-bi
+        And Create persistentvolumeclaim for volume vol-bi
+        And Create pod vol-pod-bi using volume vol-bi
+        And Wait for pod vol-pod-bi running
+        And Check file guests/catparrot.gif exists in pod vol-pod-bi
+        And Write 1024 MB data to file data.txt in pod vol-pod-bi
 
-    # (8) create a volume to be detached
-    When Create volume vol-detach with    dataEngine=v1
-    And Attach volume vol-detach
-    And Wait for volume vol-detach healthy
-    And Write data data-vol-detach to volume vol-detach
-    And Detach volume vol-detach
-    And Wait for volume vol-detach detached
+        # (8) create a volume to be detached
+        When Create volume vol-detach with    dataEngine=v1
+        And Attach volume vol-detach
+        And Wait for volume vol-detach healthy
+        And Write data data-vol-detach to volume vol-detach
+        And Detach volume vol-detach
+        And Wait for volume vol-detach detached
+    
+        # (9) create a volume for replica rebuilding after upgrade
+        When Create volume vol-rebuild with    dataEngine=v1
+        And Attach volume vol-rebuild
+        And Wait for volume vol-rebuild healthy
+        And Write data data-vol-rebuild to volume vol-rebuild
+    
+        # (10) create a volume with recurring jobs
+        When Create volume vol-recurring with    dataEngine=v1
+        And Attach volume vol-recurring
+        And Wait for volume vol-recurring healthy
+        Then Create snapshot and backup recurringjob for volume vol-recurring
+        And Check recurringjobs for volume vol-recurring work
 
-    # (9) create a volume for replica rebuilding after upgrade
-    When Create volume vol-rebuild with    dataEngine=v1
-    And Attach volume vol-rebuild
-    And Wait for volume vol-rebuild healthy
-    And Write data data-vol-rebuild to volume vol-rebuild
+        # (11) create a volume that is never attached before upgrade
+        And Create volume vol-never-attach with    dataEngine=v1
 
-    # (10) create a volume with recurring jobs
-    When Create volume vol-recurring with    dataEngine=v1
-    And Attach volume vol-recurring
-    And Wait for volume vol-recurring healthy
-    Then Create snapshot and backup recurringjob for volume vol-recurring
-    And Check recurringjobs for volume vol-recurring work
+        # (12) create custom resources
+        # support bundle
+        And Create support bundle
+        # system backup
+        And Create system backup 0
+        # orphaned replica
+        And Create volume v1 with    dataEngine=v1
+        And Attach volume v1
+        And Wait for volume v1 healthy
+        And Write data 0 to volume v1
+        And Create orphan replica for volume v1
+        And Wait for orphan count to be 1
 
-    # (11) create a volume that is never attached before upgrade
-    And Create volume vol-never-attach with    dataEngine=v1
+        # (13) create snapshot
+        And Create snapshot snapshot-v1 of volume v1
+        And Write data 1 to volume v1
 
-    # (12) create custom resources
-    # support bundle
-    And Create support bundle
-    # system backup
-    And Create system backup 0
-    # orphaned replica
-    And Create volume v1 with    dataEngine=v1
-    And Attach volume v1
-    And Wait for volume v1 healthy
-    And Write data 0 to volume v1
-    And Create orphan replica for volume v1
-    And Wait for orphan count to be 1
+        # (14) create backup
+        And Create backup backup-v1 for volume v1
 
-    # (13) create snapshot
-    And Create snapshot snapshot-v1 of volume v1
-    And Write data 1 to volume v1
-
-    # (14) create backup
-    And Create backup backup-v1 for volume v1
+    END
 
     # use DATA_ENGINE to control whether to test v2 volumes in the test
     # because v1.8.x v2 volumes aren't compatible with v1.7.x ones
@@ -213,38 +220,42 @@ Pre-release Checks
     # (0) check v1 instance manager pods didn't restart
     Then Check v1 instance manager pods did not restart
 
-    # (1-1) check the data integrity of the volume with revision counter enabled
-    And Check volume vol-revision-enabled data is intact
-    And Check volume vol-revision-enabled works
+    IF    '${test_v2_only}' == 'false'
 
-    # (2-1) check the data integrity of the volume with revision counter disabled
-    And Check volume vol-revision-disabled data is intact
-    And Check volume vol-revision-disabled works
+        # (1-1) check the data integrity of the volume with revision counter enabled
+        And Check volume vol-revision-enabled data is intact
+        And Check volume vol-revision-enabled works
 
-    # (3-1) check pod didn't restart and the data integrity of the volume used by a pod
-    And Check pod vol-pod did not restart
-    And Check pod vol-pod data in file data.txt is intact
-    And Check pod vol-pod works
+        # (2-1) check the data integrity of the volume with revision counter disabled
+        And Check volume vol-revision-disabled data is intact
+        And Check volume vol-revision-disabled works
 
-    # (4-1) check statefulset pod didn't restart and the data integrity of the volume used by a statefulset
-    And Check statefulset ss-upgrade pods did not restart
-    And Check statefulset ss-upgrade data in file data.txt is intact
-    And Check statefulset ss-upgrade works
+        # (3-1) check pod didn't restart and the data integrity of the volume used by a pod
+        And Check pod vol-pod did not restart
+        And Check pod vol-pod data in file data.txt is intact
+        And Check pod vol-pod works
 
-    # (5-1) check the data integrity of the strict-local volume
-    And Check volume vol-strict-local data is intact
-    And Check volume vol-strict-local works
+        # (4-1) check statefulset pod didn't restart and the data integrity of the volume used by a statefulset
+        And Check statefulset ss-upgrade pods did not restart
+        And Check statefulset ss-upgrade data in file data.txt is intact
+        And Check statefulset ss-upgrade works
 
-    # (6-1) check deployment pod didn't restart and the data integrity of the volume of the rwx workload
-    And Check deployment deploy-upgrade pods did not restart
-    And Check deployment deploy-upgrade data in file data.txt is intact
-    And Check deployment deploy-upgrade works
+        # (5-1) check the data integrity of the strict-local volume
+        And Check volume vol-strict-local data is intact
+        And Check volume vol-strict-local works
 
-    # (7-1) check pod didn't restart and the data integrity of the volume with a backing image
-    And Check pod vol-pod-bi did not restart
-    And Check file guests/catparrot.gif exists in pod vol-pod-bi
-    And Check pod vol-pod-bi data in file data.txt is intact
-    And Check pod vol-pod-bi works
+        # (6-1) check deployment pod didn't restart and the data integrity of the volume of the rwx workload
+        And Check deployment deploy-upgrade pods did not restart
+        And Check deployment deploy-upgrade data in file data.txt is intact
+        And Check deployment deploy-upgrade works
+
+        # (7-1) check pod didn't restart and the data integrity of the volume with a backing image
+        And Check pod vol-pod-bi did not restart
+        And Check file guests/catparrot.gif exists in pod vol-pod-bi
+        And Check pod vol-pod-bi data in file data.txt is intact
+        And Check pod vol-pod-bi works
+
+    END
 
     # volume engines upgrade
     IF    '${LONGHORN_STABLE_VERSION}' != ''
@@ -254,100 +265,104 @@ Pre-release Checks
 
     # do post engine upgrade checks
 
-    # (1-2) check the data integrity of the volume with revision counter enabled
-    Then Check volume vol-revision-enabled data is intact
-    And Check volume vol-revision-enabled works
+    IF    '${test_v2_only}' == 'false'
 
-    # (2-2) check the data integrity of the volume with revision counter disabled
-    And Check volume vol-revision-disabled data is intact
-    And Check volume vol-revision-disabled works
+        # (1-2) check the data integrity of the volume with revision counter enabled
+        Then Check volume vol-revision-enabled data is intact
+        And Check volume vol-revision-enabled works
+    
+        # (2-2) check the data integrity of the volume with revision counter disabled
+        And Check volume vol-revision-disabled data is intact
+        And Check volume vol-revision-disabled works
 
-    # (3-2) check pod didn't restart and the data integrity of the volume used by a pod
-    And And Check pod vol-pod did not restart
-    And Check pod vol-pod data in file data.txt is intact
-    And Check pod vol-pod works
+        # (3-2) check pod didn't restart and the data integrity of the volume used by a pod
+        And And Check pod vol-pod did not restart
+        And Check pod vol-pod data in file data.txt is intact
+        And Check pod vol-pod works
 
-    # (4-2) check statefulset pod didn't restart and the data integrity of the volume used by a statefulset
-    And Check statefulset ss-upgrade pods did not restart
-    And Check statefulset ss-upgrade data in file data.txt is intact
-    And Check statefulset ss-upgrade works
+       # (4-2) check statefulset pod didn't restart and the data integrity of the volume used by a statefulset
+        And Check statefulset ss-upgrade pods did not restart
+        And Check statefulset ss-upgrade data in file data.txt is intact
+        And Check statefulset ss-upgrade works
 
-    # (5-2) check the data integrity of the strict-local volume
-    And Check volume vol-strict-local data is intact
-    And Check volume vol-strict-local works
+        # (5-2) check the data integrity of the strict-local volume
+        And Check volume vol-strict-local data is intact
+        And Check volume vol-strict-local works
 
-    # (6-2) check deployment pod didn't restart and the data integrity of the volume of the rwx workload
-    And Check deployment deploy-upgrade pods did not restart
-    And Check deployment deploy-upgrade data in file data.txt is intact
-    And Check deployment deploy-upgrade works
+        # (6-2) check deployment pod didn't restart and the data integrity of the volume of the rwx workload
+        And Check deployment deploy-upgrade pods did not restart
+        And Check deployment deploy-upgrade data in file data.txt is intact
+        And Check deployment deploy-upgrade works
 
-    # (7-2) check pod didn't restart and the data integrity of the volume with a backing image
-    And Check pod vol-pod-bi did not restart
-    And Check file guests/catparrot.gif exists in pod vol-pod-bi
-    And Check pod vol-pod-bi data in file data.txt is intact
-    And Check pod vol-pod-bi works
+        # (7-2) check pod didn't restart and the data integrity of the volume with a backing image
+        And Check pod vol-pod-bi did not restart
+        And Check file guests/catparrot.gif exists in pod vol-pod-bi
+        And Check pod vol-pod-bi data in file data.txt is intact
+        And Check pod vol-pod-bi works
 
-    # (8) check the detached volume can be attached after upgrade
-    When attach volume vol-detach
-    Then wait for volume vol-detach healthy
-    And Check volume vol-detach data is intact
-    And Check volume vol-detach works
+        # (8) check the detached volume can be attached after upgrade
+        When attach volume vol-detach
+        Then wait for volume vol-detach healthy
+        And Check volume vol-detach data is intact
+        And Check volume vol-detach works
 
-    # (9) trigger replica rebuilding after upgrade
-    When Delete volume vol-rebuild replica on node 1
-    Then Wait until volume vol-rebuild replica rebuilding started on node 1
-    And Wait until volume vol-rebuild replica rebuilding completed on node 1
-    And Wait for volume vol-rebuild healthy
-    And Check volume vol-rebuild data is intact
+        # (9) trigger replica rebuilding after upgrade
+        When Delete volume vol-rebuild replica on node 1
+        Then Wait until volume vol-rebuild replica rebuilding started on node 1
+        And Wait until volume vol-rebuild replica rebuilding completed on node 1
+        And Wait for volume vol-rebuild healthy
+        And Check volume vol-rebuild data is intact
 
-    # (10) check recurring jobs are working after upgrade
-    And Check recurringjobs for volume vol-recurring work
+        # (10) check recurring jobs are working after upgrade
+        And Check recurringjobs for volume vol-recurring work
 
-    # (11) check a volume that is never attached can be attached after upgrade
-    When Attach volume vol-never-attach
-    Then Wait for volume vol-never-attach attached
-    And Wait for volume vol-never-attach healthy
-    And Check volume vol-never-attach works
+        # (11) check a volume that is never attached can be attached after upgrade
+        When Attach volume vol-never-attach
+        Then Wait for volume vol-never-attach attached
+        And Wait for volume vol-never-attach healthy
+        And Check volume vol-never-attach works
 
-    # (12) delete custom resources
-    And Cleanup orphans
-    And Delete system backup 0
+        # (12) delete custom resources
+        And Cleanup orphans
+        And Delete system backup 0
 
-    # (13) revert snapshot
-    And Check volume v1 data is data 1
-    When Detach volume v1
-    And Wait for volume v1 detached
-    And Attach volume v1 in maintenance mode
-    And Wait for volume v1 healthy
-    And Revert volume v1 to snapshot snapshot-v1
-    And Detach volume v1
-    And Wait for volume v1 detached
-    And Attach volume v1
-    And Wait for volume v1 healthy
-    And Check volume v1 data is data 0
+        # (13) revert snapshot
+        And Check volume v1 data is data 1
+        When Detach volume v1
+        And Wait for volume v1 detached
+        And Attach volume v1 in maintenance mode
+        And Wait for volume v1 healthy
+        And Revert volume v1 to snapshot snapshot-v1
+        And Detach volume v1
+        And Wait for volume v1 detached
+        And Attach volume v1
+        And Wait for volume v1 healthy
+        And Check volume v1 data is data 0
 
-    # (14) restore volume from backup
-    When Create volume vol-restore from backup backup-v1 of volume v1
-    Then Wait for volume vol-restore restoration from backup backup-v1 of volume v1 start
-    And Wait for volume vol-restore detached
-    And Attach volume vol-restore
-    And Check volume vol-restore data is backup backup-v1 of volume v1
+        # (14) restore volume from backup
+        When Create volume vol-restore from backup backup-v1 of volume v1
+        Then Wait for volume vol-restore restoration from backup backup-v1 of volume v1 start
+        And Wait for volume vol-restore detached
+        And Attach volume vol-restore
+        And Check volume vol-restore data is backup backup-v1 of volume v1
 
-    # (15) check a volume can be detached and re-attached
-    When Detach volume vol-rebuild
-    And Wait for volume vol-rebuild detached
-    Then Attach volume vol-rebuild
-    And Wait for volume vol-rebuild healthy
-    And Check volume vol-rebuild data is intact
+        # (15) check a volume can be detached and re-attached
+        When Detach volume vol-rebuild
+        And Wait for volume vol-rebuild detached
+        Then Attach volume vol-rebuild
+        And Wait for volume vol-rebuild healthy
+        And Check volume vol-rebuild data is intact
 
-    # (16) check a new volume with a backing image can be created
-    When Create volume new-vol-bi with    size=3Gi    backingImage=bi-v1
-    And Create persistentvolume for volume new-vol-bi
-    And Create persistentvolumeclaim for volume new-vol-bi
-    And Create pod new-vol-pod-bi using volume new-vol-bi
-    And Wait for pod new-vol-pod-bi running
-    And Check file guests/catparrot.gif exists in pod new-vol-pod-bi
-    And Write 1024 MB data to file data.txt in pod new-vol-pod-bi
+        # (16) check a new volume with a backing image can be created
+        When Create volume new-vol-bi with    size=3Gi    backingImage=bi-v1
+        And Create persistentvolume for volume new-vol-bi
+        And Create persistentvolumeclaim for volume new-vol-bi
+        And Create pod new-vol-pod-bi using volume new-vol-bi
+        And Wait for pod new-vol-pod-bi running
+        And Check file guests/catparrot.gif exists in pod new-vol-pod-bi
+        And Write 1024 MB data to file data.txt in pod new-vol-pod-bi
+
+    END
 
     IF    "${DATA_ENGINE}" == "v2"
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#11098

#### What this PR does / why we need it:
- Improved the logic of `prerelease_checks` to include the `${test_v2_only}` condition.  
- This enhancement aims to make it easier for developers to test v2 volumes.  
- By refining the testing logic, developers can identify v2-related issues more efficiently.  

#### Special notes for your reviewer:
@yangchiu 

#### Additional documentation or context

**CUSTOM_TEST_OPTIONS**
`-t \"Pre-release Checks\" --exclude \"cluster\" --exclude \"storage-network\" --exclude \"large-size\" -v LOOP_COUNT:1 -v RETRY_COUNT:600 -v DATA_ENGINE:v2 -v test_v2_only:true`
