### PR TITLE
Update RKE2 CIS profile and add backupstore network policy

### DIFF
--- a/manager/integration/deploy/backupstores/backupstore-networkpolicy.yaml
+++ b/manager/integration/deploy/backupstores/backupstore-networkpolicy.yaml
@@ -1,0 +1,59 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  # Purpose: Allow ingress traffic to the NFS BackupStore
+  name: allow-backupstore-nfs-ingress
+  namespace: default
+spec:
+  # Target: Apply to pods with label app: longhorn-test-nfs
+  podSelector:
+    matchLabels:
+      app: longhorn-test-nfs
+  policyTypes:
+  - Ingress
+  ingress:
+  # Rule 1: Allow traffic from the longhorn-system namespace (Production Backup Traffic)
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: longhorn-system
+  # Rule 2: Allow traffic from the Test Client Pod within the SAME namespace (Test Traffic)
+  # Note: A podSelector without a namespaceSelector implies the current namespace.
+  - from:
+    - podSelector:
+        matchLabels:
+          longhorn-test: test-job  # Matches the specific label of the longhorn-test pod
+    ports:
+    - protocol: TCP
+      port: 2049 # NFS port
+    - protocol: TCP
+      port: 111  # RPCBind port
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  # Purpose: Allow ingress traffic to the MinIO BackupStore
+  name: allow-backupstore-minio-ingress
+  namespace: default
+spec:
+  # Target: Apply to pods with label app: longhorn-test-minio
+  podSelector:
+    matchLabels:
+      app: longhorn-test-minio
+  policyTypes:
+  - Ingress
+  ingress:
+  # Rule 1: Allow traffic from the longhorn-system namespace (Production Backup Traffic)
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: longhorn-system
+  # Rule 2: Allow traffic from the Test Client Pod within the SAME namespace (Test Traffic)
+  - from:
+    - podSelector:
+        matchLabels:
+          longhorn-test: test-job  # Matches the specific label of the longhorn-test pod
+    ports:
+    - protocol: TCP
+      port: 9000 # MinIO API port

--- a/pipelines/e2e/scripts/longhorn-setup.sh
+++ b/pipelines/e2e/scripts/longhorn-setup.sh
@@ -44,6 +44,7 @@ main(){
   create_instance_mapping_configmap
 
   install_backupstores
+  install_backupstores_networkpolicy
   setup_azurite_backup_store
   install_csi_snapshotter
   create_nad_without_storage_network

--- a/pipelines/helm/scripts/longhorn-setup.sh
+++ b/pipelines/helm/scripts/longhorn-setup.sh
@@ -41,6 +41,7 @@ main(){
 
   create_longhorn_namespace
   install_backupstores
+  install_backupstores_networkpolicy
   setup_azurite_backup_store
   install_csi_snapshotter
 

--- a/pipelines/rancher/scripts/longhorn-setup.sh
+++ b/pipelines/rancher/scripts/longhorn-setup.sh
@@ -35,6 +35,7 @@ main(){
 
   create_longhorn_namespace
   install_backupstores
+  install_backupstores_networkpolicy
   setup_azurite_backup_store
   install_csi_snapshotter
 

--- a/pipelines/storage_network/scripts/longhorn-setup.sh
+++ b/pipelines/storage_network/scripts/longhorn-setup.sh
@@ -58,6 +58,7 @@ main(){
 
   create_longhorn_namespace
   install_backupstores
+  install_backupstores_networkpolicy
   setup_azurite_backup_store
   install_csi_snapshotter
 

--- a/pipelines/utilities/install_backupstores.sh
+++ b/pipelines/utilities/install_backupstores.sh
@@ -77,6 +77,11 @@ setup_azurite_backup_store(){
   kubectl delete pod az-cli --ignore-not-found
 }
 
+install_backupstores_networkpolicy(){
+  BACKUPSTORE_NETWORK_POLICY_URL="https://raw.githubusercontent.com/longhorn/longhorn-tests/master/manager/integration/deploy/backupstores/backupstore-networkpolicy.yaml"
+  kubectl create -f ${BACKUPSTORE_NETWORK_POLICY_URL}
+}
+
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   if declare -f "$1" > /dev/null; then
     "$@"

--- a/test_framework/scripts/longhorn-setup.sh
+++ b/test_framework/scripts/longhorn-setup.sh
@@ -76,6 +76,7 @@ main(){
       fi
       setup_azurite_backup_store
   fi
+  install_backupstores_networkpolicy
   install_csi_snapshotter
   if [[ "${TF_VAR_enable_mtls}" == true ]]; then
     enable_mtls

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -84,7 +84,9 @@ EOF
     systemctl restart systemd-sysctl
     useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U
     cat << EOF >> /etc/rancher/rke2/config.yaml
-profile: "cis-1.23"
+profile: "cis"
+kube-apiserver-arg:
+  - 'service-account-extend-token-expiration=false'
 EOF
 fi
 

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_server.sh.tpl
@@ -62,7 +62,9 @@ EOF
     systemctl restart systemd-sysctl
     useradd -r -c "etcd user" -s /sbin/nologin -M etcd -U
     cat << EOF >> /etc/rancher/rke2/config.yaml
-profile: "cis-1.23"
+profile: "cis"
+kube-apiserver-arg:
+  - 'service-account-extend-token-expiration=false'
 EOF
 fi
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
- Add install_backupstores_networkpolicy function to install backupstore network policy
- Apply backupstore network policy in pipeline setup scripts (e2e, helm, rancher, storage_network)
- Update RKE2 CIS profile from 'cis-1.23' to 'cis' for latest CIS benchmark support

longhorn/longhorn#11672

#### What this PR does / why we need it:

#### Special notes for your reviewer:
Hi @yangchiu 
    Following up on our discussion last week, I've applied the specific cluster configuration (No CIS profile + Network Policy enabled) to the general regression tests.
Could you please review the changes?

#### Additional documentation or context
