### PR TITLE
test(robot): DR volume support for v2 data engine

### DIFF
--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -600,9 +600,10 @@ Create volume ${volume_id} from backup ${backup_id} in another cluster
     create_volume   ${volume_name}    fromBackup=${backup_url}
 
 Create DR volume ${volume_id} from backup ${backup_id} in another cluster
+    [Arguments]    &{config}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     ${backup_url} =    get_backup_url_from_backup_list    ${backups_before_uninstall}    ${backup_id}
-    create_volume   ${volume_name}    frontend=    Standby=True    fromBackup=${backup_url}
+    create_volume   ${volume_name}    frontend=    Standby=True    fromBackup=${backup_url}    &{config}
 
 Wait for volume ${volume_id} restoration from backup ${backup_id} in another cluster completed
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -413,7 +413,8 @@ class CRD(Base):
             except Exception as e:
                 logging(f"Getting volume {volume} robustness error: {e}")
             time.sleep(self.retry_interval)
-        assert volume["status"]["robustness"] == desired_state
+        assert volume["status"]["robustness"] == desired_state, \
+            f"Failed to wait for {volume_name} robustness={desired_state}, currently it's {volume['status']['robustness']}"
 
     def wait_for_volume_robustness_not(self, volume_name, not_desired_state):
         volume = None

--- a/e2e/tests/negative/test_dr_volume.robot
+++ b/e2e/tests/negative/test_dr_volume.robot
@@ -17,6 +17,7 @@ Resource    ../keywords/workload.resource
 Resource    ../keywords/setting.resource
 Resource    ../keywords/storageclass.resource
 Resource    ../keywords/deployment.resource
+Resource    ../keywords/k8s.resource
 
 
 Test Setup    Set up test environment
@@ -127,7 +128,7 @@ Sync Up With Backup Target During DR Volume Activation
     Then Check pod 0 file version-info.txt has checksum d51dc42f616b67126fd2aa1e1f43385b
 
 Test DR Volume Live Upgrade And Rebuild
-    [Tags]    manual    negative    dr-volume    expansion    upgrade
+    [Tags]    expansion    upgrade
     [Documentation]    - Test DR volume live upgrade and rebuild
     ...                Related Issue:
     ...                https://github.com/longhorn/longhorn/issues/1279
@@ -298,3 +299,35 @@ Test DR Volume Incremental Restore After Source Volume Expansion
     Then Wait for pod 1 running
     And Check pod 1 file data0 checksum matches checksum 0
     And Check pod 1 file data1 checksum matches checksum 1
+
+Activate Degraded DR Volume With Failed Replica Node
+    [Documentation]    Test that a DR volume with a failed replica due to node power off
+    ...                can be activated and exits standby mode.
+    ...                Related Issue:
+    ...                https://github.com/longhorn/longhorn/issues/2107
+    ...                - Create a volume, write data, and take a backup.
+    ...                - Create a DR volume from the backup.
+    ...                - Wait for the DR volume initial restoration to complete.
+    ...                - Power off one of the DR volume's replica nodes.
+    ...                - Wait for the DR volume to become degraded due to the failed replica.
+    ...                - Activate the DR volume.
+    ...                - Verify the DR volume exits standby mode (detaches from standby).
+    ...                - Power on the replica node.
+    ...                - Attach the DR volume to a healthy node.
+    ...                - Wait for the DR volume to become healthy.
+    ...                - Verify the data is correct.
+    Given Create volume 0 with    dataEngine=${DATA_ENGINE}
+    And Attach volume 0
+    And Wait for volume 0 healthy
+    And Write data 0 to volume 0
+    Then Volume 0 backup 0 should be able to create
+    And Create DR volume 1 from backup 0 Of volume 0    dataEngine=${DATA_ENGINE}
+    And Wait for volume 1 restoration from backup 0 of volume 0 completed
+    When Power off volume 1 replica node
+    And Wait for volume 1 degraded
+    Then Activate DR volume 1
+    And Wait for volume 1 detached
+    When Power on off nodes
+    And Attach volume 1 to healthy node
+    And Wait for volume 1 healthy
+    Then Check volume 1 data is backup 0 of volume 0

--- a/e2e/tests/negative/uninstallation_checks.robot
+++ b/e2e/tests/negative/uninstallation_checks.robot
@@ -21,6 +21,7 @@ Test Teardown    Cleanup test resources
 
 *** Test Cases ***
 Uninstallation Checks
+    [Tags]    dr-volume
     [Documentation]    Uninstallation Checks
     ...    Prerequisites
     ...    - Have a setup of Longhorn installed on a kubernetes cluster.
@@ -60,9 +61,10 @@ Uninstallation Checks
 
     # Assume this is another Longhorn cluster
     Then Install Longhorn
+    And Enable v2 data engine and add block disks
     And Set default backupstore
     And Check backup synced from backupstore
-    When Create DR volume 0 from backup 0 in another cluster
+    When Create DR volume 0 from backup 0 in another cluster    dataEngine=${DATA_ENGINE}
     And Wait for volume 0 restoration from backup 0 in another cluster completed
     And Activate DR volume 0
     And Attach volume 0

--- a/e2e/tests/regression/test_backup.robot
+++ b/e2e/tests/regression/test_backup.robot
@@ -93,6 +93,7 @@ Test Backup Volume List
     And Delete backup volume 1
 
 Test Incremental Restore
+    [Tags]    dr-volume
     [Documentation]    Test restore from disaster recovery volume (incremental restore)
     Given Create volume 0 with    dataEngine=${DATA_ENGINE}
     And Attach volume 0
@@ -198,7 +199,6 @@ Test Backupstore With Existing Backups
     And Wait for system backup system-backup ready
 
 Backup Older Snapshot When Newer Snapshot Backup Exists
-    [Tags]    backup
     [Documentation]
     ...    This test verifies that a volume can successfully create a backup from
     ...    an older snapshot even after a newer snapshot had already been backed
@@ -219,6 +219,7 @@ Backup Older Snapshot When Newer Snapshot Backup Exists
     Then Verify backup list contains no error for volume 0
 
 Test DR Volume Backup Block Size
+    [Tags]    dr-volume
     [Documentation]
     ...    Verify the DR volume's backup block size should be always set from the latest backup.
     ...

--- a/e2e/tests/regression/test_system_backup.robot
+++ b/e2e/tests/regression/test_system_backup.robot
@@ -53,6 +53,7 @@ Test Uninstallation With System Backup
     Then Install Longhorn
 
 Test Create System Backup With DR Volume
+    [Tags]    dr-volume
     [Documentation]    Test create system backup with DR volume
     ...                Issue: https://github.com/longhorn/longhorn/issues/10239
     Given Create volume 0 with    dataEngine=${DATA_ENGINE}
@@ -62,6 +63,6 @@ Test Create System Backup With DR Volume
     And Create backup 0 for volume 0
     And Check snapshot for backup 0 of volume 0 exists True
 
-    When Create DR volume 1 from backup 0
+    When Create DR volume 1 from backup 0    dataEngine=${DATA_ENGINE}
     And Create system backup 0
     And Assert volume 1 remains attached for at least 60 seconds


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/6614

#### What this PR does / why we need it:
- Add `[Arguments] &{config}` to `Create DR Volume From Backup In Another Cluster` keyword to support passing dataEngine and other configs
- Pass `dataEngine=${DATA_ENGINE}` to DR volume creation keywords to enable v2 data engine support in DR volume test scenarios
- Add `[Tags] dr-volume` to DR volume related test cases for better test categorization and filtering

#### Special notes for your reviewer:

#### Additional documentation or context
https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#style