### PR TITLE
test(pytest/v2): update cronjob setting in test_snapshot to distinguish v1/v2 values

### DIFF
--- a/manager/integration/tests/test_snapshot.py
+++ b/manager/integration/tests/test_snapshot.py
@@ -286,7 +286,7 @@ def prepare_settings_for_snapshot_test(client, data_integrity, immediate_check, 
                                  for i in range(0, 30, period_in_minute)])
     hours = str(now.hour) + "," + str((now.hour + 1) % 24)
 
-    cronjob = f"{minutes} {hours} * * *"
+    cronjob = '{{"v1":"{0}","v2":"{0}"}}'.format(f"{minutes} {hours} * * *")
 
     snapshot_data_integrity_setting = SETTING_SNAPSHOT_DATA_INTEGRITY
     snapshot_fast_data_rebuild_enabled_setting = \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#11537

#### What this PR does / why we need it:

Avoid test case fail
```
AssertionError: expect update setting snapshot-data-integrity-cronjob to be 35,40,45,50,55,0 18,19 * * *, but it's {"v1":"35,40,45,50,55,0 18,19 * * *","v2":"35,40,45,50,55,0 18,19 * * *"}
```

#### Special notes for your reviewer:

Verified on my local env

#### Additional documentation or context
