### PR TITLE
test(robot): add case Test V2 Volume Upgrade Data Plane

### DIFF
--- a/e2e/keywords/longhorn.resource
+++ b/e2e/keywords/longhorn.resource
@@ -90,6 +90,13 @@ Check v1 instance manager pods did not restart
 Check v1 instance manager pods recreated
     wait_all_instance_managers_recreated
 
+Record ${engine_type} instance manager UIDs
+    ${im_pod_uids} =    record_instance_manager_pod_uids    ${engine_type}
+    Set Test Variable    ${im_pod_uids}
+
+Check ${engine_type} instance manager did not restart
+    check_instance_managers_not_restarted    ${engine_type}    ${im_pod_uids}
+
 Wait for engine instances in ${engine_type} instance manager CR on node ${node_id} to be cleaned up
     ${node_name} =    get_node_by_index    ${node_id}
     wait_for_instance_manager_cr_engine_instances_to_be_cleaned_up    ${node_name}    ${engine_type}

--- a/e2e/keywords/node.resource
+++ b/e2e/keywords/node.resource
@@ -196,3 +196,7 @@ Add ${disk_type} disk ${disk_name} to node ${node_id} with path ${mount_path}
 Remove dir ${dir_path} on node ${node_id}
     ${node_name} =    get_node_by_index    ${node_id}
     remove_dir    ${dir_path}    ${node_name}
+
+Set node ${node_id} upgrade requested to ${upgrade_requested}
+    ${node_name} =    get_node_by_index    ${node_id}
+    set_node_upgrade_requested    ${node_name}    ${upgrade_requested}

--- a/e2e/keywords/replica.resource
+++ b/e2e/keywords/replica.resource
@@ -6,6 +6,7 @@ Library             ../libs/keywords/replica_keywords.py
 Library             ../libs/keywords/instancemanager_keywords.py
 Library             ../libs/keywords/node_keywords.py
 Library             ../libs/keywords/workload_keywords.py
+Library             ../libs/keywords/instancemanager_keywords.py
 
 *** Keywords ***
 Volume ${volume_id} replica ${setting_name} should be ${setting_value}
@@ -53,3 +54,11 @@ Assert replica file size of ${resource_kind} ${resource_id} is ${expected_size}
     ...    ELSE
     ...        get_workload_volume_name    ${resource_name}
     wait_for_replica_file_size    ${volume_name}    ${expected_bytes}
+
+Verify raid bdev exists on node ${node_id}
+    ${node_name} =    get_node_by_index    ${node_id}
+    verify_raid_bdev_exists_on_node    ${node_name}
+
+Verify raid bdev does not exist on node ${node_id}
+    ${node_name} =    get_node_by_index    ${node_id}
+    verify_raid_bdev_not_exists_on_node    ${node_name}

--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -697,6 +697,12 @@ Upgrade v1 volumes engine to ${custom_engine_image}
         wait_for_engine_image_upgrade_completed    ${volume_name}    ${custom_engine_image}
     END
 
+Upgrade v2 volumes engine to ${custom_engine_image}
+    ${volume_names} =    list_volumes    dataEngine=v2
+    FOR    ${volume_name}    IN    @{volume_names}
+        upgrade_engine_image    ${volume_name}    ${custom_engine_image}    use_patch=${True}
+    END
+
 Check volume ${volume_id} data is backup ${backup_id} created in another cluster
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     ${current_checksum} =    get_volume_checksum    ${volume_name}

--- a/e2e/libs/instancemanager/base.py
+++ b/e2e/libs/instancemanager/base.py
@@ -102,6 +102,58 @@ class Base:
                 time.sleep(self.retry_count)
                 assert False, f"Unexpected instance manager restart: {pod}"
 
+    def record_instance_manager_pod_uids(self, engine_type):
+        ims = get_longhorn_client().list_instance_manager()
+        im_names = [im.name for im in ims if im.dataEngine == engine_type]
+        logging(f"Recording {engine_type} instance manager pod UIDs: {im_names}")
+
+        core_api = client.CoreV1Api()
+        im_pod_uids = {}
+        for im_name in im_names:
+            try:
+                pod = core_api.read_namespaced_pod(name=im_name, namespace=constant.LONGHORN_NAMESPACE)
+                im_pod_uids[im_name] = pod.metadata.uid
+                logging(f"Recorded instance manager {im_name} UID: {pod.metadata.uid}")
+            except Exception as e:
+                logging(f"Error reading instance manager pod {im_name}: {e}")
+
+        return im_pod_uids
+
+    def check_instance_managers_not_restarted(self, engine_type, recorded_pod_uids):
+        if recorded_pod_uids is None or not recorded_pod_uids:
+            logging(f"WARN: No recorded instance manager UIDs provided, skipping restart check")
+            return
+
+        logging(f"Checking {engine_type} instance managers didn't restart or recreate")
+        logging(f"Recorded instance managers: {list(recorded_pod_uids.keys())}")
+
+        core_api = client.CoreV1Api()
+
+        # Check each recorded instance manager
+        for im_name, recorded_uid in recorded_pod_uids.items():
+            try:
+                pod = core_api.read_namespaced_pod(name=im_name, namespace=constant.LONGHORN_NAMESPACE)
+
+                # Check if pod UID matches (not recreated)
+                if pod.metadata.uid != recorded_uid:
+                    logging(f"FAIL: Instance manager {im_name} was recreated!")
+                    logging(f"  Recorded UID: {recorded_uid}")
+                    logging(f"  Current UID: {pod.metadata.uid}")
+                    assert False, f"Instance manager {im_name} was recreated during upgrade"
+
+                # Check restart count
+                if pod.status.container_statuses[0].restart_count != 0:
+                    logging(f"FAIL: Instance manager {im_name} restarted {pod.status.container_statuses[0].restart_count} times")
+                    assert False, f"Instance manager {im_name} restarted during upgrade"
+
+                logging(f"OK: Instance manager {im_name} - UID matches, restart count: 0")
+
+            except Exception as e:
+                logging(f"FAIL: Error checking instance manager {im_name}: {e}")
+                assert False, f"Instance manager {im_name} not found or error occurred"
+
+        logging(f"All {len(recorded_pod_uids)} {engine_type} instance managers verified - no restarts or recreations")
+
     def check_instance_manager_existence_on_node(self, node_name, engine_type="v1", exist=True):
         longhorn_client = get_longhorn_client()
         worker_nodes = self.node.list_node_names_by_role("worker")

--- a/e2e/libs/instancemanager/v2_instancemanager.py
+++ b/e2e/libs/instancemanager/v2_instancemanager.py
@@ -8,6 +8,8 @@ from utility.utility import subprocess_exec_cmd
 import utility.constant as constant
 from utility.constant import DEFAULT_BLOCK_DISK_NAME
 
+import json
+
 class V2_InstanceManager(Base):
 
     def __init__(self):
@@ -64,3 +66,68 @@ class V2_InstanceManager(Base):
                 logging(f"Failed to wait for replica {replica_name} to be present in spdk on node {node_name}: {e}")
             time.sleep(self.retry_interval)
         assert False, f"Failed to wait for replica {replica_name} to be present in spdk on node {node_name}"
+
+    def get_spdk_raid_bdevs(self, node_name):
+        logging(f"Getting SPDK raid bdevs on node {node_name}")
+        im_pod_name = self.get_instance_manager_pod_on_node(node_name, "v2")
+        cmd = f"kubectl exec -n {constant.LONGHORN_NAMESPACE} {im_pod_name} -- go-spdk-helper raid get"
+        output = subprocess_exec_cmd(cmd)
+        logging(f"SPDK raid bdevs output on node {node_name}:\n{output}")
+        return output
+
+    def verify_raid_bdev_exists_on_node(self, node_name):
+        logging(f"Verifying raid bdev exists on node {node_name}")
+        for i in range(self.retry_count):
+            try:
+                raid_output = self.get_spdk_raid_bdevs(node_name)
+                # Parse JSON output
+                raid_bdevs = json.loads(raid_output)
+                # Check if array is not empty (raid bdevs exist)
+                if isinstance(raid_bdevs, list) and len(raid_bdevs) > 0:
+                    logging(f"Verified raid bdev exists on node {node_name}: found {len(raid_bdevs)} raid bdev(s)")
+                    return
+                logging(f"No raid bdev found on node {node_name} (empty array), retrying ... ({i})")
+                time.sleep(self.retry_interval)
+            except json.JSONDecodeError as e:
+                logging(f"Error parsing SPDK raid bdevs JSON on node {node_name}: {e}")
+                time.sleep(self.retry_interval)
+            except Exception as e:
+                logging(f"Error checking SPDK raid bdevs: {e}")
+                time.sleep(self.retry_interval)
+        assert False, f"No raid bdev found on node {node_name} after {self.retry_count} retries"
+
+    def verify_raid_bdev_not_exists_on_node(self, node_name):
+        logging(f"Verifying raid bdev does not exist on node {node_name}")
+        for i in range(self.retry_count):
+            try:
+                raid_output = self.get_spdk_raid_bdevs(node_name)
+                # Parse JSON output
+                raid_bdevs = json.loads(raid_output)
+                # Check if array is empty (no raid bdevs)
+                if isinstance(raid_bdevs, list) and len(raid_bdevs) == 0:
+                    logging(f"Verified no raid bdev on node {node_name} (empty array)")
+                    return
+                logging(f"Raid bdev still exists on node {node_name}: found {len(raid_bdevs)} raid bdev(s), retrying ... ({i})")
+                time.sleep(self.retry_interval)
+            except json.JSONDecodeError as e:
+                logging(f"Error parsing SPDK raid bdevs JSON on node {node_name}: {e}")
+                time.sleep(self.retry_interval)
+            except Exception as e:
+                logging(f"Error checking SPDK raid bdevs: {e}")
+                time.sleep(self.retry_interval)
+        assert False, f"Raid bdev still exists on node {node_name} after {self.retry_count} retries"
+
+    def verify_replica_lvol_exists_in_spdk_lvol(self, node_name, replica_name):
+        logging(f"Verifying replica {replica_name} exists in SPDK on node {node_name}")
+        for i in range(self.retry_count):
+            try:
+                lvols_output = self.get_spdk_lvols(node_name)
+                if replica_name in lvols_output:
+                    logging(f"Verified replica {replica_name} exists in SPDK on node {node_name}")
+                    return
+                logging(f"Replica {replica_name} not found in SPDK on node {node_name}, retrying ... ({i})")
+                time.sleep(self.retry_interval)
+            except Exception as e:
+                logging(f"Error checking SPDK lvols: {e}")
+                time.sleep(self.retry_interval)
+        assert False, f"Replica {replica_name} not found in SPDK on node {node_name} after {self.retry_count} retries"

--- a/e2e/libs/keywords/instancemanager_keywords.py
+++ b/e2e/libs/keywords/instancemanager_keywords.py
@@ -56,4 +56,20 @@ class instancemanager_keywords:
 
     def verify_replica_lvol_exists_in_spdk_lvol(self, node_name, replica_name):
         logging(f"Verifying replica {replica_name} exists in SPDK on node {node_name}")
-        self.instancemanager.verify_replica_lvol_exists_in_spdk_lvol(node_name, replica_name)
+        self.v2_instancemanager.verify_replica_lvol_exists_in_spdk_lvol(node_name, replica_name)
+
+    def verify_raid_bdev_exists_on_node(self, node_name):
+        logging(f"Verifying raid bdev exists on node {node_name}")
+        self.v2_instancemanager.verify_raid_bdev_exists_on_node(node_name)
+
+    def verify_raid_bdev_not_exists_on_node(self, node_name):
+        logging(f"Verifying raid bdev does not exist on node {node_name}")
+        self.v2_instancemanager.verify_raid_bdev_not_exists_on_node(node_name)
+
+    def record_instance_manager_pod_uids(self, engine_type="v1"):
+        logging(f"Recording {engine_type} instance manager pod UIDs")
+        return self.instancemanager.record_instance_manager_pod_uids(engine_type)
+
+    def check_instance_managers_not_restarted(self, engine_type="v1", recorded_pod_uids=None):
+        logging(f"Checking {engine_type} instance managers did not restart")
+        self.instancemanager.check_instance_managers_not_restarted(engine_type, recorded_pod_uids)

--- a/e2e/libs/keywords/node_keywords.py
+++ b/e2e/libs/keywords/node_keywords.py
@@ -173,3 +173,6 @@ class node_keywords:
 
     def remove_dir(self, dir_path, node_name):
         self.node.remove_dir(dir_path, node_name)
+
+    def set_node_upgrade_requested(self, node_name, upgrade_requested=True):
+        self.node.set_node_upgrade_requested(node_name, upgrade_requested)

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -445,8 +445,8 @@ class volume_keywords:
             f"Want: {expected_replica_names}\n" \
             f"Got: {actual_replica_names}"
 
-    def upgrade_engine_image(self, volume_name, engine_image_name):
-        self.volume.upgrade_engine_image(volume_name, engine_image_name)
+    def upgrade_engine_image(self, volume_name, engine_image_name, use_patch=False):
+        self.volume.upgrade_engine_image(volume_name, engine_image_name, use_patch=use_patch)
 
     def wait_for_engine_image_upgrade_completed(self, volume_name, engine_image_name):
         self.volume.wait_for_engine_image_upgrade_completed(volume_name, engine_image_name)

--- a/e2e/libs/node/node.py
+++ b/e2e/libs/node/node.py
@@ -346,6 +346,17 @@ class Node:
         """
         subprocess_exec_cmd(exec_cmd)
 
+    def set_node_upgrade_requested(self, node_name, upgrade_requested=True):
+        logging(f"Setting node {node_name} upgradeRequested to {upgrade_requested}")
+        exec_cmd = f"""
+            kubectl patch nodes.longhorn.io {node_name} -n {constant.LONGHORN_NAMESPACE} --type=merge -p '{{
+                \"spec\": {{
+                    \"upgradeRequested\": {str(upgrade_requested).lower()}
+                }}
+            }}'
+        """
+        subprocess_exec_cmd(exec_cmd)
+
     def set_default_disk_scheduling(self, node_name, allowScheduling):
         node = get_longhorn_client().by_id_node(node_name)
 

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -850,8 +850,15 @@ class CRD(Base):
     def activate(self, volume_name):
         return Rest().activate(volume_name)
 
-    def upgrade_engine_image(self, volume_name, engine_image_name):
-        return Rest().upgrade_engine_image(volume_name, engine_image_name)
+    def upgrade_engine_image(self, volume_name, engine_image_name, use_patch=False):
+        if use_patch:
+            logging(f"Upgrading volume {volume_name} engine image to {engine_image_name} using kubectl patch")
+            exec_cmd = f"""
+            kubectl -n {constant.LONGHORN_NAMESPACE} patch volume.longhorn.io {volume_name} --type='merge' -p '{{"spec":{{"image": "{engine_image_name}"}}}}'
+            """
+            subprocess_exec_cmd(exec_cmd)
+        else:
+            return Rest().upgrade_engine_image(volume_name, engine_image_name)
 
     def wait_for_engine_image_upgrade_completed(self, volume_name, engine_image_name):
         return Rest().wait_for_engine_image_upgrade_completed(volume_name, engine_image_name)

--- a/e2e/libs/volume/volume.py
+++ b/e2e/libs/volume/volume.py
@@ -195,8 +195,8 @@ class Volume(Base):
     def create_persistentvolumeclaim(self, volume_name, volumeMode, retry, sc_name="longhorn"):
         return self.volume.create_persistentvolumeclaim(volume_name, volumeMode, retry, sc_name=sc_name)
 
-    def upgrade_engine_image(self, volume_name, engine_image_name):
-        return self.volume.upgrade_engine_image(volume_name, engine_image_name)
+    def upgrade_engine_image(self, volume_name, engine_image_name, use_patch=False):
+        return self.volume.upgrade_engine_image(volume_name, engine_image_name, use_patch=use_patch)
 
     def wait_for_engine_image_upgrade_completed(self, volume_name, engine_image_name):
         return self.volume.wait_for_engine_image_upgrade_completed(volume_name, engine_image_name)

--- a/e2e/tests/regression/test_v2.robot
+++ b/e2e/tests/regression/test_v2.robot
@@ -20,6 +20,7 @@ Resource    ../keywords/k8s.resource
 Resource    ../keywords/orphan.resource
 Resource    ../keywords/replica.resource
 Resource    ../keywords/engine_frontend.resource
+Resource    ../keywords/engine_image.resource
 
 Test Setup    Set up v2 test environment
 Test Teardown    Cleanup test resources
@@ -298,7 +299,6 @@ Test Default Block Disks Delete And Re-add
     Then Check volume 0 data is intact
 
 Test V2 Volume Engine Live Switchover
-    [Tags]    v2
     [Documentation]    Test v2 volume cross-node initiator and target support with live switchover.
     ...                Verify data integrity is maintained when engine moves across nodes
     ...                while volume and enginefront remain on the original node.
@@ -396,3 +396,107 @@ Test V2 Instance Manager Pod Recreate Loop When Engine Frontend Recovery Blocks 
     And Wait for volume test-vol healthy
     And Write data to volume test-vol
     Then Check volume test-vol data is intact
+
+Test V2 Volume Upgrade Data Plane
+    [Documentation]    Test v2 volume upgrade data plane scenario.
+    ...
+    ...                Test steps:
+    ...                1. Install a stable Longhorn version.
+    ...                2. Enable the v2 data engine and add block disks.
+    ...                3. Create two v2 RWO volumes with two replicas.
+    ...                4. Create two deployments using the v2 volumes on node 0.
+    ...                5. Wait for both volumes to become healthy.
+    ...                6. Record the v2 instance-manager pod UIDs.
+    ...                7. Upgrade Longhorn to the custom version.
+    ...                8. Verify the v2 instance-manager pods were not recreated.
+    ...                9. Verify both volumes remain healthy after the Longhorn upgrade.
+    ...                10. Disable node 2 scheduling so the volume engines can only move to node 1 later.
+    ...                11. Set upgradeRequested=true on node 0.
+    ...                12. Verify the RAID bdev still exists on node 0 and does not exist on node 1 or node 2.
+    ...                13. Move both volume engines to node 1.
+    ...                14. Verify both engine CRs are on node 1 while both volumes remain attached to node 0.
+    ...                15. Upgrade the v2 volume engine image to the custom engine image.
+    ...                16. Verify the RAID bdev exists on node 1 and does not exist on node 0 or node 2.
+    ...                17. Move both volume engines back to node 0.
+    ...                18. Verify both engine CRs are on node 0 while both volumes remain attached to node 0.
+    ...                19. Verify the RAID bdev exists on node 0 and does not exist on node 1 or node 2.
+    ...                20. Reinstall Longhorn to avoid side effects from upgrading with attached v2 volumes.
+    ...
+    ...                Note:
+    ...                This test does not verify engine state transitions because the engine state changes cannot be reliably observed.
+    ...
+    ...                Reference:
+    ...                https://github.com/longhorn/longhorn/issues/6001#issuecomment-2239541696
+    ${LONGHORN_STABLE_VERSION}=    Get Environment Variable    LONGHORN_STABLE_VERSION    default=''
+    IF    '${LONGHORN_STABLE_VERSION}' == ''
+        Skip    Environment variable LONGHORN_STABLE_VERSION is not set
+    END
+
+    IF    '${DATA_ENGINE}' == 'v1'
+        Skip    Test only validate on v2 data engine
+    END
+    ${CUSTOM_LONGHORN_ENGINE_IMAGE}=    Get Environment Variable    CUSTOM_LONGHORN_ENGINE_IMAGE    default='undefined'
+
+    Given Setting deleting-confirmation-flag is set to true
+    And Uninstall Longhorn
+    And Check all Longhorn CRD removed
+    And Install Longhorn stable version
+    And Wait for longhorn ready
+    And Enable v2 data engine and add block disks
+
+    When Create storageclass longhorn-test with    dataEngine=v2    numberOfReplicas=2
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-test
+    And Create persistentvolumeclaim 1    volume_type=RWO    sc_name=longhorn-test
+    And Create deployment 0 with persistentvolumeclaim 0
+    ...    node_selector={"kubernetes.io/hostname":"${NODE_0}"}
+    And Create deployment 1 with persistentvolumeclaim 1
+    ...    node_selector={"kubernetes.io/hostname":"${NODE_0}"}
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    And Record v2 instance manager UIDs
+
+    When Upgrade Longhorn to custom version
+    And Wait for longhorn ready
+    Then Check v2 instance manager did not restart
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+
+    # Disable node 2 scheduling to ensure the RAID bdev can only move to node 1 later
+    When Disable node 2 scheduling
+    And Set node 0 upgrade requested to true
+    Then Verify raid bdev exists on node 0
+    And Verify raid bdev does not exist on node 1
+    And Verify raid bdev does not exist on node 2
+
+    When Update volume of deployment 0 engineNodeID to node 1
+    And Update volume of deployment 1 engineNodeID to node 1
+    Then Volume of deployment 0 engine CR should be on node 1
+    And Volume of deployment 1 engine CR should be on node 1
+    And Volume of deployment 0 should be attached to node 0
+    And Volume of deployment 1 should be attached to node 0
+    When Upgrade v2 volumes engine to ${CUSTOM_LONGHORN_ENGINE_IMAGE}
+
+    # Verify RAID bdev moved to node 1
+    And Verify raid bdev exists on node 1
+    And Verify raid bdev does not exist on node 0
+    And Verify raid bdev does not exist on node 2
+
+    When Update volume of deployment 0 engineNodeID to node 0
+    And Update volume of deployment 1 engineNodeID to node 0
+    Then Volume of deployment 0 engine CR should be on node 0
+    And Volume of deployment 1 engine CR should be on node 0
+    And Volume of deployment 0 should be attached to node 0
+    And Volume of deployment 1 should be attached to node 0
+
+    And Verify raid bdev exists on node 0
+    And Verify raid bdev does not exist on node 1
+    And Verify raid bdev does not exist on node 2
+
+    # Reinstall to avoid side effects of upgrade with attached v2 volumes
+    When Enable node 2 scheduling
+    And Setting deleting-confirmation-flag is set to true
+    And Uninstall Longhorn
+    And Check all Longhorn CRD removed
+    And Install Longhorn
+    And Wait for longhorn ready
+    And Enable v2 data engine and add block disks


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#8904

#### What this PR does / why we need it:

Add case Test V2 Volume Upgrade Data Plane

#### Special notes for reviewers:

The original test [steps](https://github.com/longhorn/longhorn/issues/6001#issuecomment-2239541696) were written based on Longhorn v1.7.0. Some behaviors in the original steps are different with current product behavior:

- `volume.spec.targetNodeID` is no longer available, therefore this test uses `engineNodeID` instead.
- Volumes no longer become degraded during the engine upgrade.
- The transient engine state changes are difficult to observe reliably, therefore this test focus on validates the RAID bdev location to confirm whether the engine target has moved to the expected node.

#### Additional documentation or context

https://ci.longhorn.io/job/private/job/longhorn-e2e-test/8191/
https://ci.longhorn.io/job/private/job/longhorn-e2e-test/8192/