### PR TITLE
test(robot): update e2e README.md

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -84,6 +84,9 @@ export VAGRANT_CWD=/path/to/vagrant/working/dir
 1. To run upgrade/uninstallation related test cases, export the following environment variables so the test code knows how to re-install Longhorn after the test cases are completed:
 
 ```
+cd e2e
+cp -r ../pipelines/ ./
+
 export LONGHORN_INSTALL_METHOD=manifest
 export LONGHORN_REPO_BRANCH=master
 export LONGHORN_STABLE_VERSION=v1.8.1


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

If run e2e on local and perform upgrade test case, it is necessary to manually copy folder `pipelines` into folder `e2e` now, or the test case will fail due to not find installation script. Add the step into `README.md`

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
