### PR TITLE
test(robot): fix unreachable sleep in waiting for system backup to be created

### DIFF
--- a/e2e/libs/recurringjob/crd.py
+++ b/e2e/libs/recurringjob/crd.py
@@ -111,6 +111,9 @@ class CRD(Base):
 
     def wait_for_systembackup_state(self, job_name, expected_state):
         for i in range(self.retry_count):
+
+            time.sleep(self.retry_interval)
+
             system_backup_list = filter_cr("longhorn.io", "v1beta2", "longhorn-system", "systembackups",
                                            label_selector=f"recurring-job.longhorn.io/system-backup={job_name}")
             try:
@@ -127,7 +130,6 @@ class CRD(Base):
             except Exception as e:
                 logging(f"Waiting for systembackup created by job {job_name} to reach state {expected_state} failed: {e}")
 
-            time.sleep(self.retry_interval)
         assert False, f"Waiting for systembackup created by job {job_name} to reach state {expected_state} failed"
 
     def assert_volume_backup_created(self, volume_name, job_name, retry_count=-1):

--- a/e2e/tests/regression/test_recurringjob.robot
+++ b/e2e/tests/regression/test_recurringjob.robot
@@ -16,6 +16,8 @@ Test Teardown    Cleanup test resources
 Test System Backup Recurring Job When volume-backup-policy is disabled
     [Tags]    recurring-job    system-backup-recurring-job
     Given Create volume 0 with    size=2Gi    numberOfReplicas=1    dataEngine=${DATA_ENGINE}
+    And Attach volume 0
+    And Wait for volume 0 healthy
     When Create system-backup recurringjob 0    parameters={"volume-backup-policy":"disabled"}
 
     Then Assert recurringjob 0 not created backup for volume 0
@@ -24,6 +26,8 @@ Test System Backup Recurring Job When volume-backup-policy is disabled
 Test System Backup Recurring Job When volume-backup-policy is if-not-present
     [Tags]    recurring-job    system-backup-recurring-job
     Given Create volume 0 with    size=2Gi    numberOfReplicas=1    dataEngine=${DATA_ENGINE}
+    And Attach volume 0
+    And Wait for volume 0 healthy
     When Create system-backup recurringjob 0    parameters={"volume-backup-policy":"if-not-present"}
 
     Then Assert recurringjob 0 created backup for volume 0


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/11533

#### What this PR does / why we need it:

Fix unreachable sleep in waiting for system backup to be created.
And attaching the volume before creates backups since allow-recurring-job-while-volume-detached is disabled by default

#### Special notes for your reviewer:

#### Additional documentation or context
