### PR TITLE
test(robot): update test suite checksum_enabled_large_volume_with_multiple_rebuilding for new setting value

### DIFF
--- a/e2e/tests/negative/checksum_enabled_large_volume_with_multiple_rebuilding.robot
+++ b/e2e/tests/negative/checksum_enabled_large_volume_with_multiple_rebuilding.robot
@@ -26,7 +26,7 @@ Verify Large Volume Data Integrity During Replica Rebuilding with Recurring Jobs
     ...                - Delete a replica and wait for the replica rebuilding.
     ...                - Check volume data is intact
     Given Setting snapshot-data-integrity is set to enabled
-    And Setting snapshot-data-integrity-immediate-check-after-snapshot-creation is set to true
+    And Setting snapshot-data-integrity-immediate-check-after-snapshot-creation is set to {"v1":"true","v2":"true"}
     And Create volume 0 with    size=50Gi    numberOfReplicas=3    dataEngine=${DATA_ENGINE}
     And Attach volume 0 to node 1
     And Wait for volume 0 healthy
@@ -63,7 +63,7 @@ Compare Large Volume Rebuild Performance Before and After Enabling Snapshot Inte
     And Wait for volume 0 healthy
     
     When Setting snapshot-data-integrity is set to enabled
-    And Setting snapshot-data-integrity-immediate-check-after-snapshot-creation is set to true
+    And Setting snapshot-data-integrity-immediate-check-after-snapshot-creation is set to {"v1":"true","v2":"true"}
     And Create snapshot 0 of volume 0
     And Validate snapshot 0 is in volume 0 snapshot list
     # Longhorn creates a snapshot A (data size 30 GiB) without a checksum during the first rebuild.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #

#### What this PR does / why we need it:

update test suite `checksum_enabled_large_volume_with_multiple_rebuilding` for new setting `snapshot-data-integrity-immediate-check-after-snapshot-creation` value

#### Special notes for your reviewer:

#### Additional documentation or context
