### PR TITLE
fix(backup): add failed sub-string in BACKUP_TARGET_MESSAGES_INVALID

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -333,6 +333,7 @@ HOST_PROC_DIR = "/host/proc"
 BACKUP_TARGET_MESSAGE_EMPTY_URL = "backup target URL is empty"
 BACKUP_TARGET_MESSAGES_INVALID = ["failed to init backup target clients",
                                   "failed to list backup volumes in",
+                                  "failed to list system backups in",
                                   "error listing backup volume names"]
 
 FAILED_DELETING_REASONE = "FailedDeleting"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#11337

#### What this PR does / why we need it:

Add the sub-string "failed to list system backups in" into BACKUP_TARGET_MESSAGES_INVALID

#### Special notes for your reviewer:

#### Additional documentation or context
