### PR TITLE
test(robot): refine v2 test cases

### DIFF
--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -676,7 +676,7 @@ class CRD(Base):
             f"Expected volume {volume_name} setting {setting_name} is {value}, but it's {str(volume['spec'][setting_name])}"
 
     def trim_filesystem(self, volume_name, is_expect_fail=False):
-        return Rest(self).trim_filesystem(volume_name, is_expect_fail=is_expect_fail)
+        return Rest().trim_filesystem(volume_name, is_expect_fail=is_expect_fail)
 
     def update_offline_replica_rebuild(self, volume_name, rebuild_type):
         return Rest().update_offline_replica_rebuild(volume_name, rebuild_type)

--- a/e2e/tests/negative/node_reboot_with_different_anti_affinity.robot
+++ b/e2e/tests/negative/node_reboot_with_different_anti_affinity.robot
@@ -41,9 +41,6 @@ Power Off Node With Anti-Affinity Settings
     And Setting replica-disk-soft-anti-affinity is set to ${disk_affinity}
     And Setting replica-soft-anti-affinity is set to ${node_affinity}
     And Setting replica-zone-soft-anti-affinity is set to ${zone_affinity}
-    IF    "${DATA_ENGINE}" == "v2"
-        And Setting v2-data-engine-fast-replica-rebuilding is set to true
-    END
 
     Given Create volume 0 with    dataEngine=${DATA_ENGINE}
     And Attach volume 0 to node 0


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

refine v2 test cases:

(1) remove redundant volume constructor argument
(2) v2 fast replica rebuilding has been unified with the corresponding v1 setting and enabled by default

#### Special notes for your reviewer:

#### Additional documentation or context
