### PR TITLE
test(robot): skip backing image tests by data engine

### DIFF
--- a/e2e/tests/negative/backing_image_error_and_retry.robot
+++ b/e2e/tests/negative/backing_image_error_and_retry.robot
@@ -12,6 +12,8 @@ Resource    ../keywords/setting.resource
 Resource    ../keywords/longhorn.resource
 Resource    ../keywords/node.resource
 
+Suite Setup    Skip If    '${DATA_ENGINE}' == 'v2'    reason=v2 data engine doesn't support backing image
+
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 

--- a/e2e/tests/negative/backing_image_with_http_proxy.robot
+++ b/e2e/tests/negative/backing_image_with_http_proxy.robot
@@ -7,6 +7,8 @@ Resource    ../keywords/volume.resource
 Resource    ../keywords/backing_image.resource
 Resource    ../keywords/proxy.resource
 
+Suite Setup    Skip If    '${DATA_ENGINE}' == 'v2'    reason=v2 data engine doesn't support backing image
+
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 

--- a/e2e/tests/negative/component_resilience.robot
+++ b/e2e/tests/negative/component_resilience.robot
@@ -126,6 +126,10 @@ Test Longhorn Backing Image Volume Recovery
     ...                    Delete the IM of the volume and make sure volume recovers. Check the data as well.
     ...                    Start replica rebuilding for the aforementioned volume, and delete the IM-e while it is rebuilding. Verify the recovered volume.    
     ...                    Delete the backing image manager pod and verify the pod gets recreated.
+    IF    '${DATA_ENGINE}' == 'v2'
+        Skip    test only valideate on v1 data engine since v2 doesn't support backing image
+    END
+
     When Create backing image bi    url=https://longhorn-backing-image.s3-us-west-1.amazonaws.com/parrot.qcow2
     And Create volume 0 with    backingImage=bi
     And Attach volume 0

--- a/e2e/tests/negative/node_down.robot
+++ b/e2e/tests/negative/node_down.robot
@@ -152,6 +152,10 @@ Test Backing Image On Two Nodes Down
     ...                - https://longhorn-backing-image.s3-us-west-1.amazonaws.com/parrot.raw
     ...                - https://cloud-images.ubuntu.com/minimal/releases/focal/release-20200729/ubuntu-20.04-minimal-cloudimg-amd64.img
     ...                - https://github.com/rancher/k3os/releases/download/v0.11.0/k3os-amd64.iso
+    IF    DATA_ENGINE == 'v2'
+        Skip    v2 data engine doesn't support backing image
+    END
+
     Given Setting replica-replenishment-wait-interval is set to 600
     And Setting replica-soft-anti-affinity is set to false
 

--- a/e2e/tests/negative/upgrade_with_backing_image.robot
+++ b/e2e/tests/negative/upgrade_with_backing_image.robot
@@ -14,6 +14,8 @@ Resource    ../keywords/workload.resource
 Resource    ../keywords/backing_image.resource
 Resource    ../keywords/k8s.resource
 
+Suite Setup    Skip If    '${DATA_ENGINE}' == 'v2'    reason=v2 data engine doesn't support backing image
+
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
 


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

Some test cases involve v2 volumes while still using v1 backing images, use `--exclude backing-image` will miss the coverage. Skip unsupported cases directly in the test case instead.

#### Special notes for your reviewer:

#### Additional documentation or context
