### PR TITLE
test(robot): Add case rwx encryption volume online expansion

### DIFF
--- a/e2e/keywords/sharemanager.resource
+++ b/e2e/keywords/sharemanager.resource
@@ -35,3 +35,18 @@ Wait for sharemanager pod of deployment ${deployment_id} running
     ${deployment_name} =   generate_name_with_suffix    deployment    ${deployment_id}
     ${volume_name} =    get_workload_volume_name    ${deployment_name}
     wait_for_share_manager_pod_running    ${volume_name}
+
+Assert encrypted disk size in sharemanager pod for ${workload_kind} ${workload_id} is ${size}
+    ${expected_size_byte} =    convert_size_to_bytes    ${size}    to_str=True
+
+    ${workload_name}=    generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name}=    get_workload_volume_name    ${workload_name}
+    ${share_manager_pod}=    Set Variable    share-manager-${volume_name}
+    Wait Until Keyword Succeeds    ${RETRY_COUNT}    ${RETRY_INTERVAL}
+    ...    Check encrypted disk size in sharemanager pod    ${share_manager_pod}    ${volume_name}    ${expected_size_byte}
+
+Check encrypted disk size in sharemanager pod
+    [Arguments]    ${sharemanager_pod}    ${volume_name}    ${expected_size}
+    ${cmd}=    Set Variable    fdisk -l | grep /dev/mapper/${volume_name}
+    ${result}=    pod_exec    ${sharemanager_pod}    longhorn-system    ${cmd}
+    Should Contain    ${result}    ${expected_size}

--- a/e2e/libs/keywords/common_keywords.py
+++ b/e2e/libs/keywords/common_keywords.py
@@ -4,6 +4,7 @@ from node_exec import NodeExec
 from utility.utility import convert_size_to_bytes
 from utility.utility import init_k8s_api_client
 from utility.utility import generate_name_with_suffix
+from utility.utility import pod_exec
 
 
 class common_keywords:
@@ -34,3 +35,6 @@ class common_keywords:
         if to_str:
             return str(convert_size_to_bytes(size))
         return convert_size_to_bytes(size)
+
+    def pod_exec(self, pod_name, namespace, cmd):
+        return pod_exec(pod_name, namespace, cmd)

--- a/e2e/tests/regression/test_encrypted_volume.robot
+++ b/e2e/tests/regression/test_encrypted_volume.robot
@@ -10,6 +10,7 @@ Resource    ../keywords/storageclass.resource
 Resource    ../keywords/persistentvolumeclaim.resource
 Resource    ../keywords/deployment.resource
 Resource    ../keywords/workload.resource
+Resource    ../keywords/sharemanager.resource
 
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
@@ -23,6 +24,29 @@ Test Encrypted Volume Basic
     And Wait for volume of deployment 0 healthy
     And Write 100 MB data to file data.txt in deployment 0
     Then Check deployment 0 data in file data.txt is intact
+
+    When Scale down deployment 0 to detach volume
+    And Scale up deployment 0 to attach volume
+    And Wait for volume of deployment 0 healthy
+    And Wait for workloads pods stable    deployment 0
+    Then Check deployment 0 data in file data.txt is intact
+
+Test Encrypted RWX Volume Online Expansion
+    Given Create crypto secret
+    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWX    sc_name=longhorn-crypto    storage_size=50MiB
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Wait for volume of deployment 0 healthy
+    And Write 10 MB data to file data.txt in deployment 0
+    Then Check deployment 0 data in file data.txt is intact
+
+    When Expand deployment 0 volume to 100 MiB
+    Then Wait for deployment 0 volume size expanded
+    And Check deployment 0 pods did not restart
+    # Verify the actual disk size in the sharemanager pod.
+    # NOTE: For encrypted volumes, 16MiB is reserved for the encryption header.
+    # Therefore, a 100MiB requested volume will result in an 84MiB actual disk size.
+    And Assert encrypted disk size in sharemanager pod for deployment 0 is 84MiB
 
     When Scale down deployment 0 to detach volume
     And Scale up deployment 0 to attach volume


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#11121
longhorn/longhorn#11120

#### What this PR does / why we need it:
Add case `rwx encryption volume online expansion`

#### Special notes for your reviewer:
@COLDTURNIP 

#### Additional documentation or context

PR test log : https://ci.longhorn.io/job/private/job/longhorn-e2e-test/3676/robot/report/log.html
Here's how to execute test case:  `./run.sh -t "Test Encrypted RWX Volume Online Expansion"`
