### PR TITLE
fix: wait for replica creation in best-effort data locality test

### DIFF
--- a/manager/integration/tests/test_scheduling.py
+++ b/manager/integration/tests/test_scheduling.py
@@ -2489,13 +2489,17 @@ def best_effort_data_locality_test(client, volume_name):  # NOQA
                                   numberOfReplicas=number_of_replicas,
                                   dataLocality="best-effort")
 
-    # replica should stay unscheduled until volume is attached
-    for _ in range(10):
-        time.sleep(RETRY_INTERVAL)
+    # Replica should stay unscheduled until volume is attached.
+    wait_for_volume_replica_count(client,
+                                  volume_name,
+                                  number_of_replicas)
+
+    for i in range(10):
         volume = client.by_id_volume(volume_name)
         assert len(volume.replicas) == number_of_replicas
-        assert volume.replicas[0]['hostId'] == ""
+        assert volume.replicas[0]["hostId"] == ""
         assert not volume.replicas[0].running
+        time.sleep(RETRY_INTERVAL)
 
     self_node = get_self_host_id()
     # attach volume to the self_node


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue [#13222](https://github.com/longhorn/longhorn/issues/13222)

#### What this PR does / why we need it:
This PR fixes the flaky failure in `test_best_effort_data_locality`.

The test creates a volume with `dataLocality=best-effort` and `numberOfReplicas=1`. The expected behavior is that the replica object is created first while the volume is detached, remains unscheduled, and then gets scheduled to the local node after the volume is attached.

The previous test logic asserted the replica count inside the retry loop. As a result, the test could fail on the first check if the Longhorn volume controller had not finished creating the replica CR yet.

This PR separates the replica creation wait from the data-locality validation. The test now waits until the expected replica count is observed before checking that the replica remains unscheduled before attachment.

#### Special notes for your reviewer:
The support bundle showed that the replica CR was created shortly after volume creation, so this is a test-side timing issue rather than a Longhorn scheduling failure.

#### Additional documentation or context
Verified with Jenkins:
https://ci.longhorn.io/job/private/job/longhorn-tests-regression/11083/
```text
-k test_best_effort_data_locality --count 10