### PR TITLE
test(robot): fix not all v2 volumes are detached before upgrading in prerelease check test case

### DIFF
--- a/e2e/tests/prerelease_checks.robot
+++ b/e2e/tests/prerelease_checks.robot
@@ -202,6 +202,8 @@ Pre-release Checks
         # upgrading Longhorn with attached v2 volumes is not allowed
         And Detach volume v2
         And Wait for volume v2 detached
+        And Delete pod vol-pod-bi-v2
+        And Wait for volume vol-bi-v2 detached
         And Scale down deployment deploy-v2-upgrade to detach volume
 
     END
@@ -386,6 +388,8 @@ Pre-release Checks
         And Check deployment deploy-v2-upgrade works
 
         # (4) check the data integrity of the volume with a backing image
+        When Create pod vol-pod-bi-v2 using volume vol-bi-v2
+        And Wait for pod vol-pod-bi-v2 running
         And Check file guests/catparrot.gif exists in pod vol-pod-bi-v2
         And Check pod vol-pod-bi-v2 data in file data.txt is intact
         And Check pod vol-pod-bi-v2 works


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix not all v2 volumes are detached before upgrading in prerelease check test case

#### Special notes for your reviewer:

#### Additional documentation or context
