### PR TITLE
test(robot): add engine-image liveness probe setting test cases

### DIFF
--- a/e2e/keywords/engine_image.resource
+++ b/e2e/keywords/engine_image.resource
@@ -1,7 +1,9 @@
 *** Settings ***
 Documentation       Longhorn engine image related keywords
 
+Library             String
 Library             ../libs/keywords/engine_image_keywords.py
+Resource            workload.resource
 
 *** Keywords ***
 Create compatible engine image
@@ -10,3 +12,11 @@ Create compatible engine image
 
 Wait to engine image ${custom_engine_image} to be deployed
     wait_for_engine_image_deployed    ${custom_engine_image}
+
+Wait for engine image daemonset pods recreated
+    ${output}=    Run Command And Get Output
+    ...    kubectl -n longhorn-system get ds -l longhorn.io/component=engine-image --no-headers -o custom-columns=NAME:.metadata.name
+    @{ds_names}=    Split To Lines    ${output}
+    FOR    ${ds_name}    IN    @{ds_names}
+        Wait for daemonset ${ds_name} pods recreated    namespace=longhorn-system
+    END

--- a/e2e/keywords/workload.resource
+++ b/e2e/keywords/workload.resource
@@ -425,6 +425,7 @@ Check ${workload_kind} ${workload_id} pods not recreated
 Rollout restart ${workload_kind} ${workload_id} in namespace ${namespace}
     ${workload_name} =    generate_name_with_suffix    ${workload_kind}    ${workload_id}
     rollout_restart_workload    ${workload_kind}    ${workload_name}    ${namespace}
+
 Volume of ${workload_kind} ${workload_id} actual size should be less than ${size}
     ${workload_name} =    generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${volume_name} =    get_workload_volume_name    ${workload_name}

--- a/e2e/tests/regression/test_settings.robot
+++ b/e2e/tests/regression/test_settings.robot
@@ -16,6 +16,7 @@ Resource    ../keywords/sharemanager.resource
 Resource    ../keywords/storageclass.resource
 Resource    ../keywords/workload.resource
 Resource    ../keywords/snapshot.resource
+Resource    ../keywords/engine_image.resource
 
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
@@ -59,6 +60,23 @@ Verify TooManySnapshots Condition After Creating Snapshots
     And Run command and not expect output
     ...    kubectl get volume -n ${LONGHORN_NAMESPACE} ${volume_name} -o jsonpath='{.status.conditions[?(@.type=="TooManySnapshots")].message}'
     ...    at or over the warning threshold
+
+All engine image daemonset should have liveness probe settings
+    [Arguments]    ${timeout}    ${period}    ${failure_threshold}
+    ${count}=    Run Command And Get Output
+    ...    kubectl -n longhorn-system get ds -l longhorn.io/component=engine-image --no-headers | wc -l
+    ${count}=    Convert To Integer    ${count}
+    FOR    ${index}    IN RANGE    ${count}
+        Run command and wait for output
+        ...    kubectl -n longhorn-system get ds -l longhorn.io/component=engine-image -o jsonpath='{.items[${index}].spec.template.spec.containers[0].livenessProbe.timeoutSeconds}'
+        ...    ${timeout}
+        Run command and wait for output
+        ...    kubectl -n longhorn-system get ds -l longhorn.io/component=engine-image -o jsonpath='{.items[${index}].spec.template.spec.containers[0].livenessProbe.periodSeconds}'
+        ...    ${period}
+        Run command and wait for output
+        ...    kubectl -n longhorn-system get ds -l longhorn.io/component=engine-image -o jsonpath='{.items[${index}].spec.template.spec.containers[0].livenessProbe.failureThreshold}'
+        ...    ${failure_threshold}
+    END
 
 *** Test Cases ***
 Test Setting Update With Valid Value
@@ -291,3 +309,145 @@ Test Setting Read Only Setting Should Fail
     ...                Issue: https://github.com/longhorn/longhorn/issues/5989
     ...                1. Modified setting current-longhorn-version to v1.12.0-invalid should fail
     When Set setting current-longhorn-version to v1.12.0-invalid will fail
+
+Test Engine Image Liveness Probe Default Values
+    [Tags]    setting    engine-image
+    [Documentation]    Verify engine-image liveness probe settings exist with correct default values.
+    ...                Issue: https://github.com/longhorn/longhorn/issues/12846
+    When Setting engine-image-pod-liveness-probe-timeout should be 4
+    And Setting engine-image-pod-liveness-probe-period should be 5
+    And Setting engine-image-pod-liveness-probe-failure-threshold should be 3
+    Then All engine image daemonset should have liveness probe settings
+    ...    timeout=4
+    ...    period=5
+    ...    failure_threshold=3
+
+Test Engine Image Liveness Probe DaemonSet Auto Update
+    [Tags]    setting    engine-image
+    [Documentation]    Verify DaemonSet liveness probe values are updated after patching settings.
+    ...                Issue: https://github.com/longhorn/longhorn/issues/12846
+    When Setting engine-image-pod-liveness-probe-timeout is set to 15
+    And Setting engine-image-pod-liveness-probe-period is set to 30
+    And Setting engine-image-pod-liveness-probe-failure-threshold is set to 10
+    And Wait for engine image daemonset pods recreated
+    Then All engine image daemonset should have liveness probe settings
+    ...    timeout=15
+    ...    period=30
+    ...    failure_threshold=10
+    And Run command and expect output
+    ...    kubectl -n longhorn-system get pod -l longhorn.io/component=engine-image -o jsonpath='{range .items[*]}{.status.containerStatuses[0].restartCount}{"\n"}{end}'
+    ...    0
+
+Test Engine Image Liveness Probe Invalid Value Rejection
+    [Tags]    setting    engine-image
+    [Documentation]    Verify that invalid values for liveness probe settings are rejected.
+    ...                Issue: https://github.com/longhorn/longhorn/issues/12846
+    When Set setting engine-image-pod-liveness-probe-period to -1 will fail
+    And Set setting engine-image-pod-liveness-probe-timeout to 0 will fail
+    And Set setting engine-image-pod-liveness-probe-failure-threshold to abc will fail
+    Then All engine image daemonset should have liveness probe settings
+    ...    timeout=4
+    ...    period=5
+    ...    failure_threshold=3
+
+Test Engine Image Liveness Probe Multiple Engine Images
+    [Tags]    setting    engine-image
+    [Documentation]    Verify all engine-image DaemonSets are updated consistently when probe settings change.
+    ...                Issue: https://github.com/longhorn/longhorn/issues/12846
+    Given Create compatible engine image
+    When Setting engine-image-pod-liveness-probe-timeout is set to 15
+    And Setting engine-image-pod-liveness-probe-period is set to 30
+    And Setting engine-image-pod-liveness-probe-failure-threshold is set to 10
+    And Wait for engine image daemonset pods recreated
+    Then All engine image daemonset should have liveness probe settings
+    ...    timeout=15
+    ...    period=30
+    ...    failure_threshold=10
+
+Test Engine Image Liveness Probe Install With Custom Values
+    [Tags]    setting    engine-image    uninstall
+    [Documentation]    - Verify that engine-image liveness probe settings can be configured
+    ...                  via Helm chart defaultSettings or manifest default-setting.yaml at install time.
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/12846
+    ...                - Test steps:
+    ...                - 1. Uninstall Longhorn and verify all CRDs removed.
+    ...                - 2. Install Longhorn with custom probe values (timeout=15, period=30, failureThreshold=10).
+    ...                  For helm: set via defaultSettings.engineImagePodLivenessProbeTimeout/Period/FailureThreshold.
+    ...                  For manifest: append to default-setting.yaml in longhorn.yaml ConfigMap.
+    ...                - 3. Wait for Longhorn ready.
+    ...                - 4. Assert setting values = 15, 30, 10.
+    ...                - 5. Assert DaemonSet liveness probe values = 15, 30, 10.
+
+    Given Setting deleting-confirmation-flag is set to true
+    And Uninstall Longhorn
+    And Check all Longhorn CRD removed
+
+    ${LONGHORN_INSTALL_METHOD} =    Get Environment Variable    LONGHORN_INSTALL_METHOD    default=manifest
+    IF    '${LONGHORN_INSTALL_METHOD}' == 'helm'
+        ${patch} =    Set Variable
+        ...    .defaultSettings.engineImagePodLivenessProbeTimeout = 15 | .defaultSettings.engineImagePodLivenessProbePeriod = 30 | .defaultSettings.engineImagePodLivenessProbeFailureThreshold = 10
+        ${helm_cmd} =    Set Variable    yq eval '${patch}' ${LONGHORN_REPO_DIR}/chart/values.yaml > values.yaml
+        Install Longhorn    custom_cmd=${helm_cmd}
+    ELSE
+        ${manifest_cmd} =    Set Variable
+        ...    sed -i "/default-setting\\.yaml: |-/a\\${SPACE * 4}engine-image-pod-liveness-probe-failure-threshold: 10" longhorn.yaml && sed -i "/default-setting\\.yaml: |-/a\\${SPACE * 4}engine-image-pod-liveness-probe-period: 30" longhorn.yaml && sed -i "/default-setting\\.yaml: |-/a\\${SPACE * 4}engine-image-pod-liveness-probe-timeout: 15" longhorn.yaml
+        Install Longhorn    custom_cmd=${manifest_cmd}
+    END
+
+    Then Wait for longhorn ready
+    And Setting engine-image-pod-liveness-probe-timeout should be 15
+    And Setting engine-image-pod-liveness-probe-period should be 30
+    And Setting engine-image-pod-liveness-probe-failure-threshold should be 10
+    And All engine image daemonset should have liveness probe settings
+    ...    timeout=15
+    ...    period=30
+    ...    failure_threshold=10
+
+Test Engine Image Liveness Probe Upgrade With Custom Values
+    [Tags]    setting    engine-image    uninstall
+    [Documentation]    - Verify that engine-image liveness probe settings can be configured
+    ...                  via Helm chart defaultSettings or manifest default-setting.yaml at upgrade time.
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/12846
+    ...                - Test steps:
+    ...                - 1. Uninstall Longhorn and install stable version (without liveness probe settings).
+    ...                - 2. Upgrade Longhorn with custom probe values (timeout=15, period=30, failureThreshold=10).
+    ...                  For helm: set via defaultSettings.engineImagePodLivenessProbeTimeout/Period/FailureThreshold.
+    ...                  For manifest: append to default-setting.yaml in longhorn.yaml ConfigMap.
+    ...                - 3. Wait for Longhorn ready.
+    ...                - 4. Assert setting values = 15, 30, 10.
+    ...                - 5. Assert DaemonSet liveness probe values = 15, 30, 10.
+
+    ${LONGHORN_STABLE_VERSION}=    Get Environment Variable    LONGHORN_STABLE_VERSION    default=''
+    IF    '${LONGHORN_STABLE_VERSION}' == ''
+        Skip    LONGHORN_STABLE_VERSION not set - required for upgrade test
+    END
+
+    # Precondition: Set up environment and install Longhorn
+    Given Setting deleting-confirmation-flag is set to true
+    And Uninstall Longhorn
+    And Check Longhorn CRD removed
+
+    When Install Longhorn stable version
+    And Set default backupstore
+    And Enable v2 data engine and add block disks
+
+    ${LONGHORN_INSTALL_METHOD} =    Get Environment Variable    LONGHORN_INSTALL_METHOD    default=manifest
+    IF    '${LONGHORN_INSTALL_METHOD}' == 'helm'
+        ${patch} =    Set Variable
+        ...    .defaultSettings.engineImagePodLivenessProbeTimeout = 15 | .defaultSettings.engineImagePodLivenessProbePeriod = 30 | .defaultSettings.engineImagePodLivenessProbeFailureThreshold = 10
+        ${helm_cmd} =    Set Variable    yq eval '${patch}' ${LONGHORN_REPO_DIR}/chart/values.yaml > values.yaml
+        Upgrade Longhorn to custom version    custom_cmd=${helm_cmd}
+    ELSE
+        ${manifest_cmd} =    Set Variable
+        ...    sed -i "/default-setting\\.yaml: |-/a\\${SPACE * 4}engine-image-pod-liveness-probe-failure-threshold: 10" longhorn.yaml && sed -i "/default-setting\\.yaml: |-/a\\${SPACE * 4}engine-image-pod-liveness-probe-period: 30" longhorn.yaml && sed -i "/default-setting\\.yaml: |-/a\\${SPACE * 4}engine-image-pod-liveness-probe-timeout: 15" longhorn.yaml
+        Upgrade Longhorn to custom version    custom_cmd=${manifest_cmd}
+    END
+
+    Then Wait for longhorn ready
+    And Setting engine-image-pod-liveness-probe-timeout should be 15
+    And Setting engine-image-pod-liveness-probe-period should be 30
+    And Setting engine-image-pod-liveness-probe-failure-threshold should be 10
+    Then All engine image daemonset should have liveness probe settings
+    ...    timeout=15
+    ...    period=30
+    ...    failure_threshold=10


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Ref. longhorn/longhorn#12914

#### What this PR does / why we need it:
settings introduced in longhorn/longhorn#12846:
  - engine-image-pod-liveness-probe-timeout (default: 4)
  - engine-image-pod-liveness-probe-period (default: 5)
  - engine-image-pod-liveness-probe-failure-threshold (default: 3)

Six test cases are added to test_settings.robot:

- Default Values: verify settings exist with correct defaults and that the engine-image DaemonSet reflects those values on a fresh install.
- DaemonSet Auto Update: verify that changing the settings triggers a DaemonSet rollout and pods do not restart unexpectedly.
- Invalid Value Rejection: verify that out-of-range or non-integer values are rejected and the DaemonSet remains unchanged.
- Multiple Engine Images: verify all engine-image DaemonSets are updated consistently when a second engine image is present.
- Install With Custom Values: uninstall and reinstall Longhorn with custom probe values via helm defaultSettings or manifest default-setting.yaml, then assert settings and DaemonSet match.
- Upgrade With Custom Values: install stable version, upgrade with custom probe values, then assert settings and DaemonSet reflect the new values after upgrade.



#### Special notes for your reviewer:

#### Additional documentation or context
