### PR TITLE
ci: use alpine 3.19 instead of latest in air gap container

### DIFF
--- a/airgap/Dockerfile.setup
+++ b/airgap/Dockerfile.setup
@@ -1,4 +1,4 @@
-From alpine:latest
+FROM golang:1.23-alpine3.19
 
 ARG KUBECTL_VERSION=v1.30.0
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

Change air gap alpine version from latest to `3.19` to avoid OpenSSL library version mismatch

```
3.960 OpenSSL version mismatch. Built against 3050003f, you have 30500010
------

 [33m2 warnings found (use docker --debug to expand):
[0m - ConsistentInstructionCasing: Command 'From' should match the case of the command majority (uppercase) (line 1)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 11)
Dockerfile.setup:21
--------------------
  20 |     
  21 | >>> RUN wget -q https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl && \
  22 | >>>     mv kubectl /usr/local/bin/kubectl && \
  23 | >>>     chmod +x /usr/local/bin/kubectl  && \
  24 | >>>     wget -q https://github.com/rancher/rke/releases/download/$RKE_VERSION/rke_linux-amd64 && \
  25 | >>>     mv rke_linux-amd64 /usr/bin/rke && \
  26 | >>>     chmod +x /usr/bin/rke && \
  27 | >>>     wget -q [https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip](https://releases.hashicorp.com/terraform/$%7BTERRAFORM_VERSION%7D/terraform_$%7BTERRAFORM_VERSION%7D_linux_amd64.zip) && \
  28 | >>>     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
  29 | >>>     mv terraform /usr/bin/terraform && \
  30 | >>>     chmod +x /usr/bin/terraform && \
  31 | >>>     wget -q "[https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64](https://github.com/mikefarah/yq/releases/download/$%7BYQ_VERSION%7D/yq_linux_amd64)" && \
  32 | >>>     mv yq_linux_amd64 /usr/local/bin/yq && \
  33 | >>>     chmod +x /usr/local/bin/yq && \
  34 | >>>     apk add openssh-client ca-certificates git rsync bash curl jq docker && \
  35 | >>>     ssh-keygen -t rsa -b 4096 -N "" -f ~/.ssh/id_rsa
  36 |     
--------------------
```

https://ci.longhorn.io/job/private/job/longhorn-tests-regression/9597/console

#### Special notes for your reviewer:

#### Additional documentation or context
