### PR TITLE
test(robot): use enginefrontend.status.endpoint for v2 volume

### DIFF
--- a/e2e/libs/enginefrontend/__init__.py
+++ b/e2e/libs/enginefrontend/__init__.py
@@ -1,0 +1,1 @@
+from enginefrontend.enginefrontend import EngineFrontend

--- a/e2e/libs/enginefrontend/base.py
+++ b/e2e/libs/enginefrontend/base.py
@@ -1,0 +1,8 @@
+from abc import ABC, abstractmethod
+
+
+class Base(ABC):
+
+    @abstractmethod
+    def get_enginefrontends(self, volume_name):
+        return NotImplemented

--- a/e2e/libs/enginefrontend/crd.py
+++ b/e2e/libs/enginefrontend/crd.py
@@ -1,0 +1,37 @@
+from kubernetes import client
+import time
+
+from enginefrontend.base import Base
+from utility.utility import logging
+from utility.utility import get_retry_count_and_interval
+import utility.constant as constant
+
+
+class CRD(Base):
+    def __init__(self):
+        self.obj_api = client.CustomObjectsApi()
+        self.retry_count, self.retry_interval = get_retry_count_and_interval()
+
+    def get_enginefrontends(self, volume_name):
+        logging(f"Getting enginefrontends of {volume_name}")
+
+        label_selector = []
+        if volume_name:
+            label_selector.append(f"longhornvolume={volume_name}")
+
+        api_response = self.obj_api.list_namespaced_custom_object(
+            group="longhorn.io",
+            version="v1beta2",
+            namespace=constant.LONGHORN_NAMESPACE,
+            plural="enginefrontends",
+            label_selector=",".join(label_selector)
+        )
+
+        if api_response == "" or api_response is None:
+            raise Exception(f"failed to get volume {volume_name} enginefrontend")
+
+        enginefrontends = api_response["items"]
+        if len(enginefrontends) == 0:
+            logging(f"Cannot get volume {volume_name} enginefrontends")
+
+        return enginefrontends

--- a/e2e/libs/enginefrontend/enginefrontend.py
+++ b/e2e/libs/enginefrontend/enginefrontend.py
@@ -1,0 +1,45 @@
+from enginefrontend.base import Base
+from enginefrontend.crd import CRD
+
+from strategy import LonghornOperationStrategy
+
+from utility.utility import logging
+from utility.utility import get_retry_count_and_interval
+
+import time
+
+
+class EngineFrontend(Base):
+
+    _strategy = LonghornOperationStrategy.CRD
+
+    def __init__(self):
+        self.retry_count, self.retry_interval = get_retry_count_and_interval()
+        if self._strategy == LonghornOperationStrategy.CRD:
+            self.enginefrontend = CRD()
+
+    def get_enginefrontends(self, volume_name):
+        return self.enginefrontend.get_enginefrontends(volume_name)
+
+    def get_enginefrontend(self, volume_name):
+        enginefrontends = self.get_enginefrontends(volume_name)
+        assert len(enginefrontends) == 1, \
+            f"Expected exactly one enginefrontend but found {len(enginefrontends)}"
+
+        return enginefrontends[0]
+
+    def get_enginefrontend_endpoint(self, volume_name):
+        for i in range(self.retry_count):
+            logging(f"Trying to get enginefrontend endpoint for volume {volume_name} ... ({i})")
+            try:
+                enginefrontend = self.get_enginefrontend(volume_name)
+                endpoint = enginefrontend.get('status', {}).get('endpoint', '')
+                if endpoint:
+                    logging(f"Got volume {volume_name} enginefrontend endpoint: {endpoint}")
+                    return endpoint
+                else:
+                    logging(f"EngineFrontend endpoint is empty: {enginefrontend.get('status', {})}")
+            except Exception as e:
+                logging(f"Getting enginefrontend endpoint for volume {volume_name} error: {e}")
+            time.sleep(self.retry_interval)
+        assert False, f"Failed to get enginefrontend endpoint for volume {volume_name}"

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -5,6 +5,7 @@ from kubernetes import client
 from kubernetes.client.rest import ApiException
 
 from engine import Engine
+from enginefrontend import EngineFrontend
 
 from node_exec import NodeExec
 
@@ -31,6 +32,7 @@ class CRD(Base):
         self.obj_api = client.CustomObjectsApi()
         self.retry_count, self.retry_interval = get_retry_count_and_interval()
         self.engine = Engine()
+        self.enginefrontend = EngineFrontend()
 
     def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, nodeSelector, diskSelector, backupBlockSize, rebuildConcurrentSyncLimit, snapshotMaxCount, replicaAutoBalance, retry=True):
         longhorn_version = get_longhorn_client().by_id_setting('current-longhorn-version').value
@@ -456,7 +458,14 @@ class CRD(Base):
             try:
                 engines = self.engine.get_engines(volume_name)
                 volume = self.get(volume_name)
-                engine_check = len(engines) == 1 and engines[0]['status']['endpoint'] and engines[0]['status']['ownerID'] == node_name
+                data_engine = volume['spec'].get('dataEngine', 'v1')
+
+                if data_engine == 'v2':
+                    enginefrontends = self.enginefrontend.get_enginefrontends(volume_name)
+                    engine_check = len(engines) == 1 and enginefrontends[0]['status']['endpoint'] and engines[0]['status']['ownerID'] == node_name
+                else:
+                    engine_check = len(engines) == 1 and engines[0]['status']['endpoint'] and engines[0]['status']['ownerID'] == node_name
+
                 migration_node_check = volume['spec']['migrationNodeID'] == "" and volume['status']['currentMigrationNodeID'] == ""
                 node_check = volume['spec']['nodeID'] == node_name and volume['spec']['nodeID'] == volume['status']['currentNodeID']
                 complete = engine_check and migration_node_check and node_check
@@ -474,7 +483,13 @@ class CRD(Base):
             try:
                 engines = self.engine.get_engines(volume_name)
                 volume = self.get(volume_name)
-                engine_check = len(engines) == 1 and engines[0]['status']['endpoint'] and engines[0]['status']['ownerID'] == node_name
+                data_engine = volume['spec'].get('dataEngine', 'v1')
+
+                if data_engine == 'v2':
+                    enginefrontends = self.enginefrontend.get_enginefrontends(volume_name)
+                    engine_check = len(engines) == 1 and enginefrontends[0]['status']['endpoint'] and engines[0]['status']['ownerID'] == node_name
+                else:
+                    engine_check = len(engines) == 1 and engines[0]['status']['endpoint'] and engines[0]['status']['ownerID'] == node_name
                 migration_node_check = volume['spec']['migrationNodeID'] == "" and volume['status']['currentMigrationNodeID'] == ""
                 node_check = volume['spec']['nodeID'] == node_name and volume['spec']['nodeID'] == volume['status']['currentNodeID']
                 rollback = engine_check and migration_node_check and node_check


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13057

In v1.12.0, v2 volume endpoint moved to `enginefrontend.status.endpoint `.  `Test Migration Confirm` and `Test Migration Rollback` were impacted

test_migration.robot
v1: https://ci.longhorn.io/job/private/job/longhorn-e2e-test/7714/
v2: https://ci.longhorn.io/job/private/job/longhorn-e2e-test/7715/

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
