### PR TITLE
test: fix getting longhorn api client could hang

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -406,12 +406,13 @@ def get_longhorn_api_client():
                 # Determine if IP is IPv6
                 family = socket.AF_INET6 if ':' in ip else socket.AF_INET
                 sock = socket.socket(family, socket.SOCK_STREAM)
+                sock.settimeout(RETRY_COUNTS_SHORT)
 
-            try:
-                if sock.connect_ex((ip, 9500)) == 0:
-                    return get_client(ip + PORT)
-            finally:
-                sock.close()
+                try:
+                    if sock.connect_ex((ip, 9500)) == 0:
+                        return get_client(ip + PORT)
+                finally:
+                    sock.close()
         except Exception:
             time.sleep(RETRY_INTERVAL)
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/11316

#### What this PR does / why we need it:

fix getting longhorn api client could hang

(1) set timeout for socket connect function
(2) avoid trying to get longhorn api client from a terminating longhorn manager pod

#### Special notes for your reviewer:

#### Additional documentation or context
