### PR TITLE
test(robot): add Backing image creation works with HTTP proxy enabled

### DIFF
--- a/e2e/keywords/backing_image.resource
+++ b/e2e/keywords/backing_image.resource
@@ -52,13 +52,16 @@ Delete backing image managers and wait for recreation
 Wait backing image managers running
     wait_all_backing_image_managers_running
 
-No backimg image data source pod exist
+No backing image data source pod exist
     ${ds_count}=     get_backing_image_data_source_pod_count
     Should Be Equal    ${ds_count}     ${0}
 
-Wait backimg image ${backing_image_name} data source pod created
+Wait backing image ${backing_image_name} data source pod created
     ${creation_time} =    wait_backing_image_data_source_pod_created    ${backing_image_name}
     [Return]    ${creation_time}
+
+Wait backing image ${backing_image_name} data source pod running
+    wait_backing_image_data_source_pod_running    ${backing_image_name}
 
 Wait backing image data source pod terminated
     wait_for_no_backing_image_data_source_pod_exist
@@ -108,7 +111,7 @@ Check downloaded backing image ${backing_image_name} data matches source backing
     ${bi_checksum} =  get_backing_image_checksum    ${backing_image_name}
     Should Be Equal    ${download_bi_checksum}    ${bi_checksum}
 
-Wait backimg image ${backing_image_name} download complete
+Wait backing image ${backing_image_name} download complete
     ${download_bi_checksum} =    wait_for_async_download_complete    ${backing_image_name}
     Set Test Variable    ${download_bi_checksum}
 

--- a/e2e/keywords/proxy.resource
+++ b/e2e/keywords/proxy.resource
@@ -1,0 +1,25 @@
+*** Settings ***
+Library    ../libs/keywords/proxy_keywords.py
+
+*** Keywords ***
+Deploy squid proxy server
+    [Documentation]    Deploy Squid proxy server
+    deploy_squid_proxy
+
+Remove squid proxy server
+    [Documentation]    Remove Squid proxy server
+    remove_squid_proxy
+
+Deploy Kyverno policy
+    [Documentation]    Install Kyverno v1.12.0 and deploy proxy injection policy
+    install_kyverno
+    deploy_kyverno_proxy_policy
+
+Remove Kyverno policy
+    [Documentation]    Remove proxy injection policy and uninstall Kyverno
+    remove_kyverno_proxy_policy
+    uninstall_kyverno
+
+Check backing image ${backing_image_name} data source pod has proxy env vars
+    ${result} =    verify_proxy_env_in_backing_image_data_source_pod    ${backing_image_name}
+    Should Be True    ${result}    Proxy env vars should be injected by Kyverno

--- a/e2e/libs/backing_image/backing_image.py
+++ b/e2e/libs/backing_image/backing_image.py
@@ -94,6 +94,16 @@ class BackingImage(Base):
             sleep(self.retry_interval)
         assert False, f"no data spice pod of {bi_name} created"
 
+    def wait_backing_image_data_source_pod_running(self, bi_name):
+        for i in range(self.retry_count):
+            data_source_pod = self.get_backing_image_data_source_pod(bi_name)
+            if len(data_source_pod) == 1:
+                pod_status = data_source_pod[0].status.phase
+                if pod_status == "Running":
+                    return True
+            sleep(self.retry_interval)
+        assert False, f"data source pod of {bi_name} is not running"
+
     def check_disk_file_map_contain_specific_message(self, bi_name, expected_message):
         return self.backing_image.check_disk_file_map_contain_specific_message(bi_name, expected_message)
 

--- a/e2e/libs/keywords/backing_image_keywords.py
+++ b/e2e/libs/keywords/backing_image_keywords.py
@@ -77,6 +77,9 @@ class backing_image_keywords:
         create_time = self.backing_image.wait_backing_image_data_source_pod_created(bi_name)
         return create_time
 
+    def wait_backing_image_data_source_pod_running(self, bi_name):
+        return self.backing_image.wait_backing_image_data_source_pod_running(bi_name)
+
     def wait_all_disk_file_status_are_at_state(self, bi_name, expected_state):
         self.backing_image.wait_all_disk_file_status_are_at_state(bi_name, expected_state)
 

--- a/e2e/libs/keywords/proxy_keywords.py
+++ b/e2e/libs/keywords/proxy_keywords.py
@@ -1,0 +1,227 @@
+from utility.utility import logging
+import utility.constant as constant
+import os
+import subprocess
+import time
+
+
+class proxy_keywords:
+
+    def __init__(self):
+        self.template_dir = os.path.join(os.path.dirname(__file__), "..", "..", "templates")
+
+    def deploy_squid_proxy(self):
+        """
+        Deploy Squid proxy server.
+        """
+        logging("Deploying Squid proxy server...")
+        proxy_manifest = os.path.join(self.template_dir, "proxy", "squid_proxy.yaml")
+
+        cmd = ["kubectl", "apply", "-f", proxy_manifest]
+
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            logging(f"Squid proxy deployment started: {result.stdout}")
+
+            # Wait for deployment to be ready
+            logging("Waiting for Squid proxy deployment to be ready...")
+            deployment_cmd = [
+                "kubectl", "wait", "--for=condition=available",
+                "deployment", "qa-squid",
+                "-n", "default",
+                "--timeout=120s"
+            ]
+            subprocess.run(deployment_cmd, check=True, capture_output=True, text=True)
+
+            # Wait for pod to be ready
+            logging("Waiting for Squid proxy pod to be ready...")
+            pod_cmd = [
+                "kubectl", "wait", "--for=condition=ready",
+                "pod", "-l", "app=qa-squid",
+                "-n", "default",
+                "--timeout=120s"
+            ]
+            subprocess.run(pod_cmd, check=True, capture_output=True, text=True)
+            logging("Squid proxy is ready")
+
+            return True
+        except subprocess.CalledProcessError as e:
+            logging(f"Failed to deploy Squid proxy: {e.stderr}")
+            raise
+
+    def remove_squid_proxy(self):
+        """
+        Remove Squid proxy server.
+        """
+        logging("Removing Squid proxy server...")
+        proxy_manifest = os.path.join(self.template_dir, "proxy", "squid_proxy.yaml")
+
+        cmd = ["kubectl", "delete", "-f", proxy_manifest, "--ignore-not-found=true"]
+
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            logging(f"Squid proxy removal completed: {result.stdout}")
+            return True
+        except subprocess.CalledProcessError as e:
+            logging(f"Failed to remove Squid proxy: {e.stderr}")
+            raise
+
+    def install_kyverno(self):
+        """
+        Install Kyverno policy engine if not already installed.
+        """
+        logging("Installing Kyverno...")
+        install_cmd = [
+            "kubectl", "create", "-f",
+            "https://github.com/kyverno/kyverno/releases/download/v1.12.0/install.yaml"
+        ]
+
+        try:
+            result = subprocess.run(install_cmd, check=True, capture_output=True, text=True)
+            logging(f"Kyverno installation started: {result.stdout}")
+
+            # Wait for Kyverno deployments to be ready
+            logging("Waiting for Kyverno deployments to be ready...")
+            deployment_cmd = [
+                "kubectl", "wait", "--for=condition=available",
+                "deployment", "--all",
+                "-n", "kyverno",
+                "--timeout=300s"
+            ]
+            subprocess.run(deployment_cmd, check=True, capture_output=True, text=True)
+
+            # Wait for all Kyverno pods to be running
+            logging("Waiting for all Kyverno pods to be ready...")
+            pod_cmd = [
+                "kubectl", "wait", "--for=condition=ready",
+                "pod", "--all",
+                "-n", "kyverno",
+                "--timeout=300s"
+            ]
+            subprocess.run(pod_cmd, check=True, capture_output=True, text=True)
+            logging("All Kyverno pods are ready")
+
+            return True
+        except subprocess.CalledProcessError as e:
+            logging(f"Failed to install Kyverno: {e.stderr}")
+            raise
+
+    def uninstall_kyverno(self):
+        """
+        Uninstall Kyverno deployment.
+        """
+        logging("Uninstalling Kyverno...")
+        uninstall_cmd = [
+            "kubectl", "delete", "-f",
+            "https://github.com/kyverno/kyverno/releases/download/v1.12.0/install.yaml",
+            "--ignore-not-found=true"
+        ]
+
+        try:
+            result = subprocess.run(uninstall_cmd, check=True, capture_output=True, text=True)
+            logging(f"Kyverno uninstallation completed: {result.stdout}")
+
+            # Wait for namespace deletion
+            logging("Waiting for Kyverno namespace deletion...")
+            wait_cmd = [
+                "kubectl", "wait", "--for=delete",
+                "namespace", "kyverno",
+                "--timeout=120s"
+            ]
+            subprocess.run(wait_cmd, capture_output=True, text=True)
+            logging("Kyverno namespace deleted")
+
+            return True
+        except subprocess.CalledProcessError as e:
+            logging(f"Failed to uninstall Kyverno: {e.stderr}")
+            raise
+
+    def deploy_kyverno_proxy_policy(self):
+        """
+        Deploy Kyverno ClusterPolicy to inject HTTP proxy environment variables                
+        """
+        logging("Deploying Kyverno proxy policy")
+
+        policy_manifest = os.path.join(self.template_dir, "proxy", "kyverno_proxy_policy.yaml")
+
+        cmd = ["kubectl", "apply", "-f", policy_manifest]
+
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            logging(f"Successfully deployed Kyverno proxy policy: {result.stdout}")
+
+            # Give Kyverno a moment to activate the policy
+            time.sleep(5)
+            return True
+        except subprocess.CalledProcessError as e:
+            logging(f"Failed to deploy Kyverno proxy policy: {e.stderr}")
+            raise
+
+    def remove_kyverno_proxy_policy(self):
+        """
+        Remove Kyverno ClusterPolicy for proxy injection.
+        """
+        logging("Removing Kyverno proxy policy")
+
+        policy_manifest = os.path.join(self.template_dir, "proxy", "kyverno_proxy_policy.yaml")
+
+        cmd = ["kubectl", "delete", "-f", policy_manifest, "--ignore-not-found=true"]
+
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            logging(f"Successfully removed Kyverno proxy policy: {result.stdout}")
+            return True
+        except subprocess.CalledProcessError as e:
+            logging(f"Failed to remove Kyverno proxy policy: {e.stderr}")
+            raise
+
+    def verify_proxy_env_in_backing_image_data_source_pod(self, backing_image_name):
+        """
+        Verify that HTTP_PROXY environment variables are injected into the backing image
+        data source pod by Kyverno.
+        """
+        logging(f"Verifying proxy environment variables in backing image {backing_image_name} data source pod")
+        
+        cmd = [
+            "kubectl", "-n", constant.LONGHORN_NAMESPACE,
+            "get", "pods",
+            "-l", f"longhorn.io/backing-image-data-source={backing_image_name}",
+            "-o", "jsonpath={.items[0].metadata.name}"
+        ]
+
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            pod_name = result.stdout.strip()
+
+            if not pod_name:
+                logging(f"No data source pod found for backing image {backing_image_name}")
+                return False
+
+            logging(f"Checking proxy env vars in pod: {pod_name}")
+            
+            env_cmd = [
+                "kubectl", "exec", "-n", constant.LONGHORN_NAMESPACE,
+                pod_name, "--", "env"
+            ]
+
+            env_result = subprocess.run(env_cmd, capture_output=True, text=True)
+            env_output = env_result.stdout
+
+            has_http_proxy = "HTTP_PROXY=" in env_output
+            has_https_proxy = "HTTPS_PROXY=" in env_output
+            has_no_proxy = "NO_PROXY=" in env_output
+
+            if has_http_proxy and has_https_proxy and has_no_proxy:
+                logging(f"Proxy env vars found in pod {pod_name}")
+                # Log the actual values
+                for line in env_output.split('\n'):
+                    if 'PROXY' in line:
+                        logging(f"  {line}")
+                return True
+            else:
+                logging(f"error: Proxy env vars NOT found in pod {pod_name}")
+                return False
+
+        except subprocess.CalledProcessError as e:
+            logging(f"Failed to verify proxy env vars: {e.stderr}")
+            return False

--- a/e2e/templates/proxy/kyverno_proxy_policy.yaml
+++ b/e2e/templates/proxy/kyverno_proxy_policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: inject-proxy-env-backing-image-ds
+spec:
+  background: false
+  rules:
+  - name: inject-proxy-env
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+          namespaces:
+          - longhorn-system
+    mutate:
+      patchStrategicMerge:
+        spec:
+          containers:
+          - (name): "*"
+            env:
+            - name: HTTP_PROXY
+              value: "http://qa-squid.default.svc.cluster.local:3128"
+            - name: HTTPS_PROXY
+              value: "http://qa-squid.default.svc.cluster.local:3128"
+            - name: NO_PROXY
+              value: "localhost,127.0.0.1,0.0.0.0,.svc,.cluster.local,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,longhorn-system,longhorn-backend,longhorn-backend.longhorn-system,longhorn-backend.longhorn-system.svc,longhorn-backend.longhorn-system.svc.cluster.local"

--- a/e2e/templates/proxy/squid_proxy.yaml
+++ b/e2e/templates/proxy/squid_proxy.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qa-squid
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qa-squid
+  template:
+    metadata:
+      labels:
+        app: qa-squid
+    spec:
+      containers:
+        - name: squid
+          image: ubuntu/squid:5.2-22.04_edge
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http-proxy
+              containerPort: 3128
+          readinessProbe:
+            tcpSocket:
+              port: 3128
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 3128
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qa-squid
+  namespace: default
+spec:
+  selector:
+    app: qa-squid
+  ports:
+    - name: http-proxy
+      port: 3128
+      targetPort: 3128
+  type: ClusterIP

--- a/e2e/tests/negative/backing_image_error_and_retry.robot
+++ b/e2e/tests/negative/backing_image_error_and_retry.robot
@@ -43,7 +43,7 @@ Backing image with an invalid URL schema
     And Wait backing image data source pod terminated
 
     FOR    ${i}    IN RANGE    3
-        ${recreation_time}=    Wait backimg image bi-test data source pod created
+        ${recreation_time}=    Wait backing image bi-test data source pod created
         Then Retry interval should match expected backoff window   ${recreation_time}    ${creation_time}    ${i}
         And Wait for all disk file status of backing image bi-test are failed
         And Wait for all disk file status of backing image bi-test are failed-and-cleanup

--- a/e2e/tests/negative/backing_image_with_http_proxy.robot
+++ b/e2e/tests/negative/backing_image_with_http_proxy.robot
@@ -1,0 +1,45 @@
+*** Settings ***
+Test Tags    regression    backing-image    proxy
+
+Resource    ../keywords/variables.resource
+Resource    ../keywords/common.resource
+Resource    ../keywords/volume.resource
+Resource    ../keywords/backing_image.resource
+Resource    ../keywords/proxy.resource
+
+Test Setup    Set up test environment
+Test Teardown    Cleanup test resources
+
+*** Keywords ***
+Setup proxy testing environment
+    Set up test environment
+    Deploy squid proxy server
+    Deploy Kyverno policy
+
+Cleanup proxy testing environment
+    Remove Kyverno policy
+    Remove squid proxy server
+    Cleanup test resources
+
+*** Test Cases ***
+Backing image creation works with HTTP proxy enabled
+    [Tags]    backing-image    proxy    regression
+    [Documentation]    Test for https://github.com/longhorn/longhorn/issues/12779
+    ...                Verify backing images can be created when HTTP_PROXY env vars are injected.
+    ...                Uses Kyverno to inject proxy env vars into backing image data source pods.
+
+    [Setup]    Setup proxy testing environment
+    [Teardown]    Cleanup proxy testing environment
+    Given Create backing image bi-test    url=https://cchien-backing-image.s3.us-west-1.amazonaws.com/400MB.qcow2    minNumberOfCopies=3    wait=False
+    When Wait backing image bi-test data source pod running
+    And Check backing image bi-test data source pod has proxy env vars
+    When Wait for all disk file status of backing image bi-test are ready
+    Then Verify all disk file status of backing image bi-test are ready
+
+    When Create volume 0 with    backingImage=bi-test    numberOfReplicas=3
+    And Attach volume 0 to node 0
+    And Wait for volume 0 healthy
+
+    Then Detach volume 0
+    And Delete volume 0
+    And Delete backing image bi-test

--- a/e2e/tests/negative/upgrade_with_backing_image.robot
+++ b/e2e/tests/negative/upgrade_with_backing_image.robot
@@ -139,7 +139,7 @@ System upgrade with the same backing image manager image
 
     FOR    ${i}    IN RANGE    10
         When Delete Longhorn DaemonSet longhorn-manager pod on all nodes simultaneously
-        And No backimg image data source pod exist
+        And No backing image data source pod exist
         Then Wait for Longhorn components all running
         And Wait for all disk file status of backing image bi are ready
     END

--- a/e2e/tests/regression/test_backing_image.robot
+++ b/e2e/tests/regression/test_backing_image.robot
@@ -165,7 +165,7 @@ Test Node ID Change During Backing Image Creation
     And Enable node 0 scheduling
     And Unevict evicted nodes
 
-    When Wait backimg image bi-large download complete
+    When Wait backing image bi-large download complete
     Then Check backing image bi-large download file checksum matches
     And Any app=longhorn-manager Pods Log Should Not Have but the pod became not ready After Test Start
 

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -5912,9 +5912,9 @@ def recurring_job_feature_supported(client):
 # - v2 backing images are not supported before v1.8.
 def v2_data_engine_cr_supported(client):
     longhorn_version = client.by_id_setting('current-longhorn-version').value
-    version_doesnt_support_v2_backimg_image = ['v1.5', 'v1.6', 'v1.7']
+    version_doesnt_support_v2_backing_image = ['v1.5', 'v1.6', 'v1.7']
     if any(_version in longhorn_version for
-           _version in version_doesnt_support_v2_backimg_image):
+           _version in version_doesnt_support_v2_backing_image):
         print(f'{longhorn_version} doesn\'t support v2 cr for test')
         return False
     else:


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#12782

#### What this PR does / why we need it:

- Deploy Kyverno and its policy with the fake proxy `proxy.example.com:3128`. If internet access is needed later, we may need to install a real proxy. For backing image download testing, adding `.amazonaws.com` to `NO_PROXY` is sufficient for the current test scope.
- Update typo

https://10.115.5.5/job/private/job/longhorn-e2e-test/256/

#### Special notes for your reviewer:

#### Additional documentation or context
