### PR TITLE
test(pytest): use AIO disk on arm64 machine

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -92,7 +92,8 @@ if os.environ.get("CLOUDPROVIDER") == "aws":
     if os.uname().machine == "x86_64":
         BLOCK_DEV_PATH = "/dev/xvdh"
     else:
-        BLOCK_DEV_PATH = "0000:00:1f.0"
+        # can not use BDF path before https://github.com/longhorn/longhorn/issues/13243 # NOQA
+        BLOCK_DEV_PATH = "/dev/nvme1n1"
 elif os.environ.get("CLOUDPROVIDER") == "harvester":
     BLOCK_DEV_PATH = "/dev/vdc"
 elif os.environ.get("CLOUDPROVIDER") == "vagrant":


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13243

#### What this PR does / why we need it:

Use AIO disk on arm64 machine instead of BDF path disk when running test on arm64 machine

#### Special notes for your reviewer:

arm64 v2 core test https://10.115.5.5/job/private/job/longhorn-tests-regression/476/

#### Additional documentation or context
