### PR TITLE
fix: install docker buildx tool when generating a test upgrade image

### DIFF
--- a/build_engine_test_images/scripts/generate_images.sh
+++ b/build_engine_test_images/scripts/generate_images.sh
@@ -19,6 +19,9 @@ function build_version_test_images() {
   fi
 }
 
+apt install -y docker-buildx
+export DOCKER_BUILDKIT=1
+
 # Build and get API information
 if [ ${commit_id} != '' ]
 then
@@ -26,7 +29,7 @@ then
 else
   git clone https://github.com/longhorn/longhorn-engine.git
 fi
-sed -i "s/.*ARG DAPPER_HOST_ARCH=.*/ARG DAPPER_HOST_ARCH=${arch}/" longhorn-engine/Dockerfile.dapper
+sed -i "s/.*ARG TARGETARCH=.*/ARG TARGETARCH=${arch}/" longhorn-engine/Dockerfile
 cd longhorn-engine
 echo -en test >> README.md
 git config --global user.email mock@gmail.com


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#13014

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context

@yangchiu, I tested on Ubuntu 24.02, so I'm not sure if it will work on 20.02.