### PR TITLE
fix: enable `csi-storage-capacity-tracking` setting before csi storage capacity tests

### DIFF
--- a/e2e/tests/regression/test_csi.robot
+++ b/e2e/tests/regression/test_csi.robot
@@ -23,6 +23,7 @@ Test Teardown    Cleanup test resources
 *** Test Cases ***
 Test CSI Storage Capacity Without DataEngine Parameter
     [Documentation]    Issue: https://github.com/longhorn/longhorn/issues/11906
+    Given Setting csi-storage-capacity-tracking is set to true
     When Create storageclass longhorn-test with    volumeBindingMode=WaitForFirstConsumer
     # expect no error message like:
     # err: rpc error: code = InvalidArgument desc = storage class parameters missing 'dataEngine'

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -245,6 +245,7 @@ SETTING_ALLOW_EMPTY_DISK_SELECTOR_VOLUME = "allow-empty-disk-selector-volume"
 SETTING_NODE_DRAIN_POLICY = "node-drain-policy"
 SETTING_MIN_NUMBER_OF_BACKING_IMAGE_COPIES = \
     "default-min-number-of-backing-image-copies"
+SETTING_CSI_STORAGE_CAPACITY_TRACKING = "csi-storage-capacity-tracking"
 
 DEFAULT_BACKUP_COMPRESSION_METHOD = "lz4"
 BACKUP_COMPRESSION_METHOD_LZ4 = "lz4"

--- a/manager/integration/tests/test_csi.py
+++ b/manager/integration/tests/test_csi.py
@@ -38,6 +38,8 @@ from common import fail_replica_expansion
 from common import get_volume_name, get_volume_dev_mb_data_md5sum # NOQA
 from common import exec_command_in_pod
 from common import DATA_ENGINE
+from common import update_setting
+from common import SETTING_CSI_STORAGE_CAPACITY_TRACKING
 from common import RETRY_COUNTS_SHORT
 from common import RETRY_INTERVAL_LONG
 from backupstore import set_random_backupstore  # NOQA
@@ -1026,11 +1028,14 @@ def test_csi_storage_capacity(client, storage_class): # NOQA
     """
     Test that CSIStorageCapacity objects are properly created
 
-    1. Verify that initially there are no CSIStorageCapacity objects
-    2. Create new storage class with volumeBindingMode set
+    1. Enable the 'csi-storage-capacity-tracking' setting
+    2. Verify that initially there are no CSIStorageCapacity objects
+    3. Create new storage class with volumeBindingMode set
        to WaitForFirstConsumer
-    3. Verify that CSIStorageCapacity object is created for each node
+    4. Verify that CSIStorageCapacity object is created for each node
     """
+
+    update_setting(client, SETTING_CSI_STORAGE_CAPACITY_TRACKING, "true")
 
     api = k8sclient.StorageV1Api()
     csi_storage_capacities = api.list_namespaced_csi_storage_capacity(

--- a/manager/integration/tests/test_scheduling.py
+++ b/manager/integration/tests/test_scheduling.py
@@ -93,6 +93,7 @@ from common import SETTING_REPLICA_ZONE_SOFT_ANTI_AFFINITY
 from common import SETTING_REPLICA_DISK_SOFT_ANTI_AFFINITY
 from common import SETTING_ALLOW_EMPTY_DISK_SELECTOR_VOLUME
 from common import SETTING_STORAGE_OVER_PROVISIONING_PERCENTAGE
+from common import SETTING_CSI_STORAGE_CAPACITY_TRACKING
 from common import DATA_ENGINE
 
 from time import sleep
@@ -2520,20 +2521,23 @@ def test_storage_capacity_aware_pod_scheduling(client, core_api, storage_class, 
     node when scheduling pods using a StorageClass with volumeBindingMode set
     to 'WaitForFirstConsumer'.
 
-    1. Update 'storage-over-provisioning-percentage' to 400.
-    2. Reduce the schedulable storage on all nodes (except the current node)
+    1. Enable the 'csi-storage-capacity-tracking' setting.
+    2. Update 'storage-over-provisioning-percentage' to 400.
+    3. Reduce the schedulable storage on all nodes (except the current node)
        to 1Gi.
-    3. Compute max schedulable storage on the current node taking into account
+    4. Compute max schedulable storage on the current node taking into account
        the 'storage-over-provisioning-percentage' setting.
-    4. Create a new StorageClass with volumeBindingMode set
+    5. Create a new StorageClass with volumeBindingMode set
        to 'WaitForFirstConsumer'.
-    5. Create a StatefulSet with 2 replicas, each requesting the max
+    6. Create a StatefulSet with 2 replicas, each requesting the max
        schedulable storage size.
-    6. Verify pod 0 is scheduled to the current node and volume 0 is attached
+    7. Verify pod 0 is scheduled to the current node and volume 0 is attached
        to the current node.
-    7. Verify pod 1 is not scheduled because there is no node with sufficient
+    8. Verify pod 1 is not scheduled because there is no node with sufficient
        storage and that its PVC is in Pending state.
     """
+    update_setting(client, SETTING_CSI_STORAGE_CAPACITY_TRACKING, "true")
+
     # Set storage over-provisioning to 400%
     over_provisioning_percentage = 400
     update_setting(client,


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13001

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
