### PR TITLE
ci: fix SUSE_Trust_Root.crt not found error in airgap pipelines and support running appco pipeline on public jenkins

### DIFF
--- a/pipelines/appco/Jenkinsfile
+++ b/pipelines/appco/Jenkinsfile
@@ -76,7 +76,7 @@ node {
 
         try {
             stage ('fetch test images list') {
-                sh "cp ${CA_CERT_PATH} SUSE_Trust_Root.crt"
+                sh "cp ${CA_CERT_PATH} ./SUSE_Trust_Root.crt"
                 sh "pipelines/appco/scripts/build.sh"
                 sh """ docker run -itd --name fetch-test-images-${JOB_BASE_NAME}-${BUILD_NUMBER} \
                                         -v /var/run/docker.sock:/var/run/docker.sock \
@@ -84,6 +84,8 @@ node {
                                         --env TF_VAR_docker_hub_password=${REGISTRY_PASSWORD} \
                                         --env APPCO_USERNAME=${APPCO_USERNAME} \
                                         --env APPCO_PASSWORD=${APPCO_PASSWORD} \
+                                        --dns=10.113.53.53 \
+                                        --dns=10.113.53.54 \
                                         ${imageName}
                     """
 
@@ -125,7 +127,6 @@ node {
 
             if (params.AIR_GAP_INSTALLATION) {
                 stage('private registry build') {
-                    sh "cp ${CA_CERT_PATH} SUSE_Trust_Root.crt"
                     sh "airgap/scripts/build.sh"
                     sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
                                             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -136,6 +137,8 @@ node {
                                             --env TF_VAR_arch=${ARCH}\
                                             --env TF_VAR_registry_aws_instance_type=${registry_instance_type}\
                                             --env TF_VAR_appco_test="true"\
+                                            --dns=10.113.53.53 \
+                                            --dns=10.113.53.54 \
                                             airgap-${JOB_BASE_NAME}-${BUILD_NUMBER}
                     """
                 }
@@ -189,7 +192,6 @@ node {
                 echo "Using credentials: $CREDS_ID"
                 echo "Using registration code: $REGISTRATION_CODE_ID"
 
-                sh "cp ${CA_CERT_PATH} SUSE_Trust_Root.crt"
                 sh "pipelines/appco/scripts/build.sh"
                 sh """ docker run -itd --name ${JOB_BASE_NAME}-${BUILD_NUMBER} \
                                        --env LONGHORN_CHART_URI=${LONGHORN_CHART_URI} \
@@ -238,6 +240,8 @@ node {
                                        --env QASE_PROJECT=LH \
                                        --env APPCO_TEST="true" \
                                        --env LONGHORN_INSTALL_METHOD=${LONGHORN_INSTALL_METHOD} \
+                                       --dns=10.113.53.53 \
+                                       --dns=10.113.53.54 \
                                        ${envArgs} \
                                        ${imageName}
                 """

--- a/pipelines/helm/Jenkinsfile
+++ b/pipelines/helm/Jenkinsfile
@@ -30,6 +30,7 @@ node {
         usernamePassword(credentialsId: CREDS_ID, passwordVariable: 'AWS_SECRET_KEY', usernameVariable: 'AWS_ACCESS_KEY'),
         usernamePassword(credentialsId: 'DOCKER_CREDS', passwordVariable: 'REGISTRY_PASSWORD', usernameVariable: 'REGISTRY_USERNAME'),
         string(credentialsId: REGISTRATION_CODE_ID, variable: 'REGISTRATION_CODE'),
+        file(credentialsId: 'SUSE_INTERNAL_CA', variable: 'CA_CERT_PATH'),
     ]) {
 
         if (params.SEND_SLACK_NOTIFICATION) {
@@ -43,6 +44,7 @@ node {
             if (params.AIR_GAP_INSTALLATION) {
 
                 stage('airgap build') {
+                    sh "cp ${CA_CERT_PATH} ./SUSE_Trust_Root.crt"
                     sh "airgap/scripts/build.sh"
                     sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
                                            --env TF_VAR_longhorn_version=${LONGHORN_REPO_BRANCH} \

--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -47,6 +47,7 @@ node {
         string(credentialsId: 'AZURE_TENANT_ID', variable: 'AZURE_TENANT_ID'),
         string(credentialsId: 'AZURE_SUBSCRIPTION_ID', variable: 'AZURE_SUBSCRIPTION_ID'),
         string(credentialsId: 'QASE_TOKEN', variable: 'QASE_TOKEN'),
+        file(credentialsId: 'SUSE_INTERNAL_CA', variable: 'CA_CERT_PATH'),
     ]) {
 
         if (params.SEND_SLACK_NOTIFICATION) {
@@ -60,6 +61,7 @@ node {
             if (params.AIR_GAP_INSTALLATION) {
 
                 stage('airgap build') {
+                    sh "cp ${CA_CERT_PATH} ./SUSE_Trust_Root.crt"
                     sh "airgap/scripts/build.sh"
                     sh """ docker run -itd --name airgap-${JOB_BASE_NAME}-${BUILD_NUMBER} \
                                            --env TF_VAR_longhorn_version=${LONGHORN_REPO_BRANCH} \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix SUSE_Trust_Root.crt not found error in airgap pipelines and support running appco pipeline on public jenkins

(1) fix  SUSE_Trust_Root.crt not found error in helm/manifest airgap installation pipelines
(2) fix permission denied error when cp SUSE_Trust_Root.crt on public jenkins
(3) remove redundant cp of repeatedly copying SUSE_Trust_Root.crt from jenkins server to the same test build workspace
(4) add suse dns servers to be able to access registry.suse.de on public jenkins

#### Special notes for your reviewer:

#### Additional documentation or context
