### PR TITLE
test(robot): fix RWX strict-local incompatible volume test

### DIFF
--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -343,6 +343,7 @@ class CRD(Base):
             except Exception as e:
                 logging(f"Getting volume {volume_name} status error: {e}")
             time.sleep(self.retry_interval)
+        assert volume is not None, f"Failed to wait for {volume_name} {desired_state}: volume not found"
         assert volume["status"]["state"] == desired_state, f"Failed to wait for {volume_name} {desired_state}, currently it's {volume['status']['state']}"
 
     def wait_for_volume_attaching(self, volume_name):

--- a/e2e/tests/regression/test_volume.robot
+++ b/e2e/tests/regression/test_volume.robot
@@ -67,7 +67,7 @@ Test RWX Volume Without Migratable Should Be Incompatible With Strict-Local
     ...
     ...                Issue: https://github.com/longhorn/longhorn/issues/6735
 
-    When Create volume 0 with    numberOfReplicas=1    migratable=False    accessMode=RWX    dataLocality=strict-local    dataEngine=${DATA_ENGINE}
+    When Run Keyword And Expect Error    *    Create volume 0 with    numberOfReplicas=1    migratable=False    accessMode=RWX    dataLocality=strict-local    dataEngine=${DATA_ENGINE}    retry=False
     Then No volume created
 
 Test Volume Attached at Maximum Snapshot Count


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Observed during verification of https://github.com/longhorn/longhorn/issues/12316:
robot regression test case `Test RWX Volume Without Migratable Should Be Incompatible With Strict-Local` failed unexpectedly.
<img width="1286" height="387" alt="Screenshot_20260407_193930" src="https://github.com/user-attachments/assets/14e859d8-f4f7-48be-8ea4-d1ab25e8fc96" />


#### What this PR does / why we need it:
Use `Run Keyword And Expect Error` with `retry=False` so the webhook rejection is treated as expected instead of retrying for ~20 minutes.

Also add a None guard in `wait_for_volume_state` to produce a clear AssertionError instead of TypeError when the volume does not exist.


#### Special notes for your reviewer:

#### Additional documentation or context
