### PR TITLE
test(robot): revert deferred set_backupstore and complete assert failure message

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -112,6 +112,7 @@ Set up test environment
     END
 
 Cleanup test resources
+    set_backupstore
     FOR    ${powered_off_node}    IN    @{powered_off_nodes}
         Run keyword And Ignore Error    power_on_node_by_name    ${powered_off_node}
         Remove Values From List    ${powered_off_nodes}    ${powered_off_node}
@@ -135,7 +136,6 @@ Cleanup test resources
     cleanup_persistentvolumeclaims
     cleanup_volumes
     cleanup_storageclasses
-    set_backupstore
     set_storageclass_default_state    longhorn    ${True}
     cleanup_secrets
     cleanup_backups

--- a/e2e/libs/backup/rest.py
+++ b/e2e/libs/backup/rest.py
@@ -274,7 +274,7 @@ class Rest(Base):
             self.wait_for_backup_volume_delete(backup_volume.name)
 
         backup_volumes = get_longhorn_client().list_backupVolume()
-        assert backup_volumes.data == []
+        assert not backup_volumes.data, f"Failed to cleanup backup volumes, still have backup volumes: {backup_volumes.data}"
 
     def cleanup_backups(self):
         return CRD().cleanup_backups()


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

revert deferred set_backupstore and complete assert failure message.

Backups need time to be synced from the remote backup store to Longhorn. If trying to clean up backups immediately after the backup store is set, they may not have been synced to Longhorn yet. The cleanup function may temporarily see no backups and assume the cleanup job is complete, but the backups are actually synced later.

#### Special notes for your reviewer:

#### Additional documentation or context
