### PR TITLE
test(robot): fix flaky test case Test Instance Manager AWS Role Annotation by adding wait mechanism for the instance manager annotation update

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -60,6 +60,10 @@ Run command and not expect output
     [Arguments]    ${command}    ${unexpected_output}
     execute_command_and_not_expect_output    ${command}    ${unexpected_output}
 
+Run command until output is absent
+    [Arguments]    ${command}    ${unexpected_output}
+    execute_command_until_output_is_absent    ${command}    ${unexpected_output}
+
 Test should pass
     No Operation
 

--- a/e2e/libs/keywords/common_keywords.py
+++ b/e2e/libs/keywords/common_keywords.py
@@ -101,5 +101,15 @@ class common_keywords:
             time.sleep(retry_count)
             assert False, f"Unexpected {output} in {cmd} result: {res}"
 
+    def execute_command_until_output_is_absent(self, cmd, output):
+        retry_count, retry_interval = get_retry_count_and_interval()
+        for i in range(retry_count):
+            logging(f"Waiting for command {cmd} not returning output {output} ... ({i})")
+            res = subprocess_exec_cmd(cmd)
+            if output not in res:
+                return res
+            time.sleep(retry_interval)
+        assert False, f"'{output}' still found in command result: {res}"
+
     def cleanup_events(self):
         cleanup_events()

--- a/e2e/tests/regression/test_basic.robot
+++ b/e2e/tests/regression/test_basic.robot
@@ -311,14 +311,14 @@ Test Instance Manager AWS Role Annotation
     And Wait for volume 0 healthy
     And Write data to volume 0
     And Create backup 0 for volume 0
-    Then Run command and not expect output
+    Then Run command until output is absent
     ...    kubectl get pods -n ${LONGHORN_NAMESPACE} -l longhorn.io/component=instance-manager,longhorn.io/data-engine=${DATA_ENGINE} -ojson | jq '.items[0].metadata.annotations'
     ...    iam.amazonaws.com/role
 
     # AWS_IAM_ROLE_ARN: test-aws-iam-role-arn
     When Run command
     ...    kubectl patch secret minio-secret -n ${LONGHORN_NAMESPACE} -p '{"data": {"AWS_IAM_ROLE_ARN": "dGVzdC1hd3MtaWFtLXJvbGUtYXJu"}}'
-    Then Run command and expect output
+    Then Run command and wait for output
     ...    kubectl get pods -n ${LONGHORN_NAMESPACE} -l longhorn.io/component=instance-manager,longhorn.io/data-engine=${DATA_ENGINE} -ojson | jq '.items[0].metadata.annotations'
     ...    "iam.amazonaws.com/role": "test-aws-iam-role-arn"
     And Create backup 1 for volume 0
@@ -327,13 +327,13 @@ Test Instance Manager AWS Role Annotation
     And Delete ${DATA_ENGINE} instance manager on node 1
     And Delete ${DATA_ENGINE} instance manager on node 2
     And Check volume 0 kept in healthy
-    Then Run command and expect output
+    Then Run command and wait for output
     ...    kubectl get pods -n ${LONGHORN_NAMESPACE} -l longhorn.io/component=instance-manager,longhorn.io/data-engine=${DATA_ENGINE} -ojson | jq '.items[0].metadata.annotations'
     ...    "iam.amazonaws.com/role": "test-aws-iam-role-arn"
     And Create backup 2 for volume 0
 
     When Run command
     ...    kubectl patch secret minio-secret -n ${LONGHORN_NAMESPACE} --type=json -p='[{"op": "remove", "path": "/data/AWS_IAM_ROLE_ARN"}]'
-    Then Run command and not expect output
+    Then Run command until output is absent
     ...    kubectl get pods -n ${LONGHORN_NAMESPACE} -l longhorn.io/component=instance-manager,longhorn.io/data-engine=${DATA_ENGINE} -ojson | jq '.items[0].metadata.annotations'
     ...    iam.amazonaws.com/role


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix flaky test case Test Instance Manager AWS Role Annotation by adding wait mechanism for the instance manager annotation update

#### Special notes for your reviewer:

#### Additional documentation or context
