### PR TITLE
ci: fix issues in rancher chart test pipeline

### DIFF
--- a/e2e/libs/longhorn_deploy/longhorn_deploy.py
+++ b/e2e/libs/longhorn_deploy/longhorn_deploy.py
@@ -30,6 +30,10 @@ class LonghornDeploy(Base):
             self.longhorn = LonghornArgocd()
 
     def uninstall(self, is_stable_version):
+        # for uninstall Longhorn by rancher
+        # the .terraform.lock.hcl file may need some time to sync
+        # otherwise the terraform destroy command may fail with Inconsistent dependency lock file error
+        time.sleep(60)
         logging(f"Uninstalling Longhorn")
         self.longhorn.uninstall(is_stable_version)
         logging(f"Uninstalled Longhorn")

--- a/pipelines/appco/Jenkinsfile
+++ b/pipelines/appco/Jenkinsfile
@@ -261,12 +261,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/appco/scripts/longhorn_setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/appco/scripts/download-support-bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${TF_VAR_tf_workspace}/../${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {                
                 sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-junit-report.xml ."
                 if(params.LONGHORN_UPGRADE_TEST) {
@@ -277,6 +271,13 @@ node {
                     summary = junit 'longhorn-test-junit-report.xml'
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/appco/scripts/download-support-bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${TF_VAR_tf_workspace}/../${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
+
         } catch (e) {
             currentBuild.result = "FAILED"
             throw e

--- a/pipelines/appco/scripts/download-support-bundle.sh
+++ b/pipelines/appco/scripts/download-support-bundle.sh
@@ -35,12 +35,17 @@ SUPPORT_BUNDLE_URL_RAW=$(run_curl_in_pod "${CURL_CMD}")
 SUPPORT_BUNDLE_URL=$(echo "$SUPPORT_BUNDLE_URL_RAW" | jq -r '.links.self + "/" + .name')
 
 SUPPORT_BUNDLE_READY=false
-while [[ ${SUPPORT_BUNDLE_READY} == false ]]; do
+MAX_RETRY=100
+RETRY=0
+while [[ ${SUPPORT_BUNDLE_READY} == false ]] && [[ ${RETRY} -lt ${MAX_RETRY} ]]; do
     PERCENT_RAW=$(run_curl_in_pod "curl -s -H 'Accept: application/json' ${SUPPORT_BUNDLE_URL}")
     PERCENT=$(echo "$PERCENT_RAW" | jq -r '.progressPercentage' || true)
     echo "${PERCENT}"
 
     if [[ ${PERCENT} == 100 ]]; then SUPPORT_BUNDLE_READY=true; fi
+
+    RETRY=$((RETRY+1))
+    sleep 3s
 done
 
 run_curl_in_pod "curl -sSLf ${SUPPORT_BUNDLE_URL}/download -o /tmp/support-bundle.zip"

--- a/pipelines/argocd/Jenkinsfile
+++ b/pipelines/argocd/Jenkinsfile
@@ -89,12 +89,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/argocd/scripts/longhorn-setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {
                 if (params.TEST_TYPE == 'robot') {
                     sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/log.html ."
@@ -115,6 +109,12 @@ node {
                     }
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
 
         } catch (e) {
             currentBuild.result = "FAILED"

--- a/pipelines/e2e/Jenkinsfile
+++ b/pipelines/e2e/Jenkinsfile
@@ -133,12 +133,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/e2e/scripts/longhorn-setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {
                 sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/log.html ."
                 sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/output.xml ."
@@ -153,6 +147,12 @@ node {
                     sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/junit_to_qase.py junit.xml ${BUILD_URL}"
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
 
         } catch (e) {
             currentBuild.result = "FAILED"

--- a/pipelines/fleet/Jenkinsfile
+++ b/pipelines/fleet/Jenkinsfile
@@ -88,12 +88,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/fleet/scripts/longhorn-setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {
                 if (params.TEST_TYPE == 'robot') {
                     sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/log.html ."
@@ -114,6 +108,12 @@ node {
                     }
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
 
         } catch (e) {
             currentBuild.result = "FAILED"

--- a/pipelines/flux/Jenkinsfile
+++ b/pipelines/flux/Jenkinsfile
@@ -89,12 +89,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/flux/scripts/longhorn-setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {
                 if (params.TEST_TYPE == 'robot') {
                     sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/log.html ."
@@ -115,6 +109,12 @@ node {
                     }
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
 
         } catch (e) {
             currentBuild.result = "FAILED"

--- a/pipelines/gke/Jenkinsfile
+++ b/pipelines/gke/Jenkinsfile
@@ -63,12 +63,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/gke/scripts/longhorn-setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/gke/scripts/download-support-bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {
                 sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-junit-report.xml ."
 
@@ -80,6 +74,12 @@ node {
                     summary = junit 'longhorn-test-junit-report.xml'
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/gke/scripts/download-support-bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
 
         } catch (e) {
             currentBuild.result = "FAILED"

--- a/pipelines/gke/scripts/download-support-bundle.sh
+++ b/pipelines/gke/scripts/download-support-bundle.sh
@@ -16,16 +16,21 @@ LH_FRONTEND_ADDR=`kubectl get svc -n longhorn-system longhorn-frontend -o json |
 
 JSON_PAYLOAD="{\"issueURL\": \"${SUPPORT_BUNDLE_ISSUE_DESC}\", \"description\": \"${SUPPORT_BUNDLE_ISSUE_DESC}\"}"
 
-CURL_CMD="curl -XPOST http://${LH_FRONTEND_ADDR}/v1/supportbundles -H 'Accept: application/json' -H 'Accept-Encoding: gzip, deflate' -d '"${JSON_PAYLOAD}"'"
+CURL_CMD="curl -s -XPOST http://${LH_FRONTEND_ADDR}/v1/supportbundles -H 'Accept: application/json' -H 'Accept-Encoding: gzip, deflate' -d '"${JSON_PAYLOAD}"'"
 
 SUPPORT_BUNDLE_URL=`kubectl exec -n longhorn-system svc/longhorn-frontend -- bash -c "${CURL_CMD}"  | jq -r '.links.self + "/" + .name'`
 
 SUPPORT_BUNDLE_READY=false
-while [[ ${SUPPORT_BUNDLE_READY} == false ]]; do
-    PERCENT=`kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -H 'Accept: application/json' ${SUPPORT_BUNDLE_URL} | jq -r '.progressPercentage' || true`
+MAX_RETRY=100
+RETRY=0
+while [[ ${SUPPORT_BUNDLE_READY} == false ]] && [[ ${RETRY} -lt ${MAX_RETRY} ]]; do
+    PERCENT=`kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -s -H 'Accept: application/json' ${SUPPORT_BUNDLE_URL} | jq -r '.progressPercentage' || true`
     echo ${PERCENT}
     
     if [[ ${PERCENT} == 100 ]]; then SUPPORT_BUNDLE_READY=true; fi
+
+    RETRY=$((RETRY+1))
+    sleep 3s
 done
 
 kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -H 'Accept-Encoding: gzip, deflate' ${SUPPORT_BUNDLE_URL}/download > ${SUPPORT_BUNDLE_FILE_NAME}

--- a/pipelines/helm/Jenkinsfile
+++ b/pipelines/helm/Jenkinsfile
@@ -135,12 +135,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/helm/scripts/longhorn-setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {
                 if (params.TEST_TYPE == 'robot') {
                     sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/log.html ."
@@ -161,6 +155,12 @@ node {
                     }
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
 
         } catch (e) {
             currentBuild.result = "FAILED"

--- a/pipelines/rancher/Jenkinsfile
+++ b/pipelines/rancher/Jenkinsfile
@@ -98,12 +98,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/rancher/scripts/longhorn-setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {
                 if (params.TEST_TYPE == 'robot') {
                     sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/log.html ."
@@ -124,6 +118,12 @@ node {
                     }
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/download_support_bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
 
         } catch (e) {
             currentBuild.result = "FAILED"

--- a/pipelines/rancher/scripts/longhorn-setup.sh
+++ b/pipelines/rancher/scripts/longhorn-setup.sh
@@ -11,6 +11,7 @@ source pipelines/utilities/create_instance_mapping_configmap.sh
 source pipelines/utilities/install_backupstores.sh
 source pipelines/utilities/create_longhorn_namespace.sh
 source pipelines/utilities/longhorn_rancher_chart.sh
+source pipelines/utilities/longhorn_ui.sh
 if [[ ${TEST_TYPE} == "robot" ]]; then
   source pipelines/utilities/run_longhorn_e2e_test.sh
 else
@@ -49,6 +50,8 @@ main(){
 
   if [[ "${LONGHORN_UPGRADE_TEST}" == true ]]; then
     install_longhorn_stable
+    setup_longhorn_ui_nodeport
+    export_longhorn_ui_url
     LONGHORN_UPGRADE_TEST_POD_NAME="longhorn-test-upgrade"
     if [[ ${TEST_TYPE} == "pytest" ]]; then
       run_longhorn_upgrade_test
@@ -56,6 +59,8 @@ main(){
     run_longhorn_test
   else
     install_longhorn_custom
+    setup_longhorn_ui_nodeport
+    export_longhorn_ui_url
     run_longhorn_test
   fi
 }

--- a/pipelines/storage_network/Jenkinsfile
+++ b/pipelines/storage_network/Jenkinsfile
@@ -99,12 +99,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/storage_network/scripts/longhorn-setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/storage_network/scripts/download-support-bundle.sh ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {
                 sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-junit-report.xml ."
 
@@ -116,6 +110,12 @@ node {
                     summary = junit 'longhorn-test-junit-report.xml'
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/storage_network/scripts/download-support-bundle.sh ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
 
         } catch (e) {
             currentBuild.result = "FAILED"

--- a/pipelines/storage_network/scripts/download-support-bundle.sh
+++ b/pipelines/storage_network/scripts/download-support-bundle.sh
@@ -22,11 +22,16 @@ CURL_CMD="curl -XPOST ${LONGHORN_CLIENT_URL}/v1/supportbundles -H 'Accept: appli
 SUPPORT_BUNDLE_URL=`kubectl exec -n longhorn-system svc/longhorn-frontend -- bash -c "${CURL_CMD}"  | jq -r '.links.self + "/" + .name'`
 
 SUPPORT_BUNDLE_READY=false
-while [[ ${SUPPORT_BUNDLE_READY} == false ]]; do
-    PERCENT=`kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -H 'Accept: application/json' ${SUPPORT_BUNDLE_URL} | jq -r '.progressPercentage' || true`
+MAX_RETRY=100
+RETRY=0
+while [[ ${SUPPORT_BUNDLE_READY} == false ]] && [[ ${RETRY} -lt ${MAX_RETRY} ]]; do
+    PERCENT=`kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -s -H 'Accept: application/json' ${SUPPORT_BUNDLE_URL} | jq -r '.progressPercentage' || true`
     echo ${PERCENT}
 
     if [[ ${PERCENT} == 100 ]]; then SUPPORT_BUNDLE_READY=true; fi
+
+    RETRY=$((RETRY+1))
+    sleep 3s
 done
 
 kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -H 'Accept-Encoding: gzip, deflate' ${SUPPORT_BUNDLE_URL}/download > ${SUPPORT_BUNDLE_FILE_NAME}

--- a/pipelines/utilities/download_support_bundle.sh
+++ b/pipelines/utilities/download_support_bundle.sh
@@ -14,16 +14,21 @@ export_longhorn_ui_url
 
 JSON_PAYLOAD="{\"issueURL\": \"${SUPPORT_BUNDLE_ISSUE_DESC}\", \"description\": \"${SUPPORT_BUNDLE_ISSUE_DESC}\"}"
 
-CURL_CMD="curl -XPOST ${LONGHORN_CLIENT_URL}/v1/supportbundles -H 'Accept: application/json' -H 'Accept-Encoding: gzip, deflate' -d '"${JSON_PAYLOAD}"'"
+CURL_CMD="curl -s -XPOST ${LONGHORN_CLIENT_URL}/v1/supportbundles -H 'Accept: application/json' -H 'Accept-Encoding: gzip, deflate' -d '"${JSON_PAYLOAD}"'"
 
 SUPPORT_BUNDLE_URL=`kubectl exec -n longhorn-system svc/longhorn-frontend -- bash -c "${CURL_CMD}"  | jq -r '.links.self + "/" + .name'`
 
 SUPPORT_BUNDLE_READY=false
-while [[ ${SUPPORT_BUNDLE_READY} == false ]]; do
-    PERCENT=`kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -H 'Accept: application/json' ${SUPPORT_BUNDLE_URL} | jq -r '.progressPercentage' || true`
+MAX_RETRY=100
+RETRY=0
+while [[ ${SUPPORT_BUNDLE_READY} == false ]] && [[ ${RETRY} -lt ${MAX_RETRY} ]]; do
+    PERCENT=`kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -s -H 'Accept: application/json' ${SUPPORT_BUNDLE_URL} | jq -r '.progressPercentage' || true`
     echo ${PERCENT}
-    
+
     if [[ ${PERCENT} == 100 ]]; then SUPPORT_BUNDLE_READY=true; fi
+
+    RETRY=$((RETRY+1))
+    sleep 3s
 done
 
 kubectl exec -n longhorn-system svc/longhorn-frontend -- curl -H 'Accept-Encoding: gzip, deflate' ${SUPPORT_BUNDLE_URL}/download > ${SUPPORT_BUNDLE_FILE_NAME}

--- a/pipelines/utilities/longhorn_rancher_chart.sh
+++ b/pipelines/utilities/longhorn_rancher_chart.sh
@@ -126,6 +126,10 @@ uninstall_longhorn() {
   fi
 }
 
+uninstall_longhorn_crd(){
+  helm uninstall --namespace=longhorn-system longhorn-crd
+}
+
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   if declare -f "$1" > /dev/null; then
     "$@"

--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -182,12 +182,6 @@ node {
                 sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/longhorn-setup.sh"
             }
 
-            stage ('download support bundle') {
-                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/download-support-bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
-                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${TF_VAR_tf_workspace}/../${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
-				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
-			}
-
             stage ('report generation') {
                 sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${WORKSPACE}/longhorn-test-junit-report.xml ."
 
@@ -203,6 +197,13 @@ node {
                     sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/junit_to_qase.py ${WORKSPACE}/longhorn-test-junit-report.xml ${BUILD_URL}"
                 }
             }
+
+            stage ('download support bundle') {
+                sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} ${TF_VAR_tf_workspace}/scripts/download-support-bundle.sh  ${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip"
+                sh "docker cp ${JOB_BASE_NAME}-${BUILD_NUMBER}:${TF_VAR_tf_workspace}/../${JOB_BASE_NAME}-${BUILD_NUMBER}-bundle.zip ."
+				archiveArtifacts allowEmptyArchive: true, artifacts: '**/*.zip', followSymlinks: false
+			}
+
         } catch (e) {
             currentBuild.result = "FAILED"
             throw e

--- a/test_framework/scripts/download-support-bundle.sh
+++ b/test_framework/scripts/download-support-bundle.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
-
 source test_framework/scripts/kubeconfig.sh
 source pipelines/utilities/longhorn_ui.sh
 
@@ -25,6 +23,7 @@ download_support_bundle(){
   # wait for support bundle url available
   SUPPORT_BUNDLE_URL_READY=false
   CURL_CMD="curl -s -GET ${LONGHORN_CLIENT_URL}/v1/supportbundles/${NODE_ID}/${NAME} -H 'Accept: application/json' -H 'Accept-Encoding: gzip, deflate'"
+  echo ${CURL_CMD}
   MAX_RETRY=100
   RETRY=0
   while [[ ${SUPPORT_BUNDLE_URL_READY} == false ]] && [[ ${RETRY} -lt ${MAX_RETRY} ]]; do


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/11853

#### What this PR does / why we need it:

fix issues in rancher chart test pipeline

(1) expose longhorn-ui node-port to download support bundles
(2) set max retry for downloading support bundles
(3) adjust workflow to publish test report before downloading support bundle so it won't be blocked by stucking downloading
(4) add wait_for_rancher_webhook in installing longhorn with `terraform apply` because `terraform apply` could accidentally fail due to rancher webhook not found
(5) wait 1 minute before uninstalling longhorn with `terraform destroy` because the dependent terraform.lock.hcl file may need some time to sync
(6) refine check_longhorn_crd_removed codeflow by adding wait mechanism and print more information
(7) manually uninstall longhorn-crd after uninstalling longhorn with `terraform destroy`

#### Special notes for your reviewer:

#### Additional documentation or context
