### PR TITLE
test(robot): update Wait for pod stuck in  on another node

### DIFF
--- a/e2e/keywords/workload.resource
+++ b/e2e/keywords/workload.resource
@@ -277,7 +277,6 @@ Wait for ${workload_kind} ${workload_id} pod stuck in ${expect_state}
 Wait for ${workload_kind} ${workload_id} pod stuck in ${expect_state} on another node
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
     wait_for_pod_kept_in_state    ${workload_name}    ${expect_state}
-    wait_for_workload_pod_not_on_node    ${workload_name}    ${last_volume_node}
 
 Check ${workload_kind} ${workload_id} pod is ${expect_state} on the original node
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

[Test Node Down Pod Deletion Policy Set To do-nothing And Longhorn Not Force Delete Terminating Deployment Pod](https://10.115.5.5/job/private/job/longhorn-e2e-test/453/robot/report/log.html#s1-s1-s1-t1)
[Test Node Down Pod Deletion Policy Set To delete-statefulset-pod And Longhorn Not Force Delete Terminating Deployment Pod](https://10.115.5.5/job/private/job/longhorn-e2e-test/436/)

failed at
```
15:06:02  Waiting for workload e2e-test-deployment-0 pod not on node ip-10-0-1-14 ... (1191)
15:06:03  Waiting for workload e2e-test-deployment-0 pod not on node ip-10-0-1-14 ... (1192)
15:06:04  Waiting for workload e2e-test-deployment-0 pod not on node ip-10-0-1-14 ... (1193)
15:06:05  Waiting for workload e2e-test-deployment-0 pod not on node ip-10-0-1-14 ... (1194)
15:06:06  Waiting for workload e2e-test-deployment-0 pod not on node ip-10-0-1-14 ... (1195)
15:06:07  Waiting for workload e2e-test-deployment-0 pod not on node ip-10-0-1-14 ... (1196)
15:06:08  Waiting for workload e2e-test-deployment-0 pod not on node ip-10-0-1-14 ... (1197)
15:06:09  Waiting for workload e2e-test-deployment-0 pod not on node ip-10-0-1-14 ... (1198)
15:06:10  Waiting for workload e2e-test-deployment-0 pod not on node ip-10-0-1-14 ... (1199)
```

update `Wait for ${workload_kind} ${workload_id} pod stuck in ${expect_state} on another node` by remove  `wait_for_workload_pod_not_on_node`

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
