### PR TITLE
ci: AppCo pipeline airgap supoort upgrade from dp.rancher.io

### DIFF
--- a/pipelines/appco/scripts/longhorn_helm_chart.sh
+++ b/pipelines/appco/scripts/longhorn_helm_chart.sh
@@ -13,7 +13,7 @@ set_secret_args() {
   if [[ "${AIR_GAP_INSTALLATION}" == true ]]; then
     if [[ "${chart_uri}" == "longhorn/longhorn" ]]; then
       FINAL_REGISTRY_URL="${REGISTRY_URL}"
-    elif [[ -z "${APPCO_LONGHORN_COMPONENT_REGISTRY}" ]]; then
+    elif [[ -z "${APPCO_LONGHORN_COMPONENT_REGISTRY}" || "${chart_uri}" == *"dp.apps.rancher.io"* ]]; then
       FINAL_REGISTRY_URL="${REGISTRY_URL}/dp.apps.rancher.io"
     else
       FINAL_REGISTRY_URL="${REGISTRY_URL}/${APPCO_LONGHORN_COMPONENT_REGISTRY}"


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #

#### What this PR does / why we need it:

During air gap installation, when the chart URI contains `dp.apps.rancher.io`, it should not be replaced by the `APPCO_LONGHORN_COMPONENT_REGISTRY` value.

#### Special notes for your reviewer:

#### Additional documentation or context
