### PR TITLE
test(robot): add Encrypted volume size verification tests for LUKS header pre-allocation (#9205)

### DIFF
--- a/e2e/keywords/deployment.resource
+++ b/e2e/keywords/deployment.resource
@@ -33,9 +33,11 @@ Create deployment ${deployment_id} with persistentvolumeclaim ${claim_id} with m
     create_deployment    ${deployment_name}    ${claim_name}   ${node_count}
 
 Create deployment ${deployment_id} with volume ${volume_id}
+    [Arguments]    &{config}
     ${volume_id}=  Convert To String  ${volume_id}
-    Create persistentvolume for volume ${volume_id}
-    Create persistentvolumeclaim for volume ${volume_id}
+    Create persistentvolume for volume ${volume_id}    &{config}
+    ${sc_name}=    Evaluate    $config.get('sc_name', 'longhorn')
+    Create persistentvolumeclaim for volume ${volume_id}    sc_name=${sc_name}
     ${deployment_name}=    generate_name_with_suffix    deployment    ${deployment_id}
     ${pvc_name}=    generate_name_with_suffix    volume    ${volume_id}
     create_deployment    ${deployment_name}   ${pvc_name}
@@ -78,6 +80,12 @@ And Write ${size} MB data to block device in deployment ${deployment_id} and che
 Check deployment ${deployment_id} data in file ${file_name} is intact
     ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
     check_workload_pod_data_checksum    ${deployment_name}    ${file_name}
+
+Check deployment ${deployment_id} data in file ${file_name} is intact compared to deployment ${source_deployment_id}
+    ${source_deployment_name} =    generate_name_with_suffix    deployment    ${source_deployment_id}
+    ${expected_checksum} =    get_workload_pod_data_checksum    ${source_deployment_name}    ${file_name}
+    ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
+    check_workload_pod_data_checksum    ${deployment_name}    ${file_name}    ${expected_checksum}
 
 Check deployment ${deployment_id} works    
     ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}

--- a/e2e/keywords/deployment.resource
+++ b/e2e/keywords/deployment.resource
@@ -7,7 +7,6 @@ Library    ../libs/keywords/deployment_keywords.py
 Library    ../libs/keywords/node_keywords.py
 Library    ../libs/keywords/workload_keywords.py
 Library    ../libs/keywords/volume_keywords.py
-Resource    variables.resource
 
 *** Keywords ***
 Create deployment ${deployment_id} with persistentvolumeclaim ${claim_id}
@@ -137,7 +136,4 @@ Assert block device size in deployment pod for deployment ${deployment_id} is ${
     ${expected_bytes} =    convert_size_to_bytes    ${size}    to_str=True
     ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
     ${pod_name} =    get_workload_pod_name    ${deployment_name}
-    ${cmd} =    Set Variable    blockdev --getsize64 ${BLOCK_DEVICE_PATH}
-    ${result} =    pod_exec    ${pod_name}    default    ${cmd}
-    Should Be Equal As Integers    ${result.strip()}    ${expected_bytes}
-    ...    msg=Block device size in pod ${pod_name}: expected ${expected_bytes} B, got ${result.strip()} B
+    wait_for_block_device_size_in_pod    ${pod_name}    ${expected_bytes}

--- a/e2e/keywords/deployment.resource
+++ b/e2e/keywords/deployment.resource
@@ -7,6 +7,7 @@ Library    ../libs/keywords/deployment_keywords.py
 Library    ../libs/keywords/node_keywords.py
 Library    ../libs/keywords/workload_keywords.py
 Library    ../libs/keywords/volume_keywords.py
+Resource    variables.resource
 
 *** Keywords ***
 Create deployment ${deployment_id} with persistentvolumeclaim ${claim_id}
@@ -33,10 +34,9 @@ Create deployment ${deployment_id} with persistentvolumeclaim ${claim_id} with m
     create_deployment    ${deployment_name}    ${claim_name}   ${node_count}
 
 Create deployment ${deployment_id} with volume ${volume_id}
-    [Arguments]    &{config}
+    [Arguments]    ${sc_name}=longhorn    &{config}
     ${volume_id}=  Convert To String  ${volume_id}
-    Create persistentvolume for volume ${volume_id}    &{config}
-    ${sc_name}=    Evaluate    $config.get('sc_name', 'longhorn')
+    Create persistentvolume for volume ${volume_id}    sc_name=${sc_name}    &{config}
     Create persistentvolumeclaim for volume ${volume_id}    sc_name=${sc_name}
     ${deployment_name}=    generate_name_with_suffix    deployment    ${deployment_id}
     ${pvc_name}=    generate_name_with_suffix    volume    ${volume_id}
@@ -80,12 +80,6 @@ And Write ${size} MB data to block device in deployment ${deployment_id} and che
 Check deployment ${deployment_id} data in file ${file_name} is intact
     ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
     check_workload_pod_data_checksum    ${deployment_name}    ${file_name}
-
-Check deployment ${deployment_id} data in file ${file_name} is intact compared to deployment ${source_deployment_id}
-    ${source_deployment_name} =    generate_name_with_suffix    deployment    ${source_deployment_id}
-    ${expected_checksum} =    get_workload_pod_data_checksum    ${source_deployment_name}    ${file_name}
-    ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
-    check_workload_pod_data_checksum    ${deployment_name}    ${file_name}    ${expected_checksum}
 
 Check deployment ${deployment_id} works    
     ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
@@ -138,3 +132,12 @@ Check deployment ${deployment_id} volume replica is not on node ${node_name}
     ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
     ${volume_name} =    get_workload_volume_name    ${deployment_name}
     wait_for_replica_count    ${volume_name}    ${node_name}    0
+
+Assert block device size in deployment pod for deployment ${deployment_id} is ${size}
+    ${expected_bytes} =    convert_size_to_bytes    ${size}    to_str=True
+    ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
+    ${pod_name} =    get_workload_pod_name    ${deployment_name}
+    ${cmd} =    Set Variable    blockdev --getsize64 ${BLOCK_DEVICE_PATH}
+    ${result} =    pod_exec    ${pod_name}    default    ${cmd}
+    Should Be Equal As Integers    ${result.strip()}    ${expected_bytes}
+    ...    msg=Block device size in pod ${pod_name}: expected ${expected_bytes} B, got ${result.strip()} B

--- a/e2e/keywords/longhorn.resource
+++ b/e2e/keywords/longhorn.resource
@@ -179,7 +179,8 @@ Check longhorn backing image manager image is ${expected_image}
 Assert disk size in instance manager pod for ${workload_kind} ${workload_id} is ${size}
     ${expected_size_byte} =    convert_size_to_bytes    ${size}    to_str=True
     ${workload_name}=    generate_name_with_suffix    ${workload_kind}    ${workload_id}
-    ${volume_name}=    get_workload_volume_name    ${workload_name}
+    ${volume_name}=    Run Keyword If    '${workload_kind}' == 'volume'    Set Variable    ${workload_name}
+    ...    ELSE    get_workload_volume_name    ${workload_name}
     ${instance_manager_name} =    get_engine_instance_manager_name    ${volume_name}
     Wait Until Keyword Succeeds    ${RETRY_COUNT}    ${RETRY_INTERVAL}
     ...    Check disk size in instance manager pod    ${instance_manager_name}    ${volume_name}    ${expected_size_byte}

--- a/e2e/keywords/longhorn.resource
+++ b/e2e/keywords/longhorn.resource
@@ -176,18 +176,20 @@ Check longhorn manager pods not restarted after test start
 Check longhorn backing image manager image is ${expected_image}
     check_backing_image_manager_images    ${expected_image}
 
-Assert disk size in instance manager pod for ${workload_kind} ${workload_id} is ${size}
+Assert disk size in instance manager pod for ${resource_kind} ${resource_id} is ${size}
     ${expected_size_byte} =    convert_size_to_bytes    ${size}    to_str=True
-    ${workload_name}=    generate_name_with_suffix    ${workload_kind}    ${workload_id}
-    ${volume_name}=    Run Keyword If    '${workload_kind}' == 'volume'    Set Variable    ${workload_name}
-    ...    ELSE    get_workload_volume_name    ${workload_name}
+    ${resource_name}=    generate_name_with_suffix    ${resource_kind}    ${resource_id}
+    ${volume_name}=    Run Keyword If    '${resource_kind}' == 'volume'
+    ...        Set Variable    ${resource_name}
+    ...    ELSE
+    ...        get_workload_volume_name    ${resource_name}
     ${instance_manager_name} =    get_engine_instance_manager_name    ${volume_name}
     Wait Until Keyword Succeeds    ${RETRY_COUNT}    ${RETRY_INTERVAL}
     ...    Check disk size in instance manager pod    ${instance_manager_name}    ${volume_name}    ${expected_size_byte}
 
 Check disk size in instance manager pod
     [Arguments]    ${instance_manager_name}    ${volume_name}    ${expected_size}
-    ${cmd}=    Set Variable    fdisk -l | grep /dev/mapper/${volume_name}
+    ${cmd} =    Set Variable    fdisk -l /dev/mapper/${volume_name}
     ${longhorn_namespace} =    get_longhorn_namespace
     ${result}=    pod_exec    ${instance_manager_name}    ${longhorn_namespace}    ${cmd}
     Should Contain    ${result}    ${expected_size}

--- a/e2e/keywords/replica.resource
+++ b/e2e/keywords/replica.resource
@@ -4,6 +4,7 @@ Documentation       Longhorn replica related keywords
 Library             ../libs/keywords/common_keywords.py
 Library             ../libs/keywords/replica_keywords.py
 Library             ../libs/keywords/node_keywords.py
+Library             ../libs/keywords/workload_keywords.py
 
 *** Keywords ***
 Volume ${volume_id} replica ${setting_name} should be ${setting_value}
@@ -46,3 +47,8 @@ Verify replica lvol exists in SPDK lvol list on node ${node_id}
     [Arguments]    ${replica_name}
     ${node_name} =    get_node_by_index    ${node_id}
     verify_replica_lvol_exists_in_spdk_lvol    ${node_name}    ${replica_name}
+Assert replica file size of deployment ${deployment_id} is ${expected_size}
+    ${expected_bytes} =    convert_size_to_bytes    ${expected_size}    to_str=True
+    ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
+    ${volume_name} =    get_workload_volume_name    ${deployment_name}
+    wait_for_replica_file_size    ${volume_name}    ${expected_bytes}

--- a/e2e/keywords/replica.resource
+++ b/e2e/keywords/replica.resource
@@ -47,8 +47,12 @@ Verify replica lvol exists in SPDK lvol list on node ${node_id}
     [Arguments]    ${replica_name}
     ${node_name} =    get_node_by_index    ${node_id}
     verify_replica_lvol_exists_in_spdk_lvol    ${node_name}    ${replica_name}
-Assert replica file size of deployment ${deployment_id} is ${expected_size}
+
+Assert replica file size of ${resource_kind} ${resource_id} is ${expected_size}
     ${expected_bytes} =    convert_size_to_bytes    ${expected_size}    to_str=True
-    ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
-    ${volume_name} =    get_workload_volume_name    ${deployment_name}
+    ${resource_name}=    generate_name_with_suffix    ${resource_kind}    ${resource_id}
+    ${volume_name}=    Run Keyword If    '${resource_kind}' == 'volume'
+    ...        Set Variable    ${resource_name}
+    ...    ELSE
+    ...        get_workload_volume_name    ${resource_name}
     wait_for_replica_file_size    ${volume_name}    ${expected_bytes}

--- a/e2e/keywords/sharemanager.resource
+++ b/e2e/keywords/sharemanager.resource
@@ -49,7 +49,6 @@ Wait for sharemanager pod of ${workload_kind} ${workload_id} deleted
 
 Assert disk size in sharemanager pod for ${workload_kind} ${workload_id} is ${size}
     ${expected_size_byte} =    convert_size_to_bytes    ${size}    to_str=True
-
     ${workload_name}=    generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${volume_name}=    get_workload_volume_name    ${workload_name}
     ${share_manager_pod}=    Set Variable    share-manager-${volume_name}

--- a/e2e/keywords/snapshot.resource
+++ b/e2e/keywords/snapshot.resource
@@ -123,6 +123,17 @@ Wait for volume ${volume_id} snapshot ${snapshot_id} checksum to be calculated
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     wait_for_snapshot_checksum_to_be_created    ${volume_name}    ${snapshot_id}
 
+Wait for snapshot ${snapshot_id} of ${workload_kind} ${workload_id} volume ready
+    ${workload_name} =    generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    wait_for_snapshot_ready    ${volume_name}    ${snapshot_id}
+
+Get snapshot name of ${snapshot_id} for ${workload_kind} ${workload_id} volume
+    ${workload_name} =    generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    ${snapshot_name} =    get_snapshot_name    ${volume_name}    ${snapshot_id}
+    [Return]    ${snapshot_name}
+
 Longhorn snapshot associated with csi volume snapshot ${csi_volume_snapshot_id} of ${workload_kind} ${workload_id} should be created
     ${csi_volume_snapshot_name} =    generate_name_with_suffix    csi-volume-snapshot    ${csi_volume_snapshot_id}
     ${longhorn_snapshot_name} =    get_longhorn_snapshot_name_associated_with_csi_volume_snapshot    ${csi_volume_snapshot_name}

--- a/e2e/keywords/variables.resource
+++ b/e2e/keywords/variables.resource
@@ -12,11 +12,6 @@ ${VOLUME_STATE_CHECK_TIMEOUT}    120
 ${LONGHORN_NAMESPACE}    longhorn-system
 ${DEFAULT_BLOCK_DISK_NAME}    block-disk
 
-# Block volume device path (volumeMode=Block)
-${BLOCK_DEVICE_NAME}    longhorn-testblk
-${BLOCK_DEVICE_DIR}    /dev/longhorn
-${BLOCK_DEVICE_PATH}    ${BLOCK_DEVICE_DIR}/${BLOCK_DEVICE_NAME}
-
 @{powered_off_nodes}=
 
 &{volume_checksums}=

--- a/e2e/keywords/variables.resource
+++ b/e2e/keywords/variables.resource
@@ -12,6 +12,11 @@ ${VOLUME_STATE_CHECK_TIMEOUT}    120
 ${LONGHORN_NAMESPACE}    longhorn-system
 ${DEFAULT_BLOCK_DISK_NAME}    block-disk
 
+# Block volume device path (volumeMode=Block)
+${BLOCK_DEVICE_NAME}    longhorn-testblk
+${BLOCK_DEVICE_DIR}    /dev/longhorn
+${BLOCK_DEVICE_PATH}    ${BLOCK_DEVICE_DIR}/${BLOCK_DEVICE_NAME}
+
 @{powered_off_nodes}=
 
 &{volume_checksums}=

--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -41,6 +41,14 @@ Create DR volume ${target_volume_id} from backup ${backup_id} of ${workload_kind
     ${backup_url} =    get_backup_url    ${backup_id}    ${volume_name}
     create_volume   ${target_volume_name}    frontend=    Standby=True    fromBackup=${backup_url}    &{config}
 
+Create volume ${target_volume_id} from backup ${backup_id} of ${workload_kind} ${workload_id} volume
+    [Arguments]    &{config}
+    ${target_volume_name} =    generate_name_with_suffix    volume    ${target_volume_id}
+    ${workload_name} =    generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${workload_volume_name} =    get_workload_volume_name    ${workload_name}
+    ${backup_url} =    get_backup_url    ${backup_id}    ${workload_volume_name}
+    create_volume    ${target_volume_name}    fromBackup=${backup_url}    &{config}
+
 Create volume ${target_volume_id} from backup ${backup_id} of volume ${source_volume_id}
     [Arguments]    &{config}
     ${target_volume_name} =    generate_name_with_suffix    volume    ${target_volume_id}

--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -5,6 +5,7 @@ Library    Collections
 Library    ../libs/keywords/common_keywords.py
 Library    ../libs/keywords/volume_keywords.py
 Library    ../libs/keywords/backup_keywords.py
+Library    ../libs/keywords/snapshot_keywords.py
 
 *** Variables ***
 ${SCHEDULING_STATUS_CHECK_TIMEOUT}    30
@@ -71,6 +72,23 @@ Create volume ${volume_id} from ${workload_kind} ${workload_id} volume latest ba
     ${volume_name}=    generate_name_with_suffix    volume    ${volume_id}
     ${backup_url}=    get_latest_backup_url    ${workload_volume_name}
     create_volume   ${volume_name}    numberOfReplicas=3    fromBackup=${backup_url}    &{config}
+
+Create volume ${target_volume_id} from snapshot ${snapshot_id} of volume ${source_volume_id}
+    [Arguments]    &{config}
+    ${target_volume_name} =    generate_name_with_suffix    volume    ${target_volume_id}
+    ${source_volume_name} =    generate_name_with_suffix    volume    ${source_volume_id}
+    ${snapshot_name} =    get_snapshot_name    ${source_volume_name}    ${snapshot_id}
+    ${snapshot_data_source} =    Set Variable    snap://${source_volume_name}/${snapshot_name}
+    create_volume    ${target_volume_name}    numberOfReplicas=3    dataSource=${snapshot_data_source}    &{config}
+
+Create volume ${target_volume_id} from snapshot ${snapshot_id} of ${workload_kind} ${workload_id} volume
+    [Arguments]    &{config}
+    ${target_volume_name} =    generate_name_with_suffix    volume    ${target_volume_id}
+    ${workload_name} =    generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${source_volume_name} =    get_workload_volume_name    ${workload_name}
+    ${snapshot_name} =    get_snapshot_name    ${source_volume_name}    ${snapshot_id}
+    ${snapshot_data_source} =    Set Variable    snap://${source_volume_name}/${snapshot_name}
+    create_volume    ${target_volume_name}    numberOfReplicas=3    dataSource=${snapshot_data_source}    &{config}
 
 No volume created
     ${volumes} =    list_volumes

--- a/e2e/libs/keywords/replica_keywords.py
+++ b/e2e/libs/keywords/replica_keywords.py
@@ -17,3 +17,6 @@ class replica_keywords:
 
     def get_replica_names(self, volume_name, numberOfReplicas=3):
         return self.replica.get_replica_names(volume_name, numberOfReplicas)
+
+    def wait_for_replica_file_size(self, volume_name, expected_size):
+        return self.replica.wait_for_replica_file_size(volume_name, expected_size)

--- a/e2e/libs/keywords/snapshot_keywords.py
+++ b/e2e/libs/keywords/snapshot_keywords.py
@@ -119,3 +119,22 @@ class snapshot_keywords:
                 return
             time.sleep(self.retry_interval)
         assert False, f"Volume {volume_name} head size {volume_head.size} should be less than {size}"
+
+    def wait_for_snapshot_ready(self, volume_name, snapshot_id):
+        for i in range(self.retry_count):
+            logging(f"Waiting for volume {volume_name} snapshot {snapshot_id} to be ready ... ({i})")
+            try:
+                snapshot = self.snapshot.get(volume_name, snapshot_id)
+                if snapshot and not snapshot.removed:
+                    logging(f"Volume {volume_name} snapshot {snapshot_id} is ready")
+                    return
+            except Exception as e:
+                logging(f"Failed to get volume {volume_name} snapshot {snapshot_id}: {e}")
+            time.sleep(self.retry_interval)
+        assert False, f"Timed out waiting for volume {volume_name} snapshot {snapshot_id} to be ready"
+
+    def get_snapshot_name(self, volume_name, snapshot_id):
+        snapshot = self.snapshot.get(volume_name, snapshot_id)
+        assert snapshot is not None, f"Snapshot {snapshot_id} not found in volume {volume_name}"
+        logging(f"Got snapshot name {snapshot.name} for snapshot {snapshot_id} of volume {volume_name}")
+        return snapshot.name

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -38,9 +38,9 @@ class volume_keywords:
         for volume in volumes:
             self.delete_volume(volume['metadata']['name'])
 
-    def create_volume(self, volume_name, size="2Gi", numberOfReplicas=3, frontend="blockdev", migratable=False, dataLocality="disabled", accessMode="RWO", dataEngine="v1", backingImage="", Standby=False, fromBackup="", encrypted=False, nodeSelector=[], diskSelector=[], backupBlockSize="2Mi", rebuildConcurrentSyncLimit=0, snapshotMaxCount=0, replicaAutoBalance="ignored", retry=True):
+    def create_volume(self, volume_name, size="2Gi", numberOfReplicas=3, frontend="blockdev", migratable=False, dataLocality="disabled", accessMode="RWO", dataEngine="v1", backingImage="", Standby=False, fromBackup="", encrypted=False, nodeSelector=[], diskSelector=[], backupBlockSize="2Mi", rebuildConcurrentSyncLimit=0, snapshotMaxCount=0, replicaAutoBalance="ignored", dataSource="", retry=True):
         logging(f'Creating volume {volume_name}')
-        self.volume.create(volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, nodeSelector, diskSelector, backupBlockSize, rebuildConcurrentSyncLimit, snapshotMaxCount, replicaAutoBalance, retry)
+        self.volume.create(volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, nodeSelector, diskSelector, backupBlockSize, rebuildConcurrentSyncLimit, snapshotMaxCount, replicaAutoBalance, dataSource, retry)
 
     def delete_volume(self, volume_name, wait=True):
         logging(f'Deleting volume {volume_name}')
@@ -408,8 +408,8 @@ class volume_keywords:
     def activate_dr_volume(self, volume_name):
         self.volume.activate(volume_name)
 
-    def create_persistentvolume_for_volume(self, volume_name, retry=True, volumeMode="Filesystem", fsType="ext4", sc_name="longhorn", node_stage_secret_name=None):
-        self.volume.create_persistentvolume(volume_name, retry, volumeMode, fsType, sc_name=sc_name, node_stage_secret_name=node_stage_secret_name)
+    def create_persistentvolume_for_volume(self, volume_name, retry=True, volumeMode="Filesystem", fsType="ext4", sc_name="longhorn", node_stage_secret_name=None, node_stage_secret_namespace="longhorn-system"):
+        self.volume.create_persistentvolume(volume_name, retry, volumeMode, fsType, sc_name, node_stage_secret_name, node_stage_secret_namespace)
 
     def create_persistentvolumeclaim_for_volume(self, volume_name, volumeMode="Filesystem", retry=True, sc_name="longhorn"):
         self.volume.create_persistentvolumeclaim(volume_name, volumeMode, retry, sc_name=sc_name)

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -408,11 +408,11 @@ class volume_keywords:
     def activate_dr_volume(self, volume_name):
         self.volume.activate(volume_name)
 
-    def create_persistentvolume_for_volume(self, volume_name, retry=True, volumeMode="Filesystem", fsType="ext4"):
-        self.volume.create_persistentvolume(volume_name, retry, volumeMode, fsType)
+    def create_persistentvolume_for_volume(self, volume_name, retry=True, volumeMode="Filesystem", fsType="ext4", sc_name="longhorn", node_stage_secret_name=None):
+        self.volume.create_persistentvolume(volume_name, retry, volumeMode, fsType, sc_name=sc_name, node_stage_secret_name=node_stage_secret_name)
 
-    def create_persistentvolumeclaim_for_volume(self, volume_name, volumeMode="Filesystem", retry=True):
-        self.volume.create_persistentvolumeclaim(volume_name, volumeMode, retry)
+    def create_persistentvolumeclaim_for_volume(self, volume_name, volumeMode="Filesystem", retry=True, sc_name="longhorn"):
+        self.volume.create_persistentvolumeclaim(volume_name, volumeMode, retry, sc_name=sc_name)
 
     def record_volume_replica_names(self, volume_name):
         replica_list = self.replica.get(volume_name, node_name="")

--- a/e2e/libs/keywords/workload_keywords.py
+++ b/e2e/libs/keywords/workload_keywords.py
@@ -47,6 +47,7 @@ from workload.workload import rollout_restart_workload
 from utility.constant import ANNOT_CHECKSUM
 from utility.constant import ANNOT_EXPANDED_SIZE
 from utility.constant import LABEL_LONGHORN_COMPONENT
+from utility.constant import BLOCK_PVC_VOLUME_DEVICE_PATH
 import utility.constant as constant
 from utility.utility import convert_size_to_bytes
 from utility.utility import logging
@@ -485,3 +486,20 @@ class workload_keywords:
             raise AssertionError(f"FIO verification failed with errors: {resp}")
 
         logging(f"FIO data integrity verification passed")
+
+    def wait_for_block_device_size_in_pod(self, pod_name, expected_size, namespace="default"):
+        for i in range(self.retry_count):
+            logging(f"Waiting for block device size in pod {pod_name} to be {expected_size} ... ({i})")
+            time.sleep(self.retry_interval)
+            cmd = f"blockdev --getsize64 {BLOCK_PVC_VOLUME_DEVICE_PATH}"
+            try:
+                result = pod_exec(pod_name, namespace, cmd)
+                actual_size = result.strip()
+                logging(f"Current block device size in pod {pod_name}: {actual_size}, expected: {expected_size}")
+                if actual_size == expected_size:
+                    return
+            except Exception as e:
+                logging(f"Error checking block device size in pod {pod_name}: {e}")
+                continue
+
+        assert False, f"Block device size in pod {pod_name} is not {expected_size}"

--- a/e2e/libs/persistentvolume/persistentvolume.py
+++ b/e2e/libs/persistentvolume/persistentvolume.py
@@ -16,7 +16,7 @@ class PersistentVolume():
         self.api = client.CoreV1Api()
         self.retry_count, self.retry_interval = get_retry_count_and_interval()
 
-    def create(self, name, storage, volumeMode="Filesystem", fsType="ext4", sc_name="longhorn", node_stage_secret_name=None, node_stage_secret_namespace=None):
+    def create(self, name, storage, volumeMode="Filesystem", fsType="ext4", sc_name="longhorn", node_stage_secret_name=None, node_stage_secret_namespace='longhorn-system'):
         filepath = "./templates/workload/pv.yaml"
         with open(filepath, 'r') as f:
             manifest_dict = yaml.safe_load(f)
@@ -32,7 +32,7 @@ class PersistentVolume():
             if node_stage_secret_name:
                 manifest_dict['spec']['csi']['nodeStageSecretRef'] = {
                     'name': node_stage_secret_name,
-                    'namespace': node_stage_secret_namespace or 'longhorn-system',
+                    'namespace': node_stage_secret_namespace,
                 }
 
             logging(f"yaml = {manifest_dict}")

--- a/e2e/libs/persistentvolume/persistentvolume.py
+++ b/e2e/libs/persistentvolume/persistentvolume.py
@@ -16,7 +16,7 @@ class PersistentVolume():
         self.api = client.CoreV1Api()
         self.retry_count, self.retry_interval = get_retry_count_and_interval()
 
-    def create(self, name, storage, volumeMode="Filesystem", fsType="ext4"):
+    def create(self, name, storage, volumeMode="Filesystem", fsType="ext4", sc_name="longhorn", node_stage_secret_name=None, node_stage_secret_namespace=None):
         filepath = "./templates/workload/pv.yaml"
         with open(filepath, 'r') as f:
             manifest_dict = yaml.safe_load(f)
@@ -25,8 +25,15 @@ class PersistentVolume():
             manifest_dict['metadata']['labels'][LABEL_TEST] = LABEL_TEST_VALUE
             manifest_dict['spec']['capacity']['storage'] = storage
             manifest_dict['spec']['volumeMode'] = volumeMode
+            manifest_dict['spec']['storageClassName'] = sc_name
             manifest_dict['spec']['csi']['fsType'] = fsType
             manifest_dict['spec']['csi']['volumeHandle'] = name
+
+            if node_stage_secret_name:
+                manifest_dict['spec']['csi']['nodeStageSecretRef'] = {
+                    'name': node_stage_secret_name,
+                    'namespace': node_stage_secret_namespace or 'longhorn-system',
+                }
 
             logging(f"yaml = {manifest_dict}")
 

--- a/e2e/libs/replica/crd.py
+++ b/e2e/libs/replica/crd.py
@@ -4,6 +4,8 @@ import time
 from replica.base import Base
 from replica.rest import Rest
 
+from node_exec import NodeExec
+
 from utility.utility import logging
 from utility.utility import get_retry_count_and_interval
 import utility.constant as constant
@@ -86,3 +88,41 @@ class CRD(Base):
         for replica in replicas:
             assert str(replica["spec"][setting_name]) == value, \
             f"Expected volume {volume_name} replica setting {setting_name} is {value}, but it's {str(replica['spec'][setting_name])}"
+
+    def wait_for_replica_file_size(self, volume_name, expected_size):
+        replicas = self.get(volume_name)
+        for replica in replicas:
+            node_id = replica['spec']['nodeID']
+            dir_name = replica['spec']['dataDirectoryName']
+            cmd = (
+                f"find /var/lib/longhorn/replicas/{dir_name}/ "
+                f"-maxdepth 1 -name 'volume-head-*.img' -exec stat -c%s {{}} \\;"
+            )
+            node_exec = NodeExec(node_id)
+            try:
+                for i in range(self.retry_count):
+                    logging(
+                        f"Waiting for replica file size on node {node_id} for volume {volume_name} "
+                        f"to be {expected_size} ... ({i})"
+                    )
+                    try:
+                        result = node_exec.issue_cmd(cmd).strip()
+                        logging(
+                            f"Replica file size on node {node_id} for volume {volume_name}: "
+                            f"{result}, expected: {expected_size}"
+                        )
+                        if result == expected_size:
+                            break
+                    except Exception as e:
+                        logging(
+                            f"Error checking replica file size on node {node_id} "
+                            f"for volume {volume_name}: {e}"
+                        )
+                    time.sleep(self.retry_interval)
+                else:
+                    assert False, (
+                        f"Replica backend file on node {node_id} for volume {volume_name}: "
+                        f"expected {expected_size} B, got {result} B"
+                    )
+            finally:
+                node_exec.cleanup()

--- a/e2e/libs/replica/replica.py
+++ b/e2e/libs/replica/replica.py
@@ -33,3 +33,6 @@ class Replica(Base):
 
     def validate_replica_setting(self, volume_name, setting_name, value):
         return self.replica.validate_replica_setting(volume_name, setting_name, value)
+
+    def wait_for_replica_file_size(self, volume_name, expected_size):
+        return self.replica.wait_for_replica_file_size(volume_name, expected_size)

--- a/e2e/libs/volume/base.py
+++ b/e2e/libs/volume/base.py
@@ -176,13 +176,13 @@ class Base(ABC):
     def activate(self, volume_name):
         return NotImplemented
 
-    def create_persistentvolume(self, volume_name, retry, volumeMode, fsType):
+    def create_persistentvolume(self, volume_name, retry, volumeMode, fsType, sc_name="longhorn", node_stage_secret_name=None):
         logging(f'Creating PV {volume_name} for volume {volume_name}')
         volume = self.get(volume_name)
         volume_size = self._get_volume_size(volume)
         assert volume_size is not None, f"Cannot determine size for volume {volume_name}"
         storage = str(convert_size_to_bytes(str(volume_size)))
-        self.pv.create(volume_name, storage, volumeMode, fsType)
+        self.pv.create(volume_name, storage, volumeMode, fsType, sc_name=sc_name, node_stage_secret_name=node_stage_secret_name)
 
         if not retry:
             return
@@ -195,13 +195,13 @@ class Base(ABC):
             time.sleep(self.retry_interval)
         assert created
 
-    def create_persistentvolumeclaim(self, volume_name, volumeMode, retry):
+    def create_persistentvolumeclaim(self, volume_name, volumeMode, retry, sc_name="longhorn"):
         logging(f'Creating PVC {volume_name} for volume {volume_name}')
         volume = self.get(volume_name)
         volume_size = self._get_volume_size(volume)
         assert volume_size is not None, f"Cannot determine size for volume {volume_name}"
         storage = str(convert_size_to_bytes(str(volume_size)))
-        self.pvc.create(volume_name, "RWO", "longhorn", storage_size=storage, volume_name=volume_name, volumeMode=volumeMode)
+        self.pvc.create(volume_name, "RWO", sc_name, storage_size=storage, volume_name=volume_name, volumeMode=volumeMode)
 
         if not retry:
             return

--- a/e2e/libs/volume/base.py
+++ b/e2e/libs/volume/base.py
@@ -39,7 +39,7 @@ class Base(ABC):
         return NotImplemented
 
     @abstractmethod
-    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, rebuildConcurrentSyncLimit):
+    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, rebuildConcurrentSyncLimit, dataSource=""):
         return NotImplemented
 
     def set_data_checksum(self, volume_name, data_id, checksum):
@@ -176,13 +176,13 @@ class Base(ABC):
     def activate(self, volume_name):
         return NotImplemented
 
-    def create_persistentvolume(self, volume_name, retry, volumeMode, fsType, sc_name="longhorn", node_stage_secret_name=None):
+    def create_persistentvolume(self, volume_name, retry, volumeMode, fsType, sc_name="longhorn", node_stage_secret_name=None, node_stage_secret_namespace="longhorn-system"):
         logging(f'Creating PV {volume_name} for volume {volume_name}')
         volume = self.get(volume_name)
         volume_size = self._get_volume_size(volume)
         assert volume_size is not None, f"Cannot determine size for volume {volume_name}"
         storage = str(convert_size_to_bytes(str(volume_size)))
-        self.pv.create(volume_name, storage, volumeMode, fsType, sc_name=sc_name, node_stage_secret_name=node_stage_secret_name)
+        self.pv.create(volume_name, storage, volumeMode, fsType, sc_name=sc_name, node_stage_secret_name=node_stage_secret_name, node_stage_secret_namespace=node_stage_secret_namespace)
 
         if not retry:
             return

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -30,7 +30,7 @@ class CRD(Base):
         self.core_api = client.CoreV1Api()
         self.obj_api = client.CustomObjectsApi()
 
-    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, nodeSelector, diskSelector, backupBlockSize, rebuildConcurrentSyncLimit, snapshotMaxCount, replicaAutoBalance, retry=True):
+    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, nodeSelector, diskSelector, backupBlockSize, rebuildConcurrentSyncLimit, snapshotMaxCount, replicaAutoBalance, dataSource="", retry=True):
         longhorn_version = get_longhorn_client().by_id_setting('current-longhorn-version').value
         version_doesnt_support_block_backup_size_setting = ['v1.7', 'v1.8', 'v1.9']
         size = str(convert_size_to_bytes(size))
@@ -69,6 +69,9 @@ class CRD(Base):
 
         if not fromBackup:
             body["spec"]["size"] = size
+
+        if dataSource:
+            body["spec"]["dataSource"] = dataSource
 
         if not Standby and not any(ver in longhorn_version for ver in version_doesnt_support_block_backup_size_setting):
             body["spec"]["backupBlockSize"] = backupBlockSize

--- a/e2e/libs/volume/rest.py
+++ b/e2e/libs/volume/rest.py
@@ -43,7 +43,7 @@ class Rest(Base):
             time.sleep(self.retry_interval)
         return vol_list
 
-    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, backupBlockSize, rebuildConcurrentSyncLimit):
+    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, backupBlockSize, rebuildConcurrentSyncLimit, dataSource=""):
         return NotImplemented
 
     def attach(self, volume_name, node_name, disable_frontend, wait, retry):

--- a/e2e/libs/volume/volume.py
+++ b/e2e/libs/volume/volume.py
@@ -189,11 +189,11 @@ class Volume(Base):
     def activate(self, volume_name):
         return self.volume.activate(volume_name)
 
-    def create_persistentvolume(self, volume_name, retry, volumeMode, fsType):
-        return self.volume.create_persistentvolume(volume_name, retry, volumeMode, fsType)
+    def create_persistentvolume(self, volume_name, retry, volumeMode, fsType, sc_name="longhorn", node_stage_secret_name=None):
+        return self.volume.create_persistentvolume(volume_name, retry, volumeMode, fsType, sc_name=sc_name, node_stage_secret_name=node_stage_secret_name)
 
-    def create_persistentvolumeclaim(self, volume_name, volumeMode, retry):
-        return self.volume.create_persistentvolumeclaim(volume_name, volumeMode, retry)
+    def create_persistentvolumeclaim(self, volume_name, volumeMode, retry, sc_name="longhorn"):
+        return self.volume.create_persistentvolumeclaim(volume_name, volumeMode, retry, sc_name=sc_name)
 
     def upgrade_engine_image(self, volume_name, engine_image_name):
         return self.volume.upgrade_engine_image(volume_name, engine_image_name)

--- a/e2e/libs/volume/volume.py
+++ b/e2e/libs/volume/volume.py
@@ -17,8 +17,8 @@ class Volume(Base):
         else:
             self.volume = Rest()
 
-    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, nodeSelector, diskSelector, backupBlockSize, rebuildConcurrentSyncLimit, snapshotMaxCount, replicaAutoBalance, retry):
-        return self.volume.create(volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, nodeSelector, diskSelector, backupBlockSize, rebuildConcurrentSyncLimit, snapshotMaxCount, replicaAutoBalance, retry)
+    def create(self, volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, nodeSelector, diskSelector, backupBlockSize, rebuildConcurrentSyncLimit, snapshotMaxCount, replicaAutoBalance, dataSource, retry):
+        return self.volume.create(volume_name, size, numberOfReplicas, frontend, migratable, dataLocality, accessMode, dataEngine, backingImage, Standby, fromBackup, encrypted, nodeSelector, diskSelector, backupBlockSize, rebuildConcurrentSyncLimit, snapshotMaxCount, replicaAutoBalance, dataSource, retry)
 
     def delete(self, volume_name, wait):
         return self.volume.delete(volume_name, wait)
@@ -189,8 +189,8 @@ class Volume(Base):
     def activate(self, volume_name):
         return self.volume.activate(volume_name)
 
-    def create_persistentvolume(self, volume_name, retry, volumeMode, fsType, sc_name="longhorn", node_stage_secret_name=None):
-        return self.volume.create_persistentvolume(volume_name, retry, volumeMode, fsType, sc_name=sc_name, node_stage_secret_name=node_stage_secret_name)
+    def create_persistentvolume(self, volume_name, retry, volumeMode, fsType, sc_name="longhorn", node_stage_secret_name=None, node_stage_secret_namespace="longhorn-system"):
+        return self.volume.create_persistentvolume(volume_name, retry, volumeMode, fsType, sc_name=sc_name, node_stage_secret_name=node_stage_secret_name, node_stage_secret_namespace=node_stage_secret_namespace)
 
     def create_persistentvolumeclaim(self, volume_name, volumeMode, retry, sc_name="longhorn"):
         return self.volume.create_persistentvolumeclaim(volume_name, volumeMode, retry, sc_name=sc_name)

--- a/e2e/tests/regression/test_encrypted_volume.robot
+++ b/e2e/tests/regression/test_encrypted_volume.robot
@@ -13,6 +13,8 @@ Resource    ../keywords/workload.resource
 Resource    ../keywords/sharemanager.resource
 Resource    ../keywords/longhorn.resource
 Resource    ../keywords/volume.resource
+Resource    ../keywords/snapshot.resource
+Resource    ../keywords/backing_image.resource
 Resource    ../keywords/backup.resource
 Resource    ../keywords/backupstore.resource
 Resource    ../keywords/host.resource
@@ -23,55 +25,35 @@ Resource    ../keywords/setting.resource
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
-*** Keywords ***
-Assert replica backend file sizes for volume ${volume_id} are ${expected_size}
-    [Documentation]    Verify replica backend head image file sizes for a raw (non-PVC) Longhorn volume.
-    ${expected_bytes} =    convert_size_to_bytes    ${expected_size}
-    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
-    ${replicas} =    get_replicas    ${volume_name}
-    FOR    ${replica}    IN    @{replicas}
-        ${node_id} =    Set Variable    ${replica}[spec][nodeID]
-        ${dir_name} =    Set Variable    ${replica}[spec][dataDirectoryName]
-        ${cmd} =    Set Variable
-        ...    find /var/lib/longhorn/replicas/${dir_name}/ -maxdepth 1 -name 'volume-head-*.img' -exec stat -c%s {} \\;
-        Wait Until Keyword Succeeds    ${RETRY_COUNT}    ${RETRY_INTERVAL}
-        ...    Check replica file size on node    ${cmd}    ${node_id}    ${expected_bytes}    ${volume_name}
-    END
-
-Check replica file size on node
-    [Arguments]    ${cmd}    ${node_id}    ${expected_bytes}    ${volume_name}
-    ${result} =    execute_command_on_node    ${cmd}    ${node_id}
-    Should Be Equal As Integers    ${result.strip()}    ${expected_bytes}
-    ...    msg=Replica backend file on node ${node_id} for volume ${volume_name}: expected ${expected_bytes} B, got ${result.strip()} B
-
-Assert block device size in deployment pod for deployment ${deployment_id} is ${size}
-    ${expected_bytes} =    convert_size_to_bytes    ${size}    to_str=True
-    ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
-    ${pod_name} =    get_workload_pod_name    ${deployment_name}
-    ${cmd} =    Set Variable    blockdev --getsize64 /dev/longhorn/longhorn-testblk
-    ${result} =    pod_exec    ${pod_name}    default    ${cmd}
-    Should Be Equal As Integers    ${result.strip()}    ${expected_bytes}
-    ...    msg=Block device size in pod ${pod_name}: expected ${expected_bytes} B, got ${result.strip()} B
-
 *** Test Cases ***
 Test Encrypted Volume Basic
     [Tags]    rwo    rwx
     [Documentation]    Test basic encrypted volume operations for both RWO and RWX volumes.
     ...                Deployment 0 = RWO, Deployment 1 = RWX.
+    ...
+    ...                Expected sizes for a 100 Mi volume:
+    ...                    - Replica backend file = 116 Mi (requested + 16 Mi pre-allocated).
+    ...                    - v2 data engine: Replica backend N/A (format differs, only device size is verified).
+    ...                    - dm-crypt device (RWO instance manager) = 100 Mi (full requested size).
+    ...                    - dm-crypt device (RWX sharemanager pod) = 100 Mi (full requested size).
+    ...                    - Mounted filesystem (workload pod, RWO/RWX) = ~100 Mi (accounting for filesystem overhead).
     Given Create crypto secret
     When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
-    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=100Mi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=100Mi
     And Create deployment 0 with persistentvolumeclaim 0
     And Create deployment 1 with persistentvolumeclaim 1
     And Wait for volume of deployment 0 healthy
     And Wait for volume of deployment 1 healthy
     IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 1040MiB
-        Assert replica file size of deployment 1 is 1040MiB
+        Assert replica file size of deployment 0 is 116Mi
+        Assert replica file size of deployment 1 is 116Mi
     END
-    And Write 100 MB data to file data.txt in deployment 0
-    And Write 100 MB data to file data.txt in deployment 1
+    # Verify sizes at different layers: backend replica → dm-crypt device → mounted filesystem
+    And Assert disk size in instance manager pod for deployment 0 is 100Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 100Mi
+    And Write 10 MB data to file data.txt in deployment 0
+    And Write 10 MB data to file data.txt in deployment 1
     Then Check deployment 0 data in file data.txt is intact
     And Check deployment 1 data in file data.txt is intact
 
@@ -84,20 +66,132 @@ Test Encrypted Volume Basic
     And Wait for workloads pods stable    deployment 0
     And Wait for workloads pods stable    deployment 1
     IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 1040MiB
-        Assert replica file size of deployment 1 is 1040MiB
+        Assert replica file size of deployment 0 is 116Mi
+        Assert replica file size of deployment 1 is 116Mi
     END
+    # Re-verify sizes after scale down/up cycle
+    And Assert disk size in instance manager pod for deployment 0 is 100Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 100Mi
     Then Check deployment 0 data in file data.txt is intact
     And Check deployment 1 data in file data.txt is intact
 
-Test Encrypted Volume Online Expansion
-    [Tags]    rwo    rwx    expansion
-    [Documentation]    Test online expansion for both RWO and RWX encrypted volumes.
-    ...                Deployment 0 = RWO, Deployment 1 = RWX.
+Test Encrypted Volume Cloning
+    [Tags]    rwo    rwx
     Given Create crypto secret
     When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=50MiB
-    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=50MiB
+    And Create persistentvolumeclaim source-rwo-pvc    volume_type=RWO    sc_name=longhorn-crypto    storage_size=100Mi
+    And Create persistentvolumeclaim source-rwx-pvc    volume_type=RWX    sc_name=longhorn-crypto    storage_size=100Mi
+    And Wait for volume of persistentvolumeclaim source-rwo-pvc to be created
+    And Wait for volume of persistentvolumeclaim source-rwx-pvc to be created
+    And Wait for volume of persistentvolumeclaim source-rwo-pvc detached
+    And Wait for volume of persistentvolumeclaim source-rwx-pvc detached
+
+    And Create deployment source-rwo-deployment with persistentvolumeclaim source-rwo-pvc
+    And Create deployment source-rwx-deployment with persistentvolumeclaim source-rwx-pvc
+    And Wait for volume of deployment source-rwo-deployment healthy
+    And Wait for volume of deployment source-rwx-deployment healthy
+    And Wait for workloads pods stable    deployment source-rwo-deployment
+    And Wait for workloads pods stable    deployment source-rwx-deployment
+    And Write 10 MB data to file data.txt in deployment source-rwo-deployment
+    And Write 10 MB data to file data.txt in deployment source-rwx-deployment
+    And Record file data.txt checksum in deployment source-rwo-deployment as checksum source-rwo-pvc
+    And Record file data.txt checksum in deployment source-rwx-deployment as checksum source-rwx-pvc
+
+
+    When Create persistentvolumeclaim cloned-rwo-pvc from persistentvolumeclaim source-rwo-pvc    volume_type=RWO    sc_name=longhorn-crypto    storage_size=100Mi
+    And Create persistentvolumeclaim cloned-rwx-pvc from persistentvolumeclaim source-rwx-pvc    volume_type=RWX    sc_name=longhorn-crypto    storage_size=100Mi
+    And Wait for volume of persistentvolumeclaim cloned-rwo-pvc detached
+    And Wait for volume of persistentvolumeclaim cloned-rwx-pvc detached
+
+    And Create deployment cloned-rwo-deployment with persistentvolumeclaim cloned-rwo-pvc
+    And Create deployment cloned-rwx-deployment with persistentvolumeclaim cloned-rwx-pvc
+
+    And Wait for volume of deployment cloned-rwo-deployment healthy
+    And Wait for volume of deployment cloned-rwx-deployment healthy
+    And Wait for workloads pods stable    deployment cloned-rwo-deployment
+    And Wait for workloads pods stable    deployment cloned-rwx-deployment
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment cloned-rwo-deployment is 116Mi
+        Assert replica file size of deployment cloned-rwx-deployment is 116Mi
+    END
+    And Assert disk size in instance manager pod for deployment cloned-rwo-deployment is 100Mi
+    And Assert encrypted disk size in sharemanager pod for deployment cloned-rwx-deployment is 100Mi
+    And Check deployment cloned-rwo-deployment file data.txt checksum matches checksum source-rwo-pvc
+    And Check deployment cloned-rwx-deployment file data.txt checksum matches checksum source-rwx-pvc
+
+Test Encrypted Volume Snapshot Clone
+    [Tags]    rwo    snapshot    clone
+    [Documentation]    Test creating an encrypted volume from another encrypted volume's snapshot.
+    ...
+    ...                Steps:
+    ...                  1. Create a 100 Mi encrypted RWO volume (deployment 0).
+    ...                  2. Write 10 MB of data and record checksum.
+    ...                  3. Take a snapshot (snapshot 0).
+    ...                  4. Create a new encrypted volume (volume 1) from snapshot 0.
+    ...                  5. Attach the new volume to deployment 1 via the crypto StorageClass.
+    ...                  6. Verify data integrity and size.
+    ...
+    ...                Expected (v1 data engine):
+    ...                  - Source volume: dm-crypt device = 100 Mi, replica = 116 Mi.
+    ...                  - Cloned volume: dm-crypt device = 100 Mi, replica = 116 Mi.
+    ...                  - Data checksum matches original.
+    ...
+    ...                Expected (v2 data engine):
+    ...                  - Source volume: dm-crypt device = 84 Mi (requested - 16 Mi).
+    ...                  - Cloned volume: dm-crypt device = 84 Mi (requested - 16 Mi).
+    ...                  - Data checksum matches original.
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
+    Given Create crypto secret
+    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=100Mi
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Wait for volume of deployment 0 healthy
+    And Write 10 MB data to file data.txt in deployment 0
+    Then Check deployment 0 data in file data.txt is intact
+    And Record file data.txt checksum in deployment 0 as checksum 0
+
+    # Verify source volume size
+    Assert disk size in instance manager pod for deployment 0 is 100Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 116Mi
+    END
+
+    # Create snapshot from source volume
+    When Create snapshot 0 for deployment 0 volume
+    And Wait for snapshot 0 of deployment 0 volume ready
+
+    # Create new encrypted volume from snapshot
+    When Create volume 1 from snapshot 0 of deployment 0 volume    size=100Mi    encrypted=True    dataEngine=${DATA_ENGINE}
+    And Wait for volume 1 detached
+
+    # Attach cloned volume to new deployment with crypto SC (to trigger luksOpen)
+    And Create deployment 1 with volume 1    sc_name=longhorn-crypto    node_stage_secret_name=longhorn-crypto
+    And Wait for volume of deployment 1 healthy
+
+    # Verify cloned volume size and data integrity
+    Then Check deployment 1 file data.txt checksum matches checksum 0
+    And Assert disk size in instance manager pod for deployment 1 is 100Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 1 is 116Mi
+    END
+
+Test Encrypted Volume Expansion
+    [Tags]    rwo    rwx    expansion
+    [Documentation]    Test Plan: Volume Expansion – new engine path (RWO + RWX)
+    ...
+    ...                Create a 100 Mi encrypted volume (new engine), write 10 Mi of data,
+    ...                then expand to 200 Mi. Deployment 0 = RWO, Deployment 1 = RWX.
+    ...
+    ...                Expected after expansion:
+    ...                  - Instance manager (RWO) shows 200 Mi.
+    ...                  - Share manager pod (RWX) shows 200 Mi; pod is NOT recreated.
+    ...                  - Replica image file on the worker node shows 200 Mi + 16 Mi = 216 Mi.
+    ...                  - Previously written data is intact.
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
+    Given Create crypto secret
+    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=100Mi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=100Mi
     And Create deployment 0 with persistentvolumeclaim 0
     And Create deployment 1 with persistentvolumeclaim 1
     And Wait for volume of deployment 0 healthy
@@ -107,36 +201,27 @@ Test Encrypted Volume Online Expansion
     Then Check deployment 0 data in file data.txt is intact
     And Check deployment 1 data in file data.txt is intact
 
-    When Expand deployment 0 volume to 100 MiB
-    And Expand deployment 1 volume to 100 MiB
+    When Expand deployment 0 volume to 200Mi
+    And Expand deployment 1 volume to 200Mi
     Then Wait for deployment 0 volume size expanded
     And Wait for deployment 1 volume size expanded
     And Check deployment 0 pods did not restart
     And Check deployment 1 pods did not restart
     And Check no sharemanager pod of deployment 1 recreation
-    # NOTE: With the new engine (v1.12+), the 16 MiB LUKS header is pre-allocated
-    # in the replica backend file (replica size = requested size + 16 MiB).
-    # The dm-crypt device therefore presents the full requested size to the workload.
-    # Therefore, a 100 MiB requested volume results in a 100 MiB dm-crypt device.
-    And Assert disk size in instance manager pod for deployment 0 is 100MiB
-    And Assert encrypted disk size in sharemanager pod for deployment 1 is 100MiB
-
-    When Scale down deployment 0 to detach volume
-    And Scale down deployment 1 to detach volume
-    And Scale up deployment 0 to attach volume
-    And Scale up deployment 1 to attach volume
-    And Wait for volume of deployment 0 healthy
-    And Wait for volume of deployment 1 healthy
-    And Wait for workloads pods stable    deployment 0
-    And Wait for workloads pods stable    deployment 1
-    Then Check deployment 0 data in file data.txt is intact
+    And Assert disk size in instance manager pod for deployment 0 is 200Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 200Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 216Mi
+        Assert replica file size of deployment 1 is 216Mi
+    END
+    And Check deployment 0 data in file data.txt is intact
     And Check deployment 1 data in file data.txt is intact
 
 Test Encrypted RWO Block Volume Online Expansion
     [Tags]    rwo    expansion    block-volume
     Given Create crypto secret
     And Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volumeMode=Block    volume_type=RWO    sc_name=longhorn-crypto    storage_size=50MiB
+    And Create persistentvolumeclaim 0    volumeMode=Block    volume_type=RWO    sc_name=longhorn-crypto    storage_size=100Mi
     And Create deployment 0 with block persistentvolumeclaim 0
     And Wait for volume of deployment 0 healthy
     And Make block device filesystem in deployment 0
@@ -144,15 +229,16 @@ Test Encrypted RWO Block Volume Online Expansion
     And Write 10 MB data to file data1.txt in deployment 0
     Then Check deployment 0 data in file data1.txt is intact
 
-    When Expand deployment 0 volume to 100 MiB
+    When Expand deployment 0 volume to 200 Mi
     Then Wait for deployment 0 volume size expanded
     And Check deployment 0 pods did not restart
     # Verify the actual disk size in the instance manager pod.
-    # NOTE: With the new engine (v1.12+), the 16 MiB LUKS header is pre-allocated
-    # in the replica backend file (replica size = requested size + 16 MiB).
+    # NOTE: With the new engine (v1.12+), the 16 Mi LUKS header is pre-allocated
+    # in the replica backend file (replica size = requested size + 16 Mi).
     # The dm-crypt device therefore presents the full requested size to the workload.
-    # Therefore, a 100 MiB requested volume results in a 100 MiB dm-crypt device.
-    And Assert disk size in instance manager pod for deployment 0 is 100MiB
+    # Therefore, after expansion to 200 Mi, the dm-crypt device shows 200 Mi.
+    And Assert disk size in instance manager pod for deployment 0 is 200Mi
+    And Assert block device size in deployment pod for deployment 0 is 200Mi
     When Scale down deployment 0 to detach volume
     And Scale up deployment 0 to attach volume
     Then Wait for volume of deployment 0 healthy
@@ -161,308 +247,50 @@ Test Encrypted RWO Block Volume Online Expansion
     And Write 60 MB data to file data2.txt in deployment 0
     Then Check deployment 0 data in file data2.txt is intact
 
-Test Encrypted Block Volume Creation Size
-    [Tags]    rwo    block-volume
-    [Documentation]    Test Plan: New Block Volume Creation (RWO, v1 + v2)
-    ...
-    ...                Create a 1 GiB encrypted Block-mode volume.
-    ...                Note: RWX + volumeMode=Block is not supported – Longhorn's share manager
-    ...                      uses NFS which cannot expose a raw block device to the workload.
-    ...
-    ...                Expected:
-    ...                  - blockdev --getsize64 inside the pod shows exactly
-    ...                    1073741824 bytes (1 GiB) – the full requested size is usable.
-    ...                  - (v1 only) The backend replica image file on the worker node is exactly
-    ...                    1024 MiB + 16 MiB = 1040 MiB (1090519040 bytes).
-    ...                    For v2 the replica backend format differs; only the block device size
-    ...                    is verified (similar issue: https://github.com/longhorn/longhorn/issues/9205).
-    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
-    Given Create crypto secret
-    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volumeMode=Block    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
-    And Create deployment 0 with block persistentvolumeclaim 0
-    And Wait for volume of deployment 0 healthy
-    Then Assert block device size in deployment pod for deployment 0 is 1Gi
-    IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 1040MiB
-    END
-
-Test Encrypted Volume Creation Size
-    [Tags]    rwo    rwx
-    [Documentation]    Test Plan: New Volume Creation (RWO + RWX)
-    ...
-    ...                Create a 1024 MiB encrypted volume with the current (new) engine image.
-    ...                Deployment 0 = RWO, Deployment 1 = RWX.
-    ...
-    ...                Expected:
-    ...                  - The dm-crypt device inside the instance manager (RWO) shows 1024 MiB.
-    ...                  - The dm-crypt device inside the share manager pod (RWX) shows 1024 MiB.
-    ...                  - The backend replica image file on the worker node is exactly
-    ...                    1024 MiB + 16 MiB = 1040 MiB (1090519040 bytes).
-    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
-    Given Create crypto secret
-    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1024MiB
-    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1024MiB
-    And Create deployment 0 with persistentvolumeclaim 0
-    And Create deployment 1 with persistentvolumeclaim 1
-    And Wait for volume of deployment 0 healthy
-    And Wait for volume of deployment 1 healthy
-    Then Assert disk size in instance manager pod for deployment 0 is 1024MiB
-    And Assert encrypted disk size in sharemanager pod for deployment 1 is 1024MiB
-    IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 1040MiB
-        Assert replica file size of deployment 1 is 1040MiB
-    END
-
-Test Encrypted Volume Expansion
-    [Tags]    rwo    rwx    expansion
-    [Documentation]    Test Plan: Volume Expansion – new engine path (RWO + RWX)
-    ...
-    ...                Create a 1 GiB encrypted volume (new engine), write 100 MiB of data,
-    ...                then expand to 2 GiB. Deployment 0 = RWO, Deployment 1 = RWX.
-    ...
-    ...                Expected after expansion:
-    ...                  - Instance manager (RWO) shows 2 GiB.
-    ...                  - Share manager pod (RWX) shows 2 GiB; pod is NOT recreated.
-    ...                  - Replica image file on the worker node shows 2 GiB + 16 MiB = 2064 MiB.
-    ...                  - Previously written data is intact.
-    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
-    Given Create crypto secret
-    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
-    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
-    And Create deployment 0 with persistentvolumeclaim 0
-    And Create deployment 1 with persistentvolumeclaim 1
-    And Wait for volume of deployment 0 healthy
-    And Wait for volume of deployment 1 healthy
-    And Write 100 MB data to file data.txt in deployment 0
-    And Write 100 MB data to file data.txt in deployment 1
-    Then Check deployment 0 data in file data.txt is intact
-    And Check deployment 1 data in file data.txt is intact
-
-    When Expand deployment 0 volume to 2GiB
-    And Expand deployment 1 volume to 2GiB
-    Then Wait for deployment 0 volume size expanded
-    And Wait for deployment 1 volume size expanded
-    And Check deployment 0 pods did not restart
-    And Check deployment 1 pods did not restart
-    And Check no sharemanager pod of deployment 1 recreation
-    And Assert disk size in instance manager pod for deployment 0 is 2GiB
-    And Assert encrypted disk size in sharemanager pod for deployment 1 is 2GiB
-    IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 2064MiB
-        Assert replica file size of deployment 1 is 2064MiB
-    END
-    And Check deployment 0 data in file data.txt is intact
-    And Check deployment 1 data in file data.txt is intact
-
-Test Encrypted Volume Upgrade
-    [Tags]    rwo    rwx    expansion    replica-rebuild    engine-upgrade    old-engine
-    [Documentation]    Test Plan: Old Engine – Expansion + Replica Rebuild + Engine Upgrade (RWO + RWX)
-    ...
-    ...                - Requires LONGHORN_STABLE_VERSION to be set (2-stage upgrade CI pipeline).
-    ...                - Covers old-engine (v1.11) expansion, replica rebuild, and engine upgrade
-    ...                  behaviors in a single Longhorn uninstall/reinstall/upgrade cycle.
-    ...                - Deployment 0 = RWO, Deployment 1 = RWX.
-    ...
-    ...                Steps:
-    ...                  - 1. Install stable Longhorn (v1.11) and create 1 GiB encrypted
-    ...                       RWO (deployment 0) and RWX (deployment 1) volumes.
-    ...                  - 2. Verify old-engine initial state:
-    ...                       - Device = 1024 MiB - 16 MiB = 1008 MiB.
-    ...                       - Replica file = 1 GiB (no extra 16 MiB).
-    ...                  - 3. Write 100 MiB of data. Upgrade Longhorn to v1.12+ keeping old engine.
-    ...                  - 4. Verify old engine semantics are preserved (same as step 2).
-    ...                  - 5. (Backup/Restore) Back up old-engine volumes before upgrade,
-    ...                       restore as encrypted=True after upgrade; verify new-engine sizing:
-    ...                       - Device = 1 GiB (full, 16 MiB pre-allocated in backend).
-    ...                       - Replica file = 1 GiB + 16 MiB = 1040 MiB.
-    ...                       - Data integrity preserved.
-    ...                  - 6. (Expansion) Expand to 2 GiB; verify:
-    ...                       - Device = 2048 MiB - 16 MiB = 2032 MiB.
-    ...                       - Replica file = 2 GiB; share manager pod NOT recreated.
-    ...                  - 7. (Replica Rebuild) Delete one replica per volume; verify:
-    ...                       - Rebuilt replica file = 2 GiB (old engine: no extra 16 MiB).
-    ...                  - 8. (Engine Upgrade, if CUSTOM_LONGHORN_ENGINE_IMAGE is set)
-    ...                       Upgrade both volumes to the new engine; verify:
-    ...                       - Device = 2 GiB (full usable size).
-    ...                       - Replica file = 2 GiB + 16 MiB = 2064 MiB.
-    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
-    ${LONGHORN_STABLE_VERSION} =    Get Environment Variable    LONGHORN_STABLE_VERSION    default=
-    IF    '${LONGHORN_STABLE_VERSION}' == ''
-        Skip    Environment variable LONGHORN_STABLE_VERSION is not set
-    ELSE IF    not '${LONGHORN_STABLE_VERSION}'.startswith('v1.11.')
-        Skip    This test only applies to the v1.11.x → v1.12+ upgrade path; got stable version ${LONGHORN_STABLE_VERSION}
-    END
-
-    Given Setting deleting-confirmation-flag is set to true
-    And Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}    numberOfReplicas=3
-    And Uninstall Longhorn
-    And Check Longhorn CRD removed
-    And Install Longhorn stable version
-    And Set default backupstore
-    And Enable v2 data engine and add block disks
-
-    When Create crypto secret
-    And Create storageclass longhorn-crypto-stable with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto-stable    storage_size=1Gi
-    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto-stable    storage_size=1Gi
-    And Create deployment 0 with persistentvolumeclaim 0
-    And Create deployment 1 with persistentvolumeclaim 1
-    And Wait for volume of deployment 0 healthy
-    And Wait for volume of deployment 1 healthy
-    # Verify old-engine initial state before Longhorn upgrade
-    Then Assert disk size in instance manager pod for deployment 0 is 1008MiB
-    And Assert encrypted disk size in sharemanager pod for deployment 1 is 1008MiB
-    IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 1024MiB
-        Assert replica file size of deployment 1 is 1024MiB
-    END
-
-    When Write 100 MB data to file data.txt in deployment 0
-    And Write 100 MB data to file data.txt in deployment 1
-    Then Check deployment 0 data in file data.txt is intact
-    And Check deployment 1 data in file data.txt is intact
-
-    # Take backups before upgrade (old-engine v1.11: no LUKS pre-allocation)
-    When Create backup 0 for deployment 0 volume
-    And Verify backup list contains backup no error for deployment 0 volume
-    And Create backup 1 for deployment 1 volume
-    And Verify backup list contains backup no error for deployment 1 volume
-
-    # Upgrade Longhorn system to v1.12+ but keep both volumes on the old engine image
-    When Setting concurrent-automatic-engine-upgrade-per-node-limit is set to 0
-    And Upgrade Longhorn to custom version
-    And Wait for volume of deployment 0 healthy
-    And Wait for volume of deployment 1 healthy
-
-    # Verify old engine semantics are preserved after Longhorn upgrade
-    Then Assert disk size in instance manager pod for deployment 0 is 1008MiB
-    And Assert encrypted disk size in sharemanager pod for deployment 1 is 1008MiB
-    IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 1024MiB
-        Assert replica file size of deployment 1 is 1024MiB
-    END
-
-    # --- Backup/Restore: pre-upgrade backup → new-engine restore (after upgrade) ---
-    # Restore pre-upgrade (v1.11 old-engine) backups with new Longhorn (v1.12+).
-    # New Longhorn provisions the restored volume with new-engine semantics:
-    # 16 MiB pre-allocated in the backend → device = full 1 GiB, replica = 1040 MiB.
-    # v2 data engine does not support encrypted volume CSI mounting via luksOpen;
-    # the backup/restore encrypted path is therefore skipped for v2.
-    # https://github.com/longhorn/longhorn/issues/13163.
-    IF    '${DATA_ENGINE}' == 'v1'
-        Create volume 2 from backup 0 of deployment 0 volume    size=1Gi    encrypted=True    dataEngine=${DATA_ENGINE}
-        Create volume 3 from backup 1 of deployment 1 volume    size=1Gi    encrypted=True    dataEngine=${DATA_ENGINE}
-        Wait for volume 2 healthy
-        Wait for volume 3 healthy
-        Create deployment 2 with volume 2    sc_name=longhorn-crypto-stable    node_stage_secret_name=longhorn-crypto
-        Create deployment 3 with volume 3    sc_name=longhorn-crypto-stable    node_stage_secret_name=longhorn-crypto
-        Wait for volume of deployment 2 healthy
-        Wait for volume of deployment 3 healthy
-        Assert disk size in instance manager pod for deployment 2 is 1Gi
-        Assert disk size in instance manager pod for deployment 3 is 1Gi
-        Assert replica file size of deployment 2 is 1040MiB
-        Assert replica file size of deployment 3 is 1040MiB
-        Check deployment 2 data in file data.txt is intact compared to deployment 0
-        Check deployment 3 data in file data.txt is intact compared to deployment 1
-    END
-
-    # --- Old engine: Volume Expansion ---
-    When Expand deployment 0 volume to 2GiB
-    And Expand deployment 1 volume to 2GiB
-    Then Wait for deployment 0 volume size expanded
-    And Wait for deployment 1 volume size expanded
-    And Check deployment 0 pods did not restart
-    And Check deployment 1 pods did not restart
-    And Assert disk size in instance manager pod for deployment 0 is 2032MiB
-    And Check no sharemanager pod of deployment 1 recreation
-    And Assert encrypted disk size in sharemanager pod for deployment 1 is 2032MiB
-    IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 2048MiB
-        Assert replica file size of deployment 1 is 2048MiB
-    END
-    And Check deployment 0 data in file data.txt is intact
-    And Check deployment 1 data in file data.txt is intact
-
-    # --- Old engine: Replica Rebuild (at 2 GiB) ---
-    When Delete replica of deployment 0 volume on replica node
-    And Wait until volume of deployment 0 replica rebuilding completed on replica node
-    Then Wait for volume of deployment 0 healthy
-    IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 2048MiB
-    END
-    And Check deployment 0 data in file data.txt is intact
-
-    When Delete replica of deployment 1 volume on replica node
-    And Wait until volume of deployment 1 replica rebuilding completed on replica node
-    Then Wait for volume of deployment 1 healthy
-    IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 1 is 2048MiB
-    END
-    And Check deployment 1 data in file data.txt is intact
-
-    # --- Engine Upgrade (only if CUSTOM_LONGHORN_ENGINE_IMAGE is set, v1 only) ---
-    ${CUSTOM_LONGHORN_ENGINE_IMAGE} =    Get Environment Variable    CUSTOM_LONGHORN_ENGINE_IMAGE    default=
-    IF    '${CUSTOM_LONGHORN_ENGINE_IMAGE}' != '' and '${DATA_ENGINE}' == 'v1'
-        # Upgrade both volumes to the new engine image
-        Upgrade v1 volumes engine to ${CUSTOM_LONGHORN_ENGINE_IMAGE}
-        Wait for volume of deployment 0 healthy
-        Wait for volume of deployment 1 healthy
-        # After engine upgrade: device = 2 GiB (full), replica = 2 GiB + 16 MiB = 2064 MiB
-        Assert disk size in instance manager pod for deployment 0 is 2GiB
-        Assert encrypted disk size in sharemanager pod for deployment 1 is 2GiB
-        Assert replica file size of deployment 0 is 2064MiB
-        Assert replica file size of deployment 1 is 2064MiB
-        Check deployment 0 data in file data.txt is intact
-        Check deployment 1 data in file data.txt is intact
-    END
-
 Test Encrypted Volume Replica Rebuild
     [Tags]    rwo    rwx    replica-rebuild
     [Documentation]    Test Plan: Replica Rebuild – new engine path (RWO + RWX)
     ...
-    ...                Create a 1 GiB encrypted RWO volume (deployment 0) and RWX volume
+    ...                Create a 100 Mi encrypted RWO volume (deployment 0) and RWX volume
     ...                (deployment 1) with the new engine.
-    ...                Write 100 MiB of data to each, then delete one replica per volume
+    ...                Write 10 Mi of data to each, then delete one replica per volume
     ...                to trigger a rebuild.
     ...
     ...                Expected after rebuild:
     ...                  - Rebuild completes successfully (volume returns to healthy).
-    ...                  - The dm-crypt device size is unchanged: 1024 MiB (RWO instance manager)
-    ...                    and 1024 MiB (RWX share manager pod).
-    ...                  - The newly rebuilt replica file size is 1024 MiB + 16 MiB = 1040 MiB,
+    ...                  - The dm-crypt device size is unchanged: 100 Mi (RWO instance manager)
+    ...                    and 100 Mi (RWX share manager pod).
+    ...                  - The newly rebuilt replica file size is 100 Mi + 16 Mi = 116 Mi,
     ...                    matching the existing replicas (v1 only).
     ...                  - Data integrity (md5sum / checksum) is intact.
     Given Create crypto secret
     When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
-    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=100Mi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=100Mi
     And Create deployment 0 with persistentvolumeclaim 0
     And Create deployment 1 with persistentvolumeclaim 1
     And Wait for volume of deployment 0 healthy
     And Wait for volume of deployment 1 healthy
-    And Write 100 MB data to file data.txt in deployment 0
-    And Write 100 MB data to file data.txt in deployment 1
+    And Write 10 MB data to file data.txt in deployment 0
+    And Write 10 MB data to file data.txt in deployment 1
     Then Check deployment 0 data in file data.txt is intact
     And Check deployment 1 data in file data.txt is intact
 
     When Delete replica of deployment 0 volume on replica node
     And Wait until volume of deployment 0 replica rebuilding completed on replica node
     Then Wait for volume of deployment 0 healthy
-    And Assert disk size in instance manager pod for deployment 0 is 1024MiB
+    And Assert disk size in instance manager pod for deployment 0 is 100Mi
     IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 0 is 1040MiB
+        Assert replica file size of deployment 0 is 116Mi
     END
     And Check deployment 0 data in file data.txt is intact
 
     When Delete replica of deployment 1 volume on replica node
     And Wait until volume of deployment 1 replica rebuilding completed on replica node
     Then Wait for volume of deployment 1 healthy
-    And Assert encrypted disk size in sharemanager pod for deployment 1 is 1024MiB
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 100Mi
     IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 1 is 1040MiB
+        Assert replica file size of deployment 1 is 116Mi
     END
     And Check deployment 1 data in file data.txt is intact
 
@@ -470,32 +298,34 @@ Test Encrypted Volume Backup Restore To Encrypted Volume
     [Tags]    rwo    rwx    backup    restore
     [Documentation]    Test Plan: Backup Restore – restore as encrypted (RWO + RWX)
     ...
-    ...                Create a 1 GiB encrypted RWO volume (deployment 0) and RWX volume
-    ...                (deployment 1), write 100 MiB of data to each, take backups.
+    ...                Create a 100 Mi encrypted RWO volume (deployment 0) and RWX volume
+    ...                (deployment 1), write 10 Mi of data to each, take backups.
     ...                Restore each backup to a new encrypted volume.
     ...                Deployment 0 = RWO source, Deployment 1 = RWX source.
     ...                Deployment 2 = restored from dep 0 backup, Deployment 3 = restored from dep 1 backup.
     ...
     ...                Expected:
-    ...                  - Restored volumes' dm-crypt device shows exactly 1 GiB.
-    ...                  - Restored volumes' replica backend file is exactly 1024 MiB + 16 MiB.
-    ...                  - The 100 MiB payload checksum matches the original.
+    ...                  - Restored volumes' dm-crypt device shows exactly 100 Mi.
+    ...                  - Restored volumes' replica backend file is exactly 100 Mi + 16 Mi.
+    ...                  - The 10 Mi payload checksum matches the original.
     ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
     IF    '${DATA_ENGINE}' == 'v2'
         Skip    v2 data engine does not support encrypted volume restore with encrypted=True (https://github.com/longhorn/longhorn/issues/13163)
     END
     Given Create crypto secret
     And Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    When Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
-    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
+    When Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=100Mi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=100Mi
     And Create deployment 0 with persistentvolumeclaim 0
     And Create deployment 1 with persistentvolumeclaim 1
     And Wait for volume of deployment 0 healthy
     And Wait for volume of deployment 1 healthy
-    And Write 100 MB data to file data.txt in deployment 0
-    And Write 100 MB data to file data.txt in deployment 1
+    And Write 10 MB data to file data.txt in deployment 0
+    And Write 10 MB data to file data.txt in deployment 1
     Then Check deployment 0 data in file data.txt is intact
     And Check deployment 1 data in file data.txt is intact
+    And Record file data.txt checksum in deployment 0 as checksum 0
+    And Record file data.txt checksum in deployment 1 as checksum 1
 
     When Create backup 0 for deployment 0 volume
     And Verify backup list contains backup no error for deployment 0 volume
@@ -503,8 +333,8 @@ Test Encrypted Volume Backup Restore To Encrypted Volume
     And Verify backup list contains backup no error for deployment 1 volume
 
     # Restore to new encrypted volumes (encrypted=True)
-    When Create volume 2 from backup 0 of deployment 0 volume    size=1Gi    encrypted=True    dataEngine=${DATA_ENGINE}
-    And Create volume 3 from backup 1 of deployment 1 volume    size=1Gi    encrypted=True    dataEngine=${DATA_ENGINE}
+    When Create volume 2 from backup 0 of deployment 0 volume    size=100Mi    encrypted=True    dataEngine=${DATA_ENGINE}
+    And Create volume 3 from backup 1 of deployment 1 volume    size=100Mi    encrypted=True    dataEngine=${DATA_ENGINE}
     And Wait for volume 2 detached
     And Wait for volume 3 detached
     # Mount the restored volumes via deployments so that CSI opens the LUKS container.
@@ -513,46 +343,43 @@ Test Encrypted Volume Backup Restore To Encrypted Volume
     And Create deployment 3 with volume 3    sc_name=longhorn-crypto    node_stage_secret_name=longhorn-crypto
     And Wait for volume of deployment 2 healthy
     And Wait for volume of deployment 3 healthy
-    Then Assert disk size in instance manager pod for deployment 2 is 1Gi
-    And Assert disk size in instance manager pod for deployment 3 is 1Gi
+    Then Assert disk size in instance manager pod for deployment 2 is 100Mi
+    And Assert disk size in instance manager pod for deployment 3 is 100Mi
     # v1 only: v2 replica backend uses a different format (no .img files)
     IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica file size of deployment 2 is 1040MiB
-        Assert replica file size of deployment 3 is 1040MiB
+        Assert replica file size of deployment 2 is 116Mi
+        Assert replica file size of deployment 3 is 116Mi
     END
-    And Check deployment 2 data in file data.txt is intact compared to deployment 0
-    And Check deployment 3 data in file data.txt is intact compared to deployment 1
+    And Check deployment 2 file data.txt checksum matches checksum 0
+    And Check deployment 3 file data.txt checksum matches checksum 1
 
 Test Encrypted Volume Backup Restore To Unencrypted Volume
     [Tags]    rwo    rwx    backup    restore
     [Documentation]    Test Plan: Backup Restore – restore as unencrypted (RWO + RWX)
     ...
-    ...                Create a 1 GiB encrypted RWO volume (deployment 0) and RWX volume
-    ...                (deployment 1), write 100 MiB of data to each, take backups, then
+    ...                Create a 100 Mi encrypted RWO volume (deployment 0) and RWX volume
+    ...                (deployment 1), write 10 Mi of data to each, take backups, then
     ...                restore each as an unencrypted volume (encrypted=False).
     ...                Deployment 0 = RWO source, Deployment 1 = RWX source.
     ...                Volume 2 = restored from dep 0 backup, Volume 3 = restored from dep 1 backup.
     ...
     ...                Expected:
-    ...                  - Since encrypted=False, Longhorn does not pre-allocate extra 16 MiB.
-    ...                    The replica backend file is exactly 1 GiB (no LUKS pre-allocation),
-    ...                    compared to 1 GiB + 16 MiB for an encrypted=True restore.
-    ...                  - Note: Longhorn's CSI node plugin decides whether to call luksOpen
-    ...                    based on the Longhorn volume's spec.encrypted field (via Longhorn API),
-    ...                    not the PV's nodeStageSecretRef. For encrypted=False volumes, luksOpen
-    ...                    is never called; the raw LUKS-encrypted backup data cannot be mounted
-    ...                    as a filesystem. Only backend file size is verified here.
+    ...                  - Since encrypted=False, Longhorn does not pre-allocate extra 16 Mi.
+    ...                    The replica backend file is exactly 100 Mi (no LUKS pre-allocation),
+    ...                    compared to 100 Mi + 16 Mi for an encrypted=True restore.
     ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/13234
+    Skip    This test case implementation is blocked by https://github.com/longhorn/longhorn/issues/13234.
     Given Create crypto secret
     And Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    When Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
-    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
+    When Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=100Mi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=100Mi
     And Create deployment 0 with persistentvolumeclaim 0
     And Create deployment 1 with persistentvolumeclaim 1
     And Wait for volume of deployment 0 healthy
     And Wait for volume of deployment 1 healthy
-    And Write 100 MB data to file data.txt in deployment 0
-    And Write 100 MB data to file data.txt in deployment 1
+    And Write 10 MB data to file data.txt in deployment 0
+    And Write 10 MB data to file data.txt in deployment 1
     Then Check deployment 0 data in file data.txt is intact
     And Check deployment 1 data in file data.txt is intact
 
@@ -560,14 +387,474 @@ Test Encrypted Volume Backup Restore To Unencrypted Volume
     And Verify backup list contains backup no error for deployment 0 volume
     When Create backup 1 for deployment 1 volume
     And Verify backup list contains backup no error for deployment 1 volume
-    # Restore as unencrypted: no 16 MiB pre-allocation in the backend.
-    # Replica backend file size = 1 GiB (unlike encrypted=True which is 1 GiB + 16 MiB).
-    When Create volume 2 from backup 0 of deployment 0 volume    size=1Gi    encrypted=False    dataEngine=${DATA_ENGINE}
-    And Create volume 3 from backup 1 of deployment 1 volume    size=1Gi    encrypted=False    dataEngine=${DATA_ENGINE}
-    Then Wait for volume 2 healthy
-    And Wait for volume 3 healthy
+    When Create volume 2 from backup 0 of deployment 0 volume    size=100Mi    encrypted=False    dataEngine=${DATA_ENGINE}
+    And Create volume 3 from backup 1 of deployment 1 volume    size=100Mi    encrypted=False    dataEngine=${DATA_ENGINE}
+    Then Wait for volume 2 detached
+    And Wait for volume 3 detached
     # v1 only: v2 replica backend uses a different format (no .img files)
     IF    '${DATA_ENGINE}' == 'v1'
-        Assert replica backend file sizes for volume 2 are 1Gi
-        Assert replica backend file sizes for volume 3 are 1Gi
+        Assert replica file size of volume 2 is 100Mi
+        Assert replica file size of volume 3 is 100Mi
     END
+
+Test Encrypted Volume Upgrade
+    [Tags]    rwo    rwx    block-volume    expansion    replica-rebuild    engine-upgrade    old-engine
+    [Documentation]    Test Plan: Old Engine – LUKS Header Pre-allocation across Volume Modes + Upgrade
+    ...
+    ...                - Requires LONGHORN_STABLE_VERSION to be set.
+    ...                - Covers old-engine (v1.11) LUKS header sizing behavior across ALL volume modes.
+    ...                - Each deployment is dedicated to a specific test scenario for better isolation.
+    ...
+    ...                Deployment Layout:
+    ...                  - Deployment 0: RWO Filesystem (initial state + replica rebuild at 100 Mi)
+    ...                  - Deployment 1: RWX Filesystem (initial state + replica rebuild at 100 Mi)
+    ...                  - Deployment 2: RWO Block (initial state + engine upgrade)
+    ...                  - Deployment 3: RWO Filesystem (expansion + replica rebuild at 200 Mi)
+    ...                  - Deployment 4: RWX Filesystem (expansion + replica rebuild at 200 Mi)
+    ...                  - Deployment 5: RWO Filesystem (workload reattach test)
+    ...                  - Deployment 6: RWX Filesystem (workload reattach test)
+    ...                  - Deployment 7: RWO Filesystem (backup/restore with new-engine semantics)
+    ...                  - Deployment 8: RWX Filesystem (backup/restore with new-engine semantics)
+    ...
+    ...                Test Scenarios:
+    ...                  A. Initial State Verification (deployments 0-4):
+    ...                     - Old engine: device = requested_size - 16 Mi, replica = requested_size
+    ...
+    ...                  B. Replica Rebuild at 100 Mi (deployments 0, 1):
+    ...                     - Verify rebuilt replica = 100 Mi (old engine)
+    ...
+    ...                  C. Expansion (deployments 3, 4):
+    ...                     - Expand 100 Mi → 200 Mi
+    ...                     - Device = 184 Mi, replica = 200 Mi (old engine)
+    ...
+    ...                  D. Replica Rebuild at 200 Mi (deployments 3, 4):
+    ...                     - Verify rebuilt replica = 200 Mi (old engine)
+    ...
+    ...                  E. Engine Upgrade (deployments 0-4, v1 only):
+    ...                     - After upgrade: device = full size, replica = requested_size + 16 Mi
+    ...
+    ...                  F. Workload Reattach test (deployments 5, 6):
+    ...                     - Test old-engine and new-engine workload reattach behavior
+    ...                     - Old engine: device = 84 Mi, replica = 100 Mi
+    ...                     - New engine: device = 100 Mi, replica = 116 Mi
+    ...
+    ...                  G. Backup/Restore (deployments 5, 6):
+    ...                     - Restore pre-upgrade backups with new-engine semantics
+    ...                     - Device = 100 Mi, replica = 116 Mi
+    ...
+    ...                - Issues: https://github.com/longhorn/longhorn/issues/9205
+    ...                          https://github.com/longhorn/longhorn/issues/13163
+    ${LONGHORN_STABLE_VERSION} =    Get Environment Variable    LONGHORN_STABLE_VERSION    default=
+    IF    '${LONGHORN_STABLE_VERSION}' == ''
+        Skip    Environment variable LONGHORN_STABLE_VERSION is not set
+    ELSE IF    not '${LONGHORN_STABLE_VERSION}'.startswith('v1.11.')
+        Skip    This test only applies to the v1.11.x → v1.12+ upgrade path; got stable version ${LONGHORN_STABLE_VERSION}
+    END
+
+    # ==================== Setup ====================
+    Given Setting deleting-confirmation-flag is set to true
+    And Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}    numberOfReplicas=3
+    And Uninstall Longhorn
+    And Check Longhorn CRD removed
+    And Install Longhorn stable version
+    And Set default backupstore
+    And Enable v2 data engine and add block disks
+
+    # ==================== Create All Volumes (Pre-Upgrade) ====================
+    When Create crypto secret
+    And Create storageclass longhorn-crypto-stable with    encrypted=true    dataEngine=${DATA_ENGINE}
+
+    # Deployment 0: RWO Filesystem (initial state + replica rebuild at 100 Mi)
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto-stable    storage_size=100Mi
+    And Create deployment 0 with persistentvolumeclaim 0
+
+    # Deployment 1: RWX Filesystem (initial state + replica rebuild at 100 Mi)
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto-stable    storage_size=100Mi
+    And Create deployment 1 with persistentvolumeclaim 1
+
+    # Deployment 2: RWO Block (initial state + engine upgrade)
+    And Create persistentvolumeclaim 2    volumeMode=Block    volume_type=RWO    sc_name=longhorn-crypto-stable    storage_size=100Mi
+    And Create deployment 2 with block persistentvolumeclaim 2
+
+    # Deployment 3: RWO Filesystem (expansion + replica rebuild at 200 Mi)
+    And Create persistentvolumeclaim 3    volume_type=RWO    sc_name=longhorn-crypto-stable    storage_size=100Mi
+    And Create deployment 3 with persistentvolumeclaim 3
+
+    # Deployment 4: RWX Filesystem (expansion + replica rebuild at 200 Mi)
+    And Create persistentvolumeclaim 4    volume_type=RWX    sc_name=longhorn-crypto-stable    storage_size=100Mi
+    And Create deployment 4 with persistentvolumeclaim 4
+
+    # Deployment 5: RWO Filesystem (initial state + workload reattach at 100 Mi)
+    And Create persistentvolumeclaim 5    volume_type=RWO    sc_name=longhorn-crypto-stable    storage_size=100Mi
+    And Create deployment 5 with persistentvolumeclaim 5
+
+    # Deployment 6: RWX Filesystem (initial state + workload reattach at 100 Mi)
+    And Create persistentvolumeclaim 6    volume_type=RWX    sc_name=longhorn-crypto-stable    storage_size=100Mi
+    And Create deployment 6 with persistentvolumeclaim 6
+
+    Then Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    And Wait for volume of deployment 2 healthy
+    And Wait for volume of deployment 3 healthy
+    And Wait for volume of deployment 4 healthy
+    And Wait for volume of deployment 5 healthy
+    And Wait for volume of deployment 6 healthy
+
+    # ==================== Pre-Upgrade: Write Data & Backup ====================
+    # Write data to filesystem deployments for data integrity verification
+    When Write 10 MB data to file data.txt in deployment 0
+    And Write 10 MB data to file data.txt in deployment 1
+    And Write 10 MB data to file data.txt in deployment 3
+    And Write 10 MB data to file data.txt in deployment 4
+    And Write 10 MB data to file data.txt in deployment 5
+    And Write 10 MB data to file data.txt in deployment 6
+
+    Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
+    And Check deployment 3 data in file data.txt is intact
+    And Check deployment 4 data in file data.txt is intact
+    And Check deployment 5 data in file data.txt is intact
+    And Check deployment 6 data in file data.txt is intact
+    And Record file data.txt checksum in deployment 0 as checksum 0
+    And Record file data.txt checksum in deployment 1 as checksum 1
+
+    # Create backups for later restore testing
+    When Create backup 0 for deployment 0 volume
+    And Verify backup list contains backup no error for deployment 0 volume
+    And Create backup 1 for deployment 1 volume
+    And Verify backup list contains backup no error for deployment 1 volume
+
+    # ==================== Pre-Upgrade: Initial State Verification ====================
+    # All deployments should show old-engine semantics: device = requested_size - 16 Mi
+    # Deployment 0 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
+    Then Assert disk size in instance manager pod for deployment 0 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 100Mi
+    END
+
+    # Deployment 1 (RWX Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 1 is 100Mi
+    END
+
+    # Deployment 2 (RWO Block): blockdev = 84 Mi, replica = 100 Mi
+    And Assert block device size in deployment pod for deployment 2 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 2 is 100Mi
+    END
+
+    # Deployment 3 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert disk size in instance manager pod for deployment 3 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 3 is 100Mi
+    END
+
+    # Deployment 4 (RWX Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 4 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 4 is 100Mi
+    END
+
+    # Deployment 5 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert disk size in instance manager pod for deployment 5 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 5 is 100Mi
+    END
+
+    # Deployment 6 (RWX Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 6 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 6 is 100Mi
+    END
+
+    # ==================== Upgrade Longhorn (Keep Old Engine) ====================
+    When Setting concurrent-automatic-engine-upgrade-per-node-limit is set to 0
+    When Upgrade Longhorn to custom version
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    And Wait for volume of deployment 2 healthy
+    And Wait for volume of deployment 3 healthy
+    And Wait for volume of deployment 4 healthy
+    And Wait for volume of deployment 5 healthy
+    And Wait for volume of deployment 6 healthy
+
+    # ==================== Post-Upgrade: Initial State Verification ====================
+    # Verify old engine semantics are preserved after Longhorn system upgrade
+    # Deployment 0 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
+    Then Assert disk size in instance manager pod for deployment 0 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 100Mi
+    END
+
+    # Deployment 1 (RWX Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 1 is 100Mi
+    END
+
+    # Deployment 2 (RWO Block): blockdev = 84 Mi, replica = 100 Mi
+    And Assert block device size in deployment pod for deployment 2 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 2 is 100Mi
+    END
+
+    # Deployment 3 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert disk size in instance manager pod for deployment 3 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 3 is 100Mi
+    END
+
+    # Deployment 4 (RWX Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 4 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 4 is 100Mi
+    END
+
+    # Deployment 5 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert disk size in instance manager pod for deployment 5 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 5 is 100Mi
+    END
+
+    # Deployment 6 (RWX Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 6 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 6 is 100Mi
+    END
+
+    # ==================== Replica Rebuild at 100 Mi (Deployment 0, 1) ====================
+    # Test replica rebuild on old engine at original size (100 Mi)
+    When Delete replica of deployment 0 volume on replica node
+    Then Wait until volume of deployment 0 replica rebuilding completed on replica node
+    And Wait for volume of deployment 0 healthy
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 100Mi
+    END
+    And Check deployment 0 data in file data.txt is intact
+
+    When Delete replica of deployment 1 volume on replica node
+    Then Wait until volume of deployment 1 replica rebuilding completed on replica node
+    And Wait for volume of deployment 1 healthy
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 1 is 100Mi
+    END
+    And Check deployment 1 data in file data.txt is intact
+
+    # ==================== Expansion (Deployment 3, 4) ====================
+    # Expand dedicated deployments from 100 Mi to 200 Mi
+    When Expand deployment 3 volume to 200Mi
+    And Expand deployment 4 volume to 200Mi
+    Then Wait for deployment 3 volume size expanded
+    And Wait for deployment 4 volume size expanded
+    And Check deployment 3 pods did not restart
+    And Check deployment 4 pods did not restart
+
+    # After expansion: device = 184 Mi, replica = 20 Mi (old engine)
+    And Assert disk size in instance manager pod for deployment 3 is 184Mi
+    And Check no sharemanager pod of deployment 4 recreation
+    And Assert encrypted disk size in sharemanager pod for deployment 4 is 184Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 3 is 200Mi
+        Assert replica file size of deployment 4 is 200Mi
+    END
+    And Check deployment 3 data in file data.txt is intact
+    And Check deployment 4 data in file data.txt is intact
+
+    # ==================== Replica Rebuild at 200 Mi (Deployment 3, 4) ====================
+    # Test replica rebuild on old engine after expansion (200 Mi)
+    When Delete replica of deployment 3 volume on replica node
+    Then Wait until volume of deployment 3 replica rebuilding completed on replica node
+    And Wait for volume of deployment 3 healthy
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 3 is 200Mi
+    END
+    And Check deployment 3 data in file data.txt is intact
+
+    When Delete replica of deployment 4 volume on replica node
+    Then Wait until volume of deployment 4 replica rebuilding completed on replica node
+    And Wait for volume of deployment 4 healthy
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 4 is 200Mi
+    END
+    And Check deployment 4 data in file data.txt is intact
+
+    # ==================== Workload Reattach at 100 Mi (Deployment 5, 6) ====================
+    # Test workload reattach on old engine at original size (100 Mi)
+    Then Scale down deployment 5 to detach volume
+    And Scale up deployment 5 to attach volume
+    Then Wait for volume of deployment 5 healthy
+    And Wait for workloads pods stable    deployment 5
+    # Deployment 5 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert disk size in instance manager pod for deployment 5 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 5 is 100Mi
+    END
+    And Check deployment 5 data in file data.txt is intact
+
+    Then Scale down deployment 6 to detach volume
+    And Scale up deployment 6 to attach volume
+    Then Wait for volume of deployment 6 healthy
+    And Wait for workloads pods stable    deployment 6
+    # Deployment 6 (RWX Filesystem): device = 84 Mi, replica = 100 Mi
+    And Assert encrypted disk size in sharemanager pod for deployment 6 is 84Mi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 6 is 100Mi
+    END
+    And Check deployment 6 data in file data.txt is intact
+
+    # ==================== Engine Upgrade (Deployment 0-4, v1 only) ====================
+    ${CUSTOM_LONGHORN_ENGINE_IMAGE} =    Get Environment Variable    CUSTOM_LONGHORN_ENGINE_IMAGE    default=
+    IF    '${CUSTOM_LONGHORN_ENGINE_IMAGE}' != '' and '${DATA_ENGINE}' == 'v1'
+        # Upgrade all volumes to the new engine image
+        Then Upgrade v1 volumes engine to ${CUSTOM_LONGHORN_ENGINE_IMAGE}
+        And Wait for volume of deployment 0 healthy
+        And Wait for volume of deployment 1 healthy
+        And Wait for volume of deployment 2 healthy
+        And Wait for volume of deployment 3 healthy
+        And Wait for volume of deployment 4 healthy
+        And Wait for volume of deployment 5 healthy
+        And Wait for volume of deployment 6 healthy
+
+        # Test replica rebuild on new engine at original size (Deployment 0, 1)
+        # Deployment 0 (RWO Filesystem, 100 Mi):
+        # device = 100 Mi, replica = 100 Mi + 16 Mi = 116 Mi
+        When Delete replica of deployment 0 volume on replica node
+        Then Wait until volume of deployment 0 replica rebuilding completed on replica node
+        And Wait for volume of deployment 0 healthy
+        Then Assert disk size in instance manager pod for deployment 0 is 100Mi
+        And Assert replica file size of deployment 0 is 116Mi
+        And Check deployment 0 data in file data.txt is intact
+
+        # Deployment 1 (RWX Filesystem, 100 Mi):
+        # device = 100 Mi, replica = 100 Mi + 16 Mi = 116 Mi
+        When Delete replica of deployment 1 volume on replica node
+        Then Wait until volume of deployment 1 replica rebuilding completed on replica node
+        And Wait for volume of deployment 1 healthy
+        Then Assert encrypted disk size in sharemanager pod for deployment 1 is 100Mi
+        And Assert replica file size of deployment 1 is 116Mi
+        And Check deployment 1 data in file data.txt is intact
+
+        # Deployment 2 (RWO Block, 100 Mi):
+        # blockdev = 100 Mi, replica = 100 Mi + 16 Mi = 116 Mi
+        Then Assert block device size in deployment pod for deployment 2 is 100Mi
+        And Assert replica file size of deployment 2 is 116Mi
+
+        # Deployment 3 (RWO Filesystem, 200 Mi after expansion):
+        # device = 200 Mi, replica = 200 Mi + 16 Mi = 216 Mi
+        Then Assert disk size in instance manager pod for deployment 3 is 200Mi
+        And Assert replica file size of deployment 3 is 216Mi
+        And Check deployment 3 data in file data.txt is intact
+
+        # Deployment 4 (RWX Filesystem, 200 Mi after expansion):
+        # device = 200 Mi, replica = 200 Mi + 16 Mi = 216 Mi
+        Then Assert encrypted disk size in sharemanager pod for deployment 4 is 200Mi
+        And Assert replica file size of deployment 4 is 216Mi
+        And Check deployment 4 data in file data.txt is intact
+
+        # Test workload reattach on new engine at original size (100 Mi)
+        Then Scale down deployment 5 to detach volume
+        And Scale up deployment 5 to attach volume
+        Then Wait for volume of deployment 5 healthy
+        And Wait for workloads pods stable    deployment 5
+        # Deployment 5 (RWO Filesystem, 100 Mi):
+        # device = 100 Mi, replica = 100 Mi + 16 Mi = 116 Mi
+        Then Assert disk size in instance manager pod for deployment 5 is 100Mi
+        And Assert replica file size of deployment 5 is 116Mi
+        And Check deployment 5 data in file data.txt is intact
+
+        Then Scale down deployment 6 to detach volume
+        And Scale up deployment 6 to attach volume
+        Then Wait for volume of deployment 6 healthy
+        And Wait for workloads pods stable    deployment 6
+        # Deployment 6 (RWX Filesystem, 100 Mi):
+        # device = 100 Mi, replica = 100 Mi + 16 Mi = 116 Mi
+        Then Assert encrypted disk size in sharemanager pod for deployment 6 is 100Mi
+        And Assert replica file size of deployment 6 is 116Mi
+        And Check deployment 6 data in file data.txt is intact
+    END
+
+    # ==================== Backup/Restore (Deployment 7, 8) =============================
+    # Restore pre-upgrade (v1.11 old-engine) backups with new Longhorn (v1.12+).
+    # New Longhorn provisions the restored volume with new-engine semantics:
+    # 16 Mi pre-allocated in the backend → device = full 100 Mi, replica = 116 Mi.
+
+    # Deployment 7: Restore from Backup 0 (RWO Filesystem)
+    When Create volume 7 from backup 0 of deployment 0 volume    size=100Mi    encrypted=True    dataEngine=${DATA_ENGINE}
+    Then Wait for volume 7 detached
+    And Create deployment 7 with volume 7    sc_name=longhorn-crypto-stable    node_stage_secret_name=longhorn-crypto
+    And Wait for volume of deployment 7 healthy
+    Then Assert disk size in instance manager pod for deployment 7 is 100Mi
+    And Assert replica file size of deployment 7 is 116Mi
+    And Check deployment 7 file data.txt checksum matches checksum 0
+
+    # Deployment 8: Restore from Backup 1 (RWX Filesystem)
+    When Create volume 8 from backup 1 of deployment 1 volume    size=100Mi    encrypted=True    dataEngine=${DATA_ENGINE}
+    Then Wait for volume 8 detached
+    And Create deployment 8 with volume 8    sc_name=longhorn-crypto-stable    node_stage_secret_name=longhorn-crypto
+    And Wait for volume of deployment 8 healthy
+    Then Assert disk size in instance manager pod for deployment 8 is 100Mi
+    And Assert replica file size of deployment 8 is 116Mi
+    And Check deployment 8 file data.txt checksum matches checksum 1
+
+Test Encrypted Volume With Encrypted Backing Image Clone
+    [Tags]    rwo    backing-image    encrypted    skip
+    [Documentation]    Test creating encrypted volume using an encrypted BackingImage clone.
+    ...
+    ...                **IMPLEMENTATION STATUS: TO BE IMPLEMENTED**
+    ...
+    ...                This test case is designed to verify that a Longhorn volume using an
+    ...                encrypted BackingImage clone combined with an encrypted StorageClass
+    ...                can be successfully mounted by a Pod.
+    ...
+    ...                **Test Goal:**
+    ...                Verify encrypted volume creation using encrypted BackingImage clone.
+    ...
+    ...                **Reproduce Steps:**
+    ...                1. Create source backing image "parrot" from URL
+    ...                   (https://longhorn-backing-image.s3-us-west-1.amazonaws.com/parrot.qcow2)
+    ...                2. Create crypto secret "longhorn-crypto" in longhorn-system namespace
+    ...                3. Create encrypted clone backing image "parrot-cloned-encrypted"
+    ...                   using sourceType=clone with encryption parameters:
+    ...                   - sourceType: clone
+    ...                   - sourceParameters:
+    ...                     - backing-image: parrot
+    ...                     - encryption: encrypt
+    ...                     - secret: longhorn-crypto
+    ...                     - secret-namespace: longhorn-system
+    ...                4. Create encrypted StorageClass "longhorn-crypto-global" with:
+    ...                   - encrypted: "true"
+    ...                   - backingImage: "parrot-cloned-encrypted"
+    ...                   - CSI secret references for provisioner/node-publish/node-stage
+    ...                5. Create 5 GiB RWO PVC "longhorn-backing-image-pvc" from that StorageClass
+    ...                6. Create Pod using the PVC
+    ...                7. Assert Pod is running successfully (volume mounted)
+    ...                8. Write data to verify volume is functional
+    ...
+    ...                **Expected Results:**
+    ...                - Pod should be in Running state
+    ...                - Volume should be mounted and accessible inside the Pod
+    ...                - Data written to the volume can be read back successfully
+    ...
+    ...                **Implementation Notes:**
+    ...                - Need to implement keyword: "Create encrypted clone backing image"
+    ...                  This keyword should use kubectl apply to create BackingImage CR
+    ...                  with sourceType=clone and encryption parameters
+    ...                - The implementation should extend backing_image.py to support
+    ...                  sourceType="clone" via kubectl (not REST API)
+    ...                - Consider adding to rest.py or crd.py depending on architecture
+    ...
+    ...                **Reference CR Example:**
+    ...                apiVersion: longhorn.io/v1beta2
+    ...                kind: BackingImage
+    ...                metadata:
+    ...                  name: parrot-cloned-encrypted
+    ...                  namespace: longhorn-system
+    ...                spec:
+    ...                  sourceType: clone
+    ...                  sourceParameters:
+    ...                    backing-image: parrot
+    ...                    encryption: encrypt
+    ...                    secret: longhorn-crypto
+    ...                    secret-namespace: longhorn-system
+    Skip    Implementation pending: encrypted clone backing image keyword not yet implemented

--- a/e2e/tests/regression/test_encrypted_volume.robot
+++ b/e2e/tests/regression/test_encrypted_volume.robot
@@ -12,88 +12,125 @@ Resource    ../keywords/deployment.resource
 Resource    ../keywords/workload.resource
 Resource    ../keywords/sharemanager.resource
 Resource    ../keywords/longhorn.resource
+Resource    ../keywords/volume.resource
+Resource    ../keywords/backup.resource
+Resource    ../keywords/backupstore.resource
+Resource    ../keywords/host.resource
+Resource    ../keywords/engine_image.resource
+Resource    ../keywords/replica.resource
+Resource    ../keywords/setting.resource
 
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 
 *** Keywords ***
-Test Encrypted Volume Basic
-    [Arguments]    ${volume_type}
-    [Documentation]    Test basic encrypted volume operations for both RWO and RWX volumes
-    ...                Arguments:
-    ...                - ${volume_type}: Volume access mode (RWO or RWX)
-    Given Create crypto secret
-    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volume_type=${volume_type}    sc_name=longhorn-crypto
-    And Create deployment 0 with persistentvolumeclaim 0
-    And Wait for volume of deployment 0 healthy
-    And Write 100 MB data to file data.txt in deployment 0
-    Then Check deployment 0 data in file data.txt is intact
+Assert replica backend file sizes for volume ${volume_id} are ${expected_size}
+    [Documentation]    Verify replica backend head image file sizes for a raw (non-PVC) Longhorn volume.
+    ${expected_bytes} =    convert_size_to_bytes    ${expected_size}
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${replicas} =    get_replicas    ${volume_name}
+    FOR    ${replica}    IN    @{replicas}
+        ${node_id} =    Set Variable    ${replica}[spec][nodeID]
+        ${dir_name} =    Set Variable    ${replica}[spec][dataDirectoryName]
+        ${cmd} =    Set Variable
+        ...    find /var/lib/longhorn/replicas/${dir_name}/ -maxdepth 1 -name 'volume-head-*.img' -exec stat -c%s {} \\;
+        Wait Until Keyword Succeeds    ${RETRY_COUNT}    ${RETRY_INTERVAL}
+        ...    Check replica file size on node    ${cmd}    ${node_id}    ${expected_bytes}    ${volume_name}
+    END
 
-    When Scale down deployment 0 to detach volume
-    And Scale up deployment 0 to attach volume
-    And Wait for volume of deployment 0 healthy
-    And Wait for workloads pods stable    deployment 0
-    Then Check deployment 0 data in file data.txt is intact
+Check replica file size on node
+    [Arguments]    ${cmd}    ${node_id}    ${expected_bytes}    ${volume_name}
+    ${result} =    execute_command_on_node    ${cmd}    ${node_id}
+    Should Be Equal As Integers    ${result.strip()}    ${expected_bytes}
+    ...    msg=Replica backend file on node ${node_id} for volume ${volume_name}: expected ${expected_bytes} B, got ${result.strip()} B
+
+Assert block device size in deployment pod for deployment ${deployment_id} is ${size}
+    ${expected_bytes} =    convert_size_to_bytes    ${size}    to_str=True
+    ${deployment_name} =    generate_name_with_suffix    deployment    ${deployment_id}
+    ${pod_name} =    get_workload_pod_name    ${deployment_name}
+    ${cmd} =    Set Variable    blockdev --getsize64 /dev/longhorn/longhorn-testblk
+    ${result} =    pod_exec    ${pod_name}    default    ${cmd}
+    Should Be Equal As Integers    ${result.strip()}    ${expected_bytes}
+    ...    msg=Block device size in pod ${pod_name}: expected ${expected_bytes} B, got ${result.strip()} B
 
 *** Test Cases ***
-Test Encrypted RWO Volume Basic
-    [Tags]    rwo
-    [Template]    Test Encrypted Volume Basic
-        RWO
+Test Encrypted Volume Basic
+    [Tags]    rwo    rwx
+    [Documentation]    Test basic encrypted volume operations for both RWO and RWX volumes.
+    ...                Deployment 0 = RWO, Deployment 1 = RWX.
+    Given Create crypto secret
+    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 1040MiB
+        Assert replica file size of deployment 1 is 1040MiB
+    END
+    And Write 100 MB data to file data.txt in deployment 0
+    And Write 100 MB data to file data.txt in deployment 1
+    Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
 
-Test Encrypted RWX Volume Basic
-    [Tags]    rwx
-    [Template]    Test Encrypted Volume Basic
-        RWX
+    When Scale down deployment 0 to detach volume
+    And Scale down deployment 1 to detach volume
+    And Scale up deployment 0 to attach volume
+    And Scale up deployment 1 to attach volume
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    And Wait for workloads pods stable    deployment 0
+    And Wait for workloads pods stable    deployment 1
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 1040MiB
+        Assert replica file size of deployment 1 is 1040MiB
+    END
+    Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
 
-Test Encrypted RWO Volume Online Expansion
-    [Tags]    rwo    expansion
+Test Encrypted Volume Online Expansion
+    [Tags]    rwo    rwx    expansion
+    [Documentation]    Test online expansion for both RWO and RWX encrypted volumes.
+    ...                Deployment 0 = RWO, Deployment 1 = RWX.
     Given Create crypto secret
     When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
     And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=50MiB
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=50MiB
     And Create deployment 0 with persistentvolumeclaim 0
+    And Create deployment 1 with persistentvolumeclaim 1
     And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
     And Write 10 MB data to file data.txt in deployment 0
+    And Write 10 MB data to file data.txt in deployment 1
     Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
 
     When Expand deployment 0 volume to 100 MiB
+    And Expand deployment 1 volume to 100 MiB
     Then Wait for deployment 0 volume size expanded
+    And Wait for deployment 1 volume size expanded
     And Check deployment 0 pods did not restart
-    # Verify the actual disk size in the sharemanager pod.
-    # NOTE: For encrypted volumes, 16MiB is reserved for the encryption header.
-    # Therefore, a 100MiB requested volume will result in an 84MiB actual disk size.
-    And Assert disk size in instance manager pod for deployment 0 is 84MiB
-    When Scale down deployment 0 to detach volume
-    And Scale up deployment 0 to attach volume
-    And Wait for volume of deployment 0 healthy
-    And Wait for workloads pods stable    deployment 0
-    Then Check deployment 0 data in file data.txt is intact
-
-Test Encrypted RWX Volume Online Expansion
-    [Tags]    rwx    expansion
-    Given Create crypto secret
-    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volume_type=RWX    sc_name=longhorn-crypto    storage_size=50MiB
-    And Create deployment 0 with persistentvolumeclaim 0
-    And Wait for volume of deployment 0 healthy
-    And Write 10 MB data to file data.txt in deployment 0
-    Then Check deployment 0 data in file data.txt is intact
-
-    When Expand deployment 0 volume to 100 MiB
-    Then Wait for deployment 0 volume size expanded
-    And Check deployment 0 pods did not restart
-    And Check no sharemanager pod of deployment 0 recreation
-    # Verify the actual disk size in the sharemanager pod.
-    # NOTE: For encrypted volumes, 16MiB is reserved for the encryption header.
-    # Therefore, a 100MiB requested volume will result in an 84MiB actual disk size.
-    And Assert encrypted disk size in sharemanager pod for deployment 0 is 84MiB
+    And Check deployment 1 pods did not restart
+    And Check no sharemanager pod of deployment 1 recreation
+    # NOTE: With the new engine (v1.12+), the 16 MiB LUKS header is pre-allocated
+    # in the replica backend file (replica size = requested size + 16 MiB).
+    # The dm-crypt device therefore presents the full requested size to the workload.
+    # Therefore, a 100 MiB requested volume results in a 100 MiB dm-crypt device.
+    And Assert disk size in instance manager pod for deployment 0 is 100MiB
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 100MiB
 
     When Scale down deployment 0 to detach volume
+    And Scale down deployment 1 to detach volume
     And Scale up deployment 0 to attach volume
+    And Scale up deployment 1 to attach volume
     And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
     And Wait for workloads pods stable    deployment 0
+    And Wait for workloads pods stable    deployment 1
     Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
 
 Test Encrypted RWO Block Volume Online Expansion
     [Tags]    rwo    expansion    block-volume
@@ -110,10 +147,12 @@ Test Encrypted RWO Block Volume Online Expansion
     When Expand deployment 0 volume to 100 MiB
     Then Wait for deployment 0 volume size expanded
     And Check deployment 0 pods did not restart
-    # Verify the actual disk size in the sharemanager pod.
-    # NOTE: For encrypted volumes, 16MiB is reserved for the encryption header.
-    # Therefore, a 100MiB requested volume will result in an 84MiB actual disk size.
-    And Assert disk size in instance manager pod for deployment 0 is 84MiB
+    # Verify the actual disk size in the instance manager pod.
+    # NOTE: With the new engine (v1.12+), the 16 MiB LUKS header is pre-allocated
+    # in the replica backend file (replica size = requested size + 16 MiB).
+    # The dm-crypt device therefore presents the full requested size to the workload.
+    # Therefore, a 100 MiB requested volume results in a 100 MiB dm-crypt device.
+    And Assert disk size in instance manager pod for deployment 0 is 100MiB
     When Scale down deployment 0 to detach volume
     And Scale up deployment 0 to attach volume
     Then Wait for volume of deployment 0 healthy
@@ -121,3 +160,414 @@ Test Encrypted RWO Block Volume Online Expansion
     And Mount block device on /data in deployment 0
     And Write 60 MB data to file data2.txt in deployment 0
     Then Check deployment 0 data in file data2.txt is intact
+
+Test Encrypted Block Volume Creation Size
+    [Tags]    rwo    block-volume
+    [Documentation]    Test Plan: New Block Volume Creation (RWO, v1 + v2)
+    ...
+    ...                Create a 1 GiB encrypted Block-mode volume.
+    ...                Note: RWX + volumeMode=Block is not supported – Longhorn's share manager
+    ...                      uses NFS which cannot expose a raw block device to the workload.
+    ...
+    ...                Expected:
+    ...                  - blockdev --getsize64 inside the pod shows exactly
+    ...                    1073741824 bytes (1 GiB) – the full requested size is usable.
+    ...                  - (v1 only) The backend replica image file on the worker node is exactly
+    ...                    1024 MiB + 16 MiB = 1040 MiB (1090519040 bytes).
+    ...                    For v2 the replica backend format differs; only the block device size
+    ...                    is verified (similar issue: https://github.com/longhorn/longhorn/issues/9205).
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
+    Given Create crypto secret
+    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volumeMode=Block    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create deployment 0 with block persistentvolumeclaim 0
+    And Wait for volume of deployment 0 healthy
+    Then Assert block device size in deployment pod for deployment 0 is 1Gi
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 1040MiB
+    END
+
+Test Encrypted Volume Creation Size
+    [Tags]    rwo    rwx
+    [Documentation]    Test Plan: New Volume Creation (RWO + RWX)
+    ...
+    ...                Create a 1024 MiB encrypted volume with the current (new) engine image.
+    ...                Deployment 0 = RWO, Deployment 1 = RWX.
+    ...
+    ...                Expected:
+    ...                  - The dm-crypt device inside the instance manager (RWO) shows 1024 MiB.
+    ...                  - The dm-crypt device inside the share manager pod (RWX) shows 1024 MiB.
+    ...                  - The backend replica image file on the worker node is exactly
+    ...                    1024 MiB + 16 MiB = 1040 MiB (1090519040 bytes).
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
+    Given Create crypto secret
+    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1024MiB
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1024MiB
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    Then Assert disk size in instance manager pod for deployment 0 is 1024MiB
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 1024MiB
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 1040MiB
+        Assert replica file size of deployment 1 is 1040MiB
+    END
+
+Test Encrypted Volume Expansion
+    [Tags]    rwo    rwx    expansion
+    [Documentation]    Test Plan: Volume Expansion – new engine path (RWO + RWX)
+    ...
+    ...                Create a 1 GiB encrypted volume (new engine), write 100 MiB of data,
+    ...                then expand to 2 GiB. Deployment 0 = RWO, Deployment 1 = RWX.
+    ...
+    ...                Expected after expansion:
+    ...                  - Instance manager (RWO) shows 2 GiB.
+    ...                  - Share manager pod (RWX) shows 2 GiB; pod is NOT recreated.
+    ...                  - Replica image file on the worker node shows 2 GiB + 16 MiB = 2064 MiB.
+    ...                  - Previously written data is intact.
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
+    Given Create crypto secret
+    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    And Write 100 MB data to file data.txt in deployment 0
+    And Write 100 MB data to file data.txt in deployment 1
+    Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
+
+    When Expand deployment 0 volume to 2GiB
+    And Expand deployment 1 volume to 2GiB
+    Then Wait for deployment 0 volume size expanded
+    And Wait for deployment 1 volume size expanded
+    And Check deployment 0 pods did not restart
+    And Check deployment 1 pods did not restart
+    And Check no sharemanager pod of deployment 1 recreation
+    And Assert disk size in instance manager pod for deployment 0 is 2GiB
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 2GiB
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 2064MiB
+        Assert replica file size of deployment 1 is 2064MiB
+    END
+    And Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
+
+Test Encrypted Volume Upgrade
+    [Tags]    rwo    rwx    expansion    replica-rebuild    engine-upgrade    old-engine
+    [Documentation]    Test Plan: Old Engine – Expansion + Replica Rebuild + Engine Upgrade (RWO + RWX)
+    ...
+    ...                - Requires LONGHORN_STABLE_VERSION to be set (2-stage upgrade CI pipeline).
+    ...                - Covers old-engine (v1.11) expansion, replica rebuild, and engine upgrade
+    ...                  behaviors in a single Longhorn uninstall/reinstall/upgrade cycle.
+    ...                - Deployment 0 = RWO, Deployment 1 = RWX.
+    ...
+    ...                Steps:
+    ...                  - 1. Install stable Longhorn (v1.11) and create 1 GiB encrypted
+    ...                       RWO (deployment 0) and RWX (deployment 1) volumes.
+    ...                  - 2. Verify old-engine initial state:
+    ...                       - Device = 1024 MiB - 16 MiB = 1008 MiB.
+    ...                       - Replica file = 1 GiB (no extra 16 MiB).
+    ...                  - 3. Write 100 MiB of data. Upgrade Longhorn to v1.12+ keeping old engine.
+    ...                  - 4. Verify old engine semantics are preserved (same as step 2).
+    ...                  - 5. (Backup/Restore) Back up old-engine volumes before upgrade,
+    ...                       restore as encrypted=True after upgrade; verify new-engine sizing:
+    ...                       - Device = 1 GiB (full, 16 MiB pre-allocated in backend).
+    ...                       - Replica file = 1 GiB + 16 MiB = 1040 MiB.
+    ...                       - Data integrity preserved.
+    ...                  - 6. (Expansion) Expand to 2 GiB; verify:
+    ...                       - Device = 2048 MiB - 16 MiB = 2032 MiB.
+    ...                       - Replica file = 2 GiB; share manager pod NOT recreated.
+    ...                  - 7. (Replica Rebuild) Delete one replica per volume; verify:
+    ...                       - Rebuilt replica file = 2 GiB (old engine: no extra 16 MiB).
+    ...                  - 8. (Engine Upgrade, if CUSTOM_LONGHORN_ENGINE_IMAGE is set)
+    ...                       Upgrade both volumes to the new engine; verify:
+    ...                       - Device = 2 GiB (full usable size).
+    ...                       - Replica file = 2 GiB + 16 MiB = 2064 MiB.
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
+    ${LONGHORN_STABLE_VERSION} =    Get Environment Variable    LONGHORN_STABLE_VERSION    default=
+    IF    '${LONGHORN_STABLE_VERSION}' == ''
+        Skip    Environment variable LONGHORN_STABLE_VERSION is not set
+    ELSE IF    not '${LONGHORN_STABLE_VERSION}'.startswith('v1.11.')
+        Skip    This test only applies to the v1.11.x → v1.12+ upgrade path; got stable version ${LONGHORN_STABLE_VERSION}
+    END
+
+    Given Setting deleting-confirmation-flag is set to true
+    And Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}    numberOfReplicas=3
+    And Uninstall Longhorn
+    And Check Longhorn CRD removed
+    And Install Longhorn stable version
+    And Set default backupstore
+    And Enable v2 data engine and add block disks
+
+    When Create crypto secret
+    And Create storageclass longhorn-crypto-stable with    encrypted=true    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto-stable    storage_size=1Gi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto-stable    storage_size=1Gi
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    # Verify old-engine initial state before Longhorn upgrade
+    Then Assert disk size in instance manager pod for deployment 0 is 1008MiB
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 1008MiB
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 1024MiB
+        Assert replica file size of deployment 1 is 1024MiB
+    END
+
+    When Write 100 MB data to file data.txt in deployment 0
+    And Write 100 MB data to file data.txt in deployment 1
+    Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
+
+    # Take backups before upgrade (old-engine v1.11: no LUKS pre-allocation)
+    When Create backup 0 for deployment 0 volume
+    And Verify backup list contains backup no error for deployment 0 volume
+    And Create backup 1 for deployment 1 volume
+    And Verify backup list contains backup no error for deployment 1 volume
+
+    # Upgrade Longhorn system to v1.12+ but keep both volumes on the old engine image
+    When Setting concurrent-automatic-engine-upgrade-per-node-limit is set to 0
+    And Upgrade Longhorn to custom version
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+
+    # Verify old engine semantics are preserved after Longhorn upgrade
+    Then Assert disk size in instance manager pod for deployment 0 is 1008MiB
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 1008MiB
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 1024MiB
+        Assert replica file size of deployment 1 is 1024MiB
+    END
+
+    # --- Backup/Restore: pre-upgrade backup → new-engine restore (after upgrade) ---
+    # Restore pre-upgrade (v1.11 old-engine) backups with new Longhorn (v1.12+).
+    # New Longhorn provisions the restored volume with new-engine semantics:
+    # 16 MiB pre-allocated in the backend → device = full 1 GiB, replica = 1040 MiB.
+    # v2 data engine does not support encrypted volume CSI mounting via luksOpen;
+    # the backup/restore encrypted path is therefore skipped for v2.
+    # https://github.com/longhorn/longhorn/issues/13163.
+    IF    '${DATA_ENGINE}' == 'v1'
+        Create volume 2 from backup 0 of deployment 0 volume    size=1Gi    encrypted=True    dataEngine=${DATA_ENGINE}
+        Create volume 3 from backup 1 of deployment 1 volume    size=1Gi    encrypted=True    dataEngine=${DATA_ENGINE}
+        Wait for volume 2 healthy
+        Wait for volume 3 healthy
+        Create deployment 2 with volume 2    sc_name=longhorn-crypto-stable    node_stage_secret_name=longhorn-crypto
+        Create deployment 3 with volume 3    sc_name=longhorn-crypto-stable    node_stage_secret_name=longhorn-crypto
+        Wait for volume of deployment 2 healthy
+        Wait for volume of deployment 3 healthy
+        Assert disk size in instance manager pod for deployment 2 is 1Gi
+        Assert disk size in instance manager pod for deployment 3 is 1Gi
+        Assert replica file size of deployment 2 is 1040MiB
+        Assert replica file size of deployment 3 is 1040MiB
+        Check deployment 2 data in file data.txt is intact compared to deployment 0
+        Check deployment 3 data in file data.txt is intact compared to deployment 1
+    END
+
+    # --- Old engine: Volume Expansion ---
+    When Expand deployment 0 volume to 2GiB
+    And Expand deployment 1 volume to 2GiB
+    Then Wait for deployment 0 volume size expanded
+    And Wait for deployment 1 volume size expanded
+    And Check deployment 0 pods did not restart
+    And Check deployment 1 pods did not restart
+    And Assert disk size in instance manager pod for deployment 0 is 2032MiB
+    And Check no sharemanager pod of deployment 1 recreation
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 2032MiB
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 2048MiB
+        Assert replica file size of deployment 1 is 2048MiB
+    END
+    And Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
+
+    # --- Old engine: Replica Rebuild (at 2 GiB) ---
+    When Delete replica of deployment 0 volume on replica node
+    And Wait until volume of deployment 0 replica rebuilding completed on replica node
+    Then Wait for volume of deployment 0 healthy
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 2048MiB
+    END
+    And Check deployment 0 data in file data.txt is intact
+
+    When Delete replica of deployment 1 volume on replica node
+    And Wait until volume of deployment 1 replica rebuilding completed on replica node
+    Then Wait for volume of deployment 1 healthy
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 1 is 2048MiB
+    END
+    And Check deployment 1 data in file data.txt is intact
+
+    # --- Engine Upgrade (only if CUSTOM_LONGHORN_ENGINE_IMAGE is set, v1 only) ---
+    ${CUSTOM_LONGHORN_ENGINE_IMAGE} =    Get Environment Variable    CUSTOM_LONGHORN_ENGINE_IMAGE    default=
+    IF    '${CUSTOM_LONGHORN_ENGINE_IMAGE}' != '' and '${DATA_ENGINE}' == 'v1'
+        # Upgrade both volumes to the new engine image
+        Upgrade v1 volumes engine to ${CUSTOM_LONGHORN_ENGINE_IMAGE}
+        Wait for volume of deployment 0 healthy
+        Wait for volume of deployment 1 healthy
+        # After engine upgrade: device = 2 GiB (full), replica = 2 GiB + 16 MiB = 2064 MiB
+        Assert disk size in instance manager pod for deployment 0 is 2GiB
+        Assert encrypted disk size in sharemanager pod for deployment 1 is 2GiB
+        Assert replica file size of deployment 0 is 2064MiB
+        Assert replica file size of deployment 1 is 2064MiB
+        Check deployment 0 data in file data.txt is intact
+        Check deployment 1 data in file data.txt is intact
+    END
+
+Test Encrypted Volume Replica Rebuild
+    [Tags]    rwo    rwx    replica-rebuild
+    [Documentation]    Test Plan: Replica Rebuild – new engine path (RWO + RWX)
+    ...
+    ...                Create a 1 GiB encrypted RWO volume (deployment 0) and RWX volume
+    ...                (deployment 1) with the new engine.
+    ...                Write 100 MiB of data to each, then delete one replica per volume
+    ...                to trigger a rebuild.
+    ...
+    ...                Expected after rebuild:
+    ...                  - Rebuild completes successfully (volume returns to healthy).
+    ...                  - The dm-crypt device size is unchanged: 1024 MiB (RWO instance manager)
+    ...                    and 1024 MiB (RWX share manager pod).
+    ...                  - The newly rebuilt replica file size is 1024 MiB + 16 MiB = 1040 MiB,
+    ...                    matching the existing replicas (v1 only).
+    ...                  - Data integrity (md5sum / checksum) is intact.
+    Given Create crypto secret
+    When Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    And Write 100 MB data to file data.txt in deployment 0
+    And Write 100 MB data to file data.txt in deployment 1
+    Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
+
+    When Delete replica of deployment 0 volume on replica node
+    And Wait until volume of deployment 0 replica rebuilding completed on replica node
+    Then Wait for volume of deployment 0 healthy
+    And Assert disk size in instance manager pod for deployment 0 is 1024MiB
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 0 is 1040MiB
+    END
+    And Check deployment 0 data in file data.txt is intact
+
+    When Delete replica of deployment 1 volume on replica node
+    And Wait until volume of deployment 1 replica rebuilding completed on replica node
+    Then Wait for volume of deployment 1 healthy
+    And Assert encrypted disk size in sharemanager pod for deployment 1 is 1024MiB
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 1 is 1040MiB
+    END
+    And Check deployment 1 data in file data.txt is intact
+
+Test Encrypted Volume Backup Restore To Encrypted Volume
+    [Tags]    rwo    rwx    backup    restore
+    [Documentation]    Test Plan: Backup Restore – restore as encrypted (RWO + RWX)
+    ...
+    ...                Create a 1 GiB encrypted RWO volume (deployment 0) and RWX volume
+    ...                (deployment 1), write 100 MiB of data to each, take backups.
+    ...                Restore each backup to a new encrypted volume.
+    ...                Deployment 0 = RWO source, Deployment 1 = RWX source.
+    ...                Deployment 2 = restored from dep 0 backup, Deployment 3 = restored from dep 1 backup.
+    ...
+    ...                Expected:
+    ...                  - Restored volumes' dm-crypt device shows exactly 1 GiB.
+    ...                  - Restored volumes' replica backend file is exactly 1024 MiB + 16 MiB.
+    ...                  - The 100 MiB payload checksum matches the original.
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
+    IF    '${DATA_ENGINE}' == 'v2'
+        Skip    v2 data engine does not support encrypted volume restore with encrypted=True (https://github.com/longhorn/longhorn/issues/13163)
+    END
+    Given Create crypto secret
+    And Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    When Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    And Write 100 MB data to file data.txt in deployment 0
+    And Write 100 MB data to file data.txt in deployment 1
+    Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
+
+    When Create backup 0 for deployment 0 volume
+    And Verify backup list contains backup no error for deployment 0 volume
+    When Create backup 1 for deployment 1 volume
+    And Verify backup list contains backup no error for deployment 1 volume
+
+    # Restore to new encrypted volumes (encrypted=True)
+    When Create volume 2 from backup 0 of deployment 0 volume    size=1Gi    encrypted=True    dataEngine=${DATA_ENGINE}
+    And Create volume 3 from backup 1 of deployment 1 volume    size=1Gi    encrypted=True    dataEngine=${DATA_ENGINE}
+    And Wait for volume 2 detached
+    And Wait for volume 3 detached
+    # Mount the restored volumes via deployments so that CSI opens the LUKS container.
+    # Must use longhorn-crypto SC (with node-stage-secret-ref) so luksOpen is triggered.
+    And Create deployment 2 with volume 2    sc_name=longhorn-crypto    node_stage_secret_name=longhorn-crypto
+    And Create deployment 3 with volume 3    sc_name=longhorn-crypto    node_stage_secret_name=longhorn-crypto
+    And Wait for volume of deployment 2 healthy
+    And Wait for volume of deployment 3 healthy
+    Then Assert disk size in instance manager pod for deployment 2 is 1Gi
+    And Assert disk size in instance manager pod for deployment 3 is 1Gi
+    # v1 only: v2 replica backend uses a different format (no .img files)
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica file size of deployment 2 is 1040MiB
+        Assert replica file size of deployment 3 is 1040MiB
+    END
+    And Check deployment 2 data in file data.txt is intact compared to deployment 0
+    And Check deployment 3 data in file data.txt is intact compared to deployment 1
+
+Test Encrypted Volume Backup Restore To Unencrypted Volume
+    [Tags]    rwo    rwx    backup    restore
+    [Documentation]    Test Plan: Backup Restore – restore as unencrypted (RWO + RWX)
+    ...
+    ...                Create a 1 GiB encrypted RWO volume (deployment 0) and RWX volume
+    ...                (deployment 1), write 100 MiB of data to each, take backups, then
+    ...                restore each as an unencrypted volume (encrypted=False).
+    ...                Deployment 0 = RWO source, Deployment 1 = RWX source.
+    ...                Volume 2 = restored from dep 0 backup, Volume 3 = restored from dep 1 backup.
+    ...
+    ...                Expected:
+    ...                  - Since encrypted=False, Longhorn does not pre-allocate extra 16 MiB.
+    ...                    The replica backend file is exactly 1 GiB (no LUKS pre-allocation),
+    ...                    compared to 1 GiB + 16 MiB for an encrypted=True restore.
+    ...                  - Note: Longhorn's CSI node plugin decides whether to call luksOpen
+    ...                    based on the Longhorn volume's spec.encrypted field (via Longhorn API),
+    ...                    not the PV's nodeStageSecretRef. For encrypted=False volumes, luksOpen
+    ...                    is never called; the raw LUKS-encrypted backup data cannot be mounted
+    ...                    as a filesystem. Only backend file size is verified here.
+    ...                - Issue: https://github.com/longhorn/longhorn/issues/9205
+    Given Create crypto secret
+    And Create storageclass longhorn-crypto with    encrypted=true    dataEngine=${DATA_ENGINE}
+    When Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-crypto    storage_size=1Gi
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    And Write 100 MB data to file data.txt in deployment 0
+    And Write 100 MB data to file data.txt in deployment 1
+    Then Check deployment 0 data in file data.txt is intact
+    And Check deployment 1 data in file data.txt is intact
+
+    When Create backup 0 for deployment 0 volume
+    And Verify backup list contains backup no error for deployment 0 volume
+    When Create backup 1 for deployment 1 volume
+    And Verify backup list contains backup no error for deployment 1 volume
+    # Restore as unencrypted: no 16 MiB pre-allocation in the backend.
+    # Replica backend file size = 1 GiB (unlike encrypted=True which is 1 GiB + 16 MiB).
+    When Create volume 2 from backup 0 of deployment 0 volume    size=1Gi    encrypted=False    dataEngine=${DATA_ENGINE}
+    And Create volume 3 from backup 1 of deployment 1 volume    size=1Gi    encrypted=False    dataEngine=${DATA_ENGINE}
+    Then Wait for volume 2 healthy
+    And Wait for volume 3 healthy
+    # v1 only: v2 replica backend uses a different format (no .img files)
+    IF    '${DATA_ENGINE}' == 'v1'
+        Assert replica backend file sizes for volume 2 are 1Gi
+        Assert replica backend file sizes for volume 3 are 1Gi
+    END


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/9205
https://github.com/longhorn/longhorn/issues/13013
https://github.com/longhorn/longhorn/issues/13234

#### What this PR does / why we need it:
- Add size verification tests to validate LUKS header pre-allocation behavior for encrypted volumes
- Verify replica backend file size, share-manager disk size, and instance manager disk size
- Cover the upgrade path from v1.11.x → v1.12+ for encrypted volume size behavior changes
- Expand encrypted volume test coverage including:
  - RWO volume size verification (old engine vs. new engine)
  - Restore encrypted backup to unencrypted volume behavior

#### Special notes for your reviewer:

#### Additional documentation or context
