### PR TITLE
fix(robot): replace `Run Command And Get Output` with `Run Command`

### DIFF
--- a/e2e/keywords/engine_image.resource
+++ b/e2e/keywords/engine_image.resource
@@ -14,7 +14,7 @@ Wait to engine image ${custom_engine_image} to be deployed
     wait_for_engine_image_deployed    ${custom_engine_image}
 
 Wait for engine image daemonset pods recreated
-    ${output}=    Run Command And Get Output
+    ${output}=    Run Command
     ...    kubectl -n longhorn-system get ds -l longhorn.io/component=engine-image --no-headers -o custom-columns=NAME:.metadata.name
     @{ds_names}=    Split To Lines    ${output}
     FOR    ${ds_name}    IN    @{ds_names}

--- a/e2e/tests/regression/test_settings.robot
+++ b/e2e/tests/regression/test_settings.robot
@@ -63,7 +63,7 @@ Verify TooManySnapshots Condition After Creating Snapshots
 
 All engine image daemonset should have liveness probe settings
     [Arguments]    ${timeout}    ${period}    ${failure_threshold}
-    ${count}=    Run Command And Get Output
+    ${count}=    Run Command
     ...    kubectl -n longhorn-system get ds -l longhorn.io/component=engine-image --no-headers | wc -l
     ${count}=    Convert To Integer    ${count}
     FOR    ${index}    IN RANGE    ${count}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Follow-up fix for commit [1bdde57](https://github.com/longhorn/longhorn-tests/commit/1bdde57a2be261e93260fcb17e127f47152e02cb) which enhanced the `Run Command And Get Output` keyword from `common.resource`. Update remaining usages in engine_image.resource and test_settings.robot to use `Run Command` instead.

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
