### PR TITLE
test(pytest): extend test_csi_snapshotter v2 volume test coverage

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -5237,7 +5237,8 @@ def create_and_wait_deployment(apps_api, deployment_manifest):
 
 
 def wait_and_get_any_deployment_pod(core_api, deployment_name,
-                                    is_phase="Running"):
+                                    is_phase="Running",
+                                    timeout_cnt=DEFAULT_DEPLOYMENT_TIMEOUT):
     """
     Add mechanism to wait for a stable running pod when deployment restarts its
     workload, since Longhorn manager could create/delete the new workload pod
@@ -5248,7 +5249,7 @@ def wait_and_get_any_deployment_pod(core_api, deployment_name,
     stable_pod = None
     wait_for_stable_retry = 0
 
-    for _ in range(DEFAULT_DEPLOYMENT_TIMEOUT):
+    for _ in range(timeout_cnt):
         label_selector = "name=" + deployment_name
         pods = core_api.list_namespaced_pod(namespace="default",
                                             label_selector=label_selector)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#11885

#### What this PR does / why we need it:

extend `test_csi_snapshotter` v2 volume test coverage

#### Special notes for your reviewer:

https://github.com/longhorn/longhorn/issues/9760#issuecomment-2538283018

test result of `test_csi_snapshotter.py`
- [v1](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/9632/)
- [v2](https://ci.longhorn.io/job/private/job/longhorn-tests-regression/9633/)

#### Additional documentation or context
