### PR TITLE
test: revert aws instance type to the lower-cost t2.xlarge

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -76,7 +76,11 @@ Set disk path based on host provider and architecture
     ${HOST_PROVIDER}=    Get Environment Variable    HOST_PROVIDER    vagrant
     ${ARCH}=    Get Environment Variable    ARCH    amd64
     IF    "${HOST_PROVIDER}" == "aws"
-        Set Test Variable    ${DISK_PATH}    0000:00:1f.0
+        IF    "${ARCH}" == "amd64"
+            Set Test Variable    ${DISK_PATH}    /dev/xvdh
+        ELSE IF    "${ARCH}" == "arm64"
+            Set Test Variable    ${DISK_PATH}    0000:00:1f.0
+        END
     ELSE IF    '${HOST_PROVIDER}' == "harvester"
         Set Test Variable    ${DISK_PATH}    /dev/vdc
     ELSE IF    '${HOST_PROVIDER}' == "vagrant"

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -89,7 +89,10 @@ ISCSI_DEV_PATH = "/dev/disk/by-path"
 ISCSI_PROCESS = "iscsid"
 
 if os.environ.get("CLOUDPROVIDER") == "aws":
-    BLOCK_DEV_PATH = "0000:00:1f.0"
+    if os.uname().machine == "x86_64":
+        BLOCK_DEV_PATH = "/dev/xvdh"
+    else:
+        BLOCK_DEV_PATH = "0000:00:1f.0"
 elif os.environ.get("CLOUDPROVIDER") == "harvester":
     BLOCK_DEV_PATH = "/dev/vdc"
 elif os.environ.get("CLOUDPROVIDER") == "vagrant":

--- a/pipelines/storage_network/terraform/variables.tf
+++ b/pipelines/storage_network/terraform/variables.tf
@@ -46,8 +46,8 @@ variable "aws_instance_count" {
 
 variable "aws_instance_type" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "aws_ssh_public_key_file_path" {

--- a/test_framework/terraform/aws/eks/main.tf
+++ b/test_framework/terraform/aws/eks/main.tf
@@ -122,7 +122,7 @@ resource "aws_eks_node_group" "node_group" {
   capacity_type  = "ON_DEMAND"
   # For Arm-based instances, Amazon Linux 2023 (AL2023) only supports instance types that use Graviton2 or later processors.
   # AL2023 doesn’t support A1 instances.
-  instance_types = [var.arch == "amd64" ? "t3.xlarge" : "t4g.xlarge"]
+  instance_types = [var.arch == "amd64" ? "t2.xlarge" : "t4g.xlarge"]
   disk_size      = var.block_device_size_worker
   scaling_config {
     desired_size = 3

--- a/test_framework/terraform/aws/oracle/variables.tf
+++ b/test_framework/terraform/aws/oracle/variables.tf
@@ -56,14 +56,14 @@ variable "lh_aws_instance_name_controlplane" {
 
 variable "lh_aws_instance_type_controlplane" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "lh_aws_instance_type_worker" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "block_device_size_controlplane" {

--- a/test_framework/terraform/aws/rhel/variables.tf
+++ b/test_framework/terraform/aws/rhel/variables.tf
@@ -56,14 +56,14 @@ variable "lh_aws_instance_name_controlplane" {
 
 variable "lh_aws_instance_type_controlplane" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "lh_aws_instance_type_worker" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "block_device_size_controlplane" {

--- a/test_framework/terraform/aws/rockylinux/variables.tf
+++ b/test_framework/terraform/aws/rockylinux/variables.tf
@@ -56,14 +56,14 @@ variable "lh_aws_instance_name_controlplane" {
 
 variable "lh_aws_instance_type_controlplane" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "lh_aws_instance_type_worker" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "block_device_size_controlplane" {

--- a/test_framework/terraform/aws/sle-micro/variables.tf
+++ b/test_framework/terraform/aws/sle-micro/variables.tf
@@ -56,14 +56,14 @@ variable "lh_aws_instance_name_controlplane" {
 
 variable "lh_aws_instance_type_controlplane" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "lh_aws_instance_type_worker" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "block_device_size_controlplane" {

--- a/test_framework/terraform/aws/sles/variables.tf
+++ b/test_framework/terraform/aws/sles/variables.tf
@@ -56,14 +56,14 @@ variable "lh_aws_instance_name_controlplane" {
 
 variable "lh_aws_instance_type_controlplane" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "lh_aws_instance_type_worker" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "block_device_size_controlplane" {

--- a/test_framework/terraform/aws/talos/variables.tf
+++ b/test_framework/terraform/aws/talos/variables.tf
@@ -61,14 +61,14 @@ variable "lh_aws_instance_name_worker" {
 
 variable "lh_aws_instance_type_controlplane" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.xlarge  for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.xlarge  for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "lh_aws_instance_type_worker" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.xlarge  for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.xlarge  for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "block_device_size_controlplane" {

--- a/test_framework/terraform/aws/ubuntu/variables.tf
+++ b/test_framework/terraform/aws/ubuntu/variables.tf
@@ -56,14 +56,14 @@ variable "lh_aws_instance_name_controlplane" {
 
 variable "lh_aws_instance_type_controlplane" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "lh_aws_instance_type_worker" {
   type        = string
-  description = "Recommended instance types t3.xlarge for amd64 & a1.2xlarge for arm64"
-  default     = "t3.xlarge"
+  description = "Recommended instance types t2.xlarge for amd64 & a1.2xlarge for arm64"
+  default     = "t2.xlarge"
 }
 
 variable "block_device_size_controlplane" {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10949

#### What this PR does / why we need it:

t3.xlarge is too expensive, revert to using t2.xlarge instead.

To test nvme type driver, use arm64.

#### Special notes for your reviewer:

#### Additional documentation or context
