### PR TITLE
ci: add missing CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE in regression test Jenkinsfile

### DIFF
--- a/test_framework/Jenkinsfile
+++ b/test_framework/Jenkinsfile
@@ -133,6 +133,7 @@ node {
                                        --env CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE=${CUSTOM_LONGHORN_INSTANCE_MANAGER_IMAGE} \
                                        --env CUSTOM_LONGHORN_MANAGER_IMAGE=${CUSTOM_LONGHORN_MANAGER_IMAGE} \
                                        --env CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE=${CUSTOM_LONGHORN_SHARE_MANAGER_IMAGE} \
+                                       --env CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE=${CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE} \
                                        --env LONGHORN_TESTS_CUSTOM_IMAGE=${LONGHORN_TESTS_CUSTOM_IMAGE} \
                                        --env DISTRO=${DISTRO} \
                                        --env LONGHORN_REPO_URI=${LONGHORN_REPO_URI} \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

add missing CUSTOM_LONGHORN_BACKING_IMAGE_MANAGER_IMAGE in regression test Jenkinsfile

#### Special notes for your reviewer:

#### Additional documentation or context
