### PR TITLE
test(pytest): add more ha test cases support v2 data engine

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -1535,6 +1535,7 @@ def test_all_replica_restore_failure(set_random_backupstore, client, core_api, v
     wait_for_volume_delete(client, res_name)
 
 
+@pytest.mark.v2_volume_test
 def test_single_replica_restore_failure(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make):  # NOQA
     """
     [HA] Test if one replica restore failure will lead to the restore volume
@@ -1567,6 +1568,7 @@ def test_single_replica_restore_failure(set_random_backupstore, client, core_api
                                  REPLICA_FAILURE_MODE_CRASH)
 
 
+@pytest.mark.v2_volume_test  # NOQA
 def test_single_replica_unschedulable_restore_failure(set_random_backupstore, client, core_api, volume_name, csi_pv, pvc, pod_make): # NOQA
     """
     [HA] Test if the restore can complete if a restoring replica is killed


### PR DESCRIPTION




#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#12831

- [test_single_replica_restore_failure](https://10.115.5.5/job/private/job/longhorn-tests-regression/428/testReport/tests/test_ha/)
- [test_single_replica_unschedulable_restore_failure](https://10.115.5.5/job/private/job/longhorn-tests-regression/429/testReport/tests/test_ha/)

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
