### PR TITLE
test(robot): fix failed v2 robot test cases

### DIFF
--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -347,14 +347,20 @@ Crash volume ${volume_id} replica processes
 Crash volume ${volume_id} replica process on node ${node_id}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     ${node_name} =    get_node_by_index    ${node_id}
-    ${crashed_replica_name} =     crash_node_replica_process    ${volume_name}    ${node_name}
-    Set Test Variable    ${crashed_replica_name}
+    ${original_replica_name} =     crash_node_replica_process    ${volume_name}    ${node_name}
+    Set Test Variable    ${original_replica_name}
+
+Record volume ${volume_id} replica name on node ${node_id}
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${node_name} =    get_node_by_index    ${node_id}
+    ${original_replica_name} =     get_replica_name_on_node    ${volume_name}    ${node_name}
+    Set Test Variable    ${original_replica_name}
 
 Check volume ${volume_id} crashed replica reused on node ${node_id}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     ${node_name} =    get_node_by_index    ${node_id}
     ${current_replica_name} =     get_replica_name_on_node    ${volume_name}    ${node_name}
-    Should Be Equal    ${crashed_replica_name}    ${current_replica_name}
+    Should Be Equal    ${original_replica_name}    ${current_replica_name}
 
 Wait volume ${volume_id} replica on node ${node_id} stopped
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}

--- a/e2e/tests/regression/test_basic.robot
+++ b/e2e/tests/regression/test_basic.robot
@@ -116,7 +116,7 @@ Test Strict Local Volume Disabled Revision Counter By Default
     And Volume 0 engine revisionCounterDisabled should be True
     And Volume 0 replica revisionCounterDisabled should be True
 
-V1 Replica Rebuilding
+Replica Rebuilding
     [Documentation]    -- Manual test plan --
     ...                1. Create and attach a volume.
     ...                2. Write a large amount of data to the volume.
@@ -136,7 +136,7 @@ V1 Replica Rebuilding
     ...                - the rebuilding progress in UI page looks good.
     ...                - the data content is correct after rebuilding.
     ...                - volume r/w works fine.
-    Given Create volume 0 with    size=10Gi    numberOfReplicas=3    dataEngine=v1
+    Given Create volume 0 with    size=10Gi    numberOfReplicas=3    dataEngine=${DATA_ENGINE}
     And Attach volume 0 to node 0
     And Wait for volume 0 healthy
 
@@ -145,7 +145,8 @@ V1 Replica Rebuilding
     And Disable node 1 scheduling
     And Disable node 1 default disk
 
-    When Crash volume 0 replica process on node 1
+    When Record volume 0 replica name on node 1
+    And Delete ${DATA_ENGINE} instance manager on node 1
     Then Wait volume 0 replica on node 1 stopped
     And Wait for volume 0 degraded
 

--- a/e2e/tests/regression/test_v2.robot
+++ b/e2e/tests/regression/test_v2.robot
@@ -85,33 +85,6 @@ Test V2 Snapshot
 
     And Check volume 0 data is data 1
 
-Test V2 Replica Rebuilding
-    Given Create volume 0 with    size=10Gi    numberOfReplicas=3    dataEngine=v2
-    And Attach volume 0 to node 0
-    And Wait for volume 0 healthy
-    And Write 1 GB data to volume 0
-
-    When Disable node 1 scheduling
-    And Disable disk block-disk scheduling on node 1
-    And Delete v2 instance manager on node 1
-
-    # for a v2 volume, when a replica process crashed or an instance manager deleted,
-    # the corresponding replica running state won't be set to false,
-    # but the replica will be directly deleted
-    Then Wait for volume 0 replica on node 1 to be deleted
-    And Wait for volume 0 degraded
-
-    When Enable disk block-disk scheduling on node 1
-    Then Check volume 0 kept in degraded
-
-    When Enable node 1 scheduling
-    # since the replica has been deleted, no replica will be reused on node 1
-    Then Wait until volume 0 replica rebuilding started on node 1
-    And Wait for volume 0 healthy
-
-    And Check volume 0 data is intact
-    And Check volume 0 works
-
 Degraded Volume Replica Rebuilding
     [Tags]    coretest
     Given Disable node 2 scheduling
@@ -284,7 +257,7 @@ Test V2 Instance Manager Deletion On Volume Attached Node With Inactivated Data 
     When Label node 2 with node.longhorn.io/disable-v2-data-engine=true
     And Delete v2 instance manager on node 2
     Then Check v2 instance manager is not running on node 2
-    And Check volume 0 kept in attaching
+    And Wait for volume 0 detached
 
     When Label node 2 with node.longhorn.io/disable-v2-data-engine-
     Then Check v2 instance manager is running on node 2


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix failed v2 robot test cases

(1) v2 replica rebuilding behavior has been aligned with v1. v2 volumes can reuse failed replica now. so merge v1/v2 replica rebuilding test cases into one.
(2) label v2 volume attached node with disable-v2-data-engine and delete the instance manager, the volume will be detached instead of stuck in attaching.

#### Special notes for your reviewer:

#### Additional documentation or context
