### PR TITLE
ci: Force `Ubuntu` use `IPv4` for install dependency

### DIFF
--- a/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/ubuntu/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-apt-get update
-apt-get install -y nfs-common cryptsetup dmsetup samba linux-modules-extra-`uname -r`
+apt-get -o Acquire::ForceIPv4=true update
+apt-get -o Acquire::ForceIPv4=true install -y "linux-modules-extra-$(uname -r)"
+apt-get -o Acquire::ForceIPv4=true install -y nfs-common cryptsetup dmsetup samba
 
 systemctl stop multipathd.socket
 systemctl disable multipathd.socket


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11529

#### What this PR does / why we need it:

Force `Ubuntu` use `IPv4` for install dependency to avoid dependency install fail

#### Special notes for your reviewer:

Before the fix, v2 regression test case all failed
- https://ci.longhorn.io/job/private/job/longhorn-tests-regression/9226/

Use this fix, v2 test case worked properly with Ubuntu
- https://10.115.5.5/job/private/job/longhorn-tests-regression-experiment/16/

#### Additional documentation or context
