### PR TITLE
test(pytest): update test_basic.py::test_volume for IPv6 nvmf address

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2919,13 +2919,27 @@ def parse_nvmf_endpoint(nvmf):
 
 
 def get_nvmf_ip(nvmf):
+    """
+    Extract IP address from NVMf endpoint.
+    IPv6 example: fd42:0:0:1::e:20103 -> fd42:0:0:1::e
+    IPv4 example: 10.0.1.24:4420 -> 10.0.1.24
+    """
     nvmf_endpoint = parse_nvmf_endpoint(nvmf)
-    return nvmf_endpoint[0].split(':')[0]
+    host_port = nvmf_endpoint[0]
+
+    # Port is always after the last colon for both IPv4 and IPv6
+    last_colon_idx = host_port.rfind(':')
+    ip = host_port[:last_colon_idx]
+
+    # Validate it's a valid IP address
+    ipaddress.ip_address(ip)
+    return ip
 
 
 def get_nvmf_port(nvmf):
     nvmf_endpoint = parse_nvmf_endpoint(nvmf)
-    return nvmf_endpoint[0].split(':')[1]
+    host_port = nvmf_endpoint[0]
+    return host_port.split(':')[-1]
 
 
 def get_nvmf_nqn(nvmf):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

`test_basic.py::test_volume_basic[nvmf]` failed when running on IPv6 with v2 data engine
```
test_basic.py::test_volume_basic[blockdev] PASSED
failed to resolve host fd00 info
could not add new controller: failed to get transport address
test_basic.py::test_volume_basic[nvmf] NQN:nqn.2023-01.io.longhorn.spdk:volume-longhorn-testvol-c60dfs disconnected 0 controller(s)
Disconnected from nqn.2023-01.io.longhorn.spdk:volume-longhorn-testvol-c60dfs
FAILED
```

ipv4: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/10634/
ipv6: https://ci.longhorn.io/job/private/job/longhorn-tests-regression/10635/

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
