### PR TITLE
test(ci): install released suse-storage chart with revision images

### DIFF
--- a/manager/integration/Dockerfile
+++ b/manager/integration/Dockerfile
@@ -14,7 +14,7 @@ ARG YQ_VERSION=v4.24.2
 ARG TERRAFORM_VERSION=1.3.5
 
 RUN zypper ref -f
-RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python311-devel gawk java-21-openjdk tar awk gzip wget unzip nvme-cli && \
+RUN zypper in -y vim-small nfs-client xfsprogs e2fsprogs util-linux-systemd gcc python311-devel gawk java-21-openjdk tar awk gzip wget unzip nvme-cli jq && \
     rm -rf /var/cache/zypp/*
 
 RUN curl -sO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/${ARCH}/kubectl && \

--- a/pipelines/appco/Jenkinsfile
+++ b/pipelines/appco/Jenkinsfile
@@ -11,6 +11,17 @@ def WORKSPACE = "/src/longhorn-tests"
 def LONGHORN_INSTALL_METHOD = 'helm'
 def summary_msg = ""
 
+def APPCO_LONGHORN_COMPONENT_IMAGE_PATH = params.APPCO_LONGHORN_COMPONENT_IMAGE_PATH ? params.APPCO_LONGHORN_COMPONENT_IMAGE_PATH : ""
+def LONGHORN_COMPONENT_TAG = params.LONGHORN_COMPONENT_TAG ? params.LONGHORN_COMPONENT_TAG : ""
+def CSI_ATTACHER_TAG = params.CSI_ATTACHER_TAG ? params.CSI_ATTACHER_TAG : ""
+def CSI_PROVISIONER_TAG = params.CSI_PROVISIONER_TAG ? params.CSI_PROVISIONER_TAG : ""
+def CSI_RESIZER_TAG = params.CSI_RESIZER_TAG ? params.CSI_RESIZER_TAG : ""
+def CSI_SNAPSHOTTER_TAG = params.CSI_SNAPSHOTTER_TAG ? params.CSI_SNAPSHOTTER_TAG : ""
+def CSI_LIVENESSPROBE_TAG = params.CSI_LIVENESSPROBE_TAG ? params.CSI_LIVENESSPROBE_TAG : ""
+def CSI_REGISTRAR_TAG = params.CSI_REGISTRAR_TAG ? params.CSI_REGISTRAR_TAG : ""
+def SUPPORT_BUNDLE_TAG = params.SUPPORT_BUNDLE_TAG ? params.SUPPORT_BUNDLE_TAG : ""
+def USE_REVERSION_IMAGES = params.USE_REVERSION_IMAGES ? params.USE_REVERSION_IMAGES : false
+
 // define optional parameters
 def SELINUX_MODE = params.SELINUX_MODE ? params.SELINUX_MODE : ""
 
@@ -93,6 +104,7 @@ node {
                                        --env CSI_LIVENESSPROBE_TAG=${CSI_LIVENESSPROBE_TAG} \
                                        --env CSI_REGISTRAR_TAG=${CSI_REGISTRAR_TAG} \
                                        --env SUPPORT_BUNDLE_TAG=${SUPPORT_BUNDLE_TAG} \
+                                       --env USE_REVERSION_IMAGES=${USE_REVERSION_IMAGES} \
                                        --env APPCO_USERNAME=${APPCO_USERNAME} \
                                        --env APPCO_PASSWORD=${APPCO_PASSWORD} \
                                        --env JOB_NAME=${JOB_BASE_NAME}-${BUILD_NUMBER} \

--- a/pipelines/appco/scripts/fetch-revision-tag.sh
+++ b/pipelines/appco/scripts/fetch-revision-tag.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+
+API_URL="https://api.apps.rancher.io/v1/artifacts"
+PAGE_SIZE=100
+SLEEP_SECONDS=0.2
+CURL_TIMEOUT=10
+MAX_PAGES_PER_COMPONENT=50
+MAX_TOTAL_API_CALLS=500
+TARGET_LONGHORN_VERSION="${TARGET_LONGHORN_VERSION:-1.11.2}"
+TOTAL_API_CALLS=0
+
+LONGHORN_COMPONENTS=(
+  longhorn-backing-image-manager longhorn-engine longhorn-instance-manager
+  longhorn-manager longhorn-share-manager longhorn-ui
+)
+
+DEPENDENCY_COMPONENTS=(
+  kubernetes-csi-external-attacher kubernetes-csi-external-provisioner
+  kubernetes-csi-external-resizer kubernetes-csi-external-snapshotter
+  kubernetes-csi-livenessprobe kubernetes-csi-node-driver-registrar
+  rancher-support-bundle-kit
+)
+
+declare -A COMPONENT_PATHS=(
+  [kubernetes-csi-external-attacher]='.image.csi.attacher.tag'
+  [kubernetes-csi-external-provisioner]='.image.csi.provisioner.tag'
+  [kubernetes-csi-external-resizer]='.image.csi.resizer.tag'
+  [kubernetes-csi-external-snapshotter]='.image.csi.snapshotter.tag'
+  [kubernetes-csi-livenessprobe]='.image.csi.livenessProbe.tag'
+  [kubernetes-csi-node-driver-registrar]='.image.csi.nodeDriverRegistrar.tag'
+  [rancher-support-bundle-kit]='.image.longhorn.supportBundleKit.tag'
+  [longhorn-backing-image-manager]='.image.longhorn.backingImageManager.tag'
+  [longhorn-engine]='.image.longhorn.engine.tag'
+  [longhorn-instance-manager]='.image.longhorn.instanceManager.tag'
+  [longhorn-manager]='.image.longhorn.manager.tag'
+  [longhorn-share-manager]='.image.longhorn.shareManager.tag'
+  [longhorn-ui]='.image.longhorn.ui.tag'
+)
+
+declare -A COMPONENT_VERSIONS COMPONENT_TAGS COMPONENT_ARTIFACT_NAMES COMPONENT_CHART_TAGS
+
+to_env_name() {
+  echo "${1}_tag" | tr '[:lower:]-' '[:upper:]_'
+}
+
+get_chart_values() {
+  local chart_version="${1%%-*}" values_output
+
+  echo "INFO: Fetching Helm chart values for suse-storage version ${chart_version}" >&2
+  if ! values_output="$(helm show values \
+      "oci://dp.apps.rancher.io/charts/suse-storage" --version "$chart_version" 2>&1)"; then
+    echo "ERROR: Failed to fetch Helm chart values for suse-storage version ${chart_version}" >&2
+    echo "$values_output" >&2
+    exit 1
+  fi
+
+  echo "$values_output" | grep -vE '^(Pulled|Digest):'
+}
+
+parse_component_versions() {
+  local values component tag
+  values="$(get_chart_values "$1")"
+
+  for component in "${DEPENDENCY_COMPONENTS[@]}"; do
+    tag="$(echo "$values" | yq eval "${COMPONENT_PATHS[$component]}" -)"
+    COMPONENT_CHART_TAGS["$component"]="$tag"
+    if [[ "$tag" =~ ^([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+      COMPONENT_VERSIONS["$component"]="${BASH_REMATCH[1]}"
+    fi
+  done
+
+  for component in "${LONGHORN_COMPONENTS[@]}"; do
+    COMPONENT_CHART_TAGS["$component"]="$(echo "$values" | yq eval "${COMPONENT_PATHS[$component]}" -)"
+  done
+}
+
+fetch_page() {
+  local component="$1" page="$2" version_filter="${3:-}"
+  local response http_code
+  local -a args=(
+    --data-urlencode 'packaging_formats=CONTAINER'
+    --data-urlencode "component_slug_name=${component}"
+    --data-urlencode "page_number=${page}"
+    --data-urlencode "page_size=${PAGE_SIZE}"
+  )
+
+  if [[ "$TOTAL_API_CALLS" -ge "$MAX_TOTAL_API_CALLS" ]]; then
+    echo "ERROR: Exceeded maximum API calls ${MAX_TOTAL_API_CALLS}" >&2
+    exit 1
+  fi
+  TOTAL_API_CALLS=$((TOTAL_API_CALLS + 1))
+  [[ -n "$version_filter" ]] && args+=(--data-urlencode "version=${version_filter}")
+
+  response="$(curl --max-time "$CURL_TIMEOUT" -sG -w "\n%{http_code}" \
+    "$API_URL" "${args[@]}")"
+  http_code="$(tail -n1 <<< "$response")"
+
+  if [[ ! "$http_code" =~ ^2[0-9]{2}$ ]]; then
+    echo "ERROR: API request failed with HTTP ${http_code} for component ${component}, page ${page}" >&2
+    exit 1
+  fi
+
+  head -n -1 <<< "$response"
+}
+
+fetch_all_items() {
+  local component="$1" version_filter="${2:-}"
+  local first_resp total_pages page
+
+  first_resp="$(fetch_page "$component" 1 "$version_filter")"
+  if ! jq empty <<< "$first_resp" 2>/dev/null; then
+    echo "ERROR: Invalid JSON response for component ${component}" >&2
+    exit 1
+  fi
+
+  total_pages="$(jq -r '.total_pages // 1' <<< "$first_resp")"
+  if [[ "$total_pages" -gt "$MAX_PAGES_PER_COMPONENT" ]]; then
+    echo "ERROR: Component ${component} has ${total_pages} pages, exceeds limit ${MAX_PAGES_PER_COMPONENT}" >&2
+    echo "ERROR: Refuse to continue because the latest revision may be missed." >&2
+    echo "ERROR: Increase MAX_PAGES_PER_COMPONENT or add more specific API filters." >&2
+    exit 1
+  fi
+
+  {
+    jq '.items[]?' <<< "$first_resp"
+    for ((page = 2; page <= total_pages; page++)); do
+      sleep "$SLEEP_SECONDS"
+      fetch_page "$component" "$page" "$version_filter" | jq '.items[]?'
+    done
+  } | jq -s '.'
+}
+
+get_latest_revision_for_version() {
+  fetch_all_items "$1" "$2" | jq -r '
+    unique_by((.version // "") + "-" + ((.revision // "0") | tostring))
+    | sort_by(
+        ((.revision // "0") | tostring)
+        | split(".")
+        | map(tonumber? // 0)
+      )
+    | reverse
+    | if length == 0 then
+        "NOT_FOUND|NOT_FOUND"
+      else
+        .[0] | "\(.version)-\(.revision)|\(.name)"
+      end
+  '
+}
+
+set_component_result() {
+  local component="$1" target_version="$2"
+  local result tag artifact_name env_name
+
+  result="$(get_latest_revision_for_version "$component" "$target_version")"
+  tag="${result%%|*}"
+  artifact_name="${result#*|}"
+
+  if [[ "$tag" == "NOT_FOUND" || -z "$tag" ]]; then
+    echo "ERROR: Cannot find AppCo artifact for component=${component}, version=${target_version}" >&2
+    exit 1
+  fi
+
+  COMPONENT_TAGS["$component"]="$tag"
+  COMPONENT_ARTIFACT_NAMES["$component"]="$artifact_name"
+  env_name="$(to_env_name "$component")"
+  export "${env_name}=${tag}"
+}
+
+print_exported_variables() {
+  local component env_name
+  echo "Exported environment variables:"
+
+  for component in "${DEPENDENCY_COMPONENTS[@]}" "${LONGHORN_COMPONENTS[@]}"; do
+    env_name="$(to_env_name "$component")"
+    echo "  export ${env_name}='${!env_name:-}'"
+  done
+  echo "  export CUSTOM_LONGHORN_ENGINE_IMAGE='${CUSTOM_LONGHORN_ENGINE_IMAGE}'"
+}
+
+print_tag_comparison() {
+  local component chart_tag appco_tag env_name
+  local all_current=true
+
+  echo ""
+  echo "=== AppCo Revision Tag Comparison ==="
+  printf "%-50s %-25s %-25s %-12s\n" \
+    "COMPONENT" "CHART TAG" "APPCO LATEST TAG" "STATUS"
+  printf '%*s\n' 116 '' | tr ' ' '-'
+
+  for component in "${DEPENDENCY_COMPONENTS[@]}" "${LONGHORN_COMPONENTS[@]}"; do
+    chart_tag="${COMPONENT_CHART_TAGS[$component]:-N/A}"
+    env_name="$(to_env_name "$component")"
+    appco_tag="${!env_name:-N/A}"
+
+    if [[ "$chart_tag" == "$appco_tag" ]]; then
+      printf "%-50s %-25s %-25s %-12s\n" \
+        "$component" "$chart_tag" "$appco_tag" "UP-TO-DATE"
+    else
+      printf "%-50s %-25s %-25s %-12s\n" \
+        "$component" "$chart_tag" "$appco_tag" "OUTDATED"
+      all_current=false
+    fi
+  done
+
+  echo "======================================"
+  echo ""
+  [[ "$all_current" == true ]]
+}
+
+fetch_appco_revision_tags() {
+  local target_version="${1:-${TARGET_LONGHORN_VERSION}}" component
+
+  parse_component_versions "$target_version"
+
+  for component in "${DEPENDENCY_COMPONENTS[@]}"; do
+    if [[ -z "${COMPONENT_VERSIONS[$component]:-}" ]]; then
+      echo "ERROR: Cannot find image version for dependency component ${component} from Helm chart version ${target_version}" >&2
+      exit 1
+    fi
+    set_component_result "$component" "${COMPONENT_VERSIONS[$component]}"
+  done
+
+  for component in "${LONGHORN_COMPONENTS[@]}"; do
+    set_component_result "$component" "$target_version"
+  done
+
+  export CUSTOM_LONGHORN_ENGINE_IMAGE="dp.apps.rancher.io/containers/longhorn-engine:${LONGHORN_ENGINE_TAG}"
+  print_exported_variables
+
+  if print_tag_comparison; then
+    echo "INFO: All image tags in the chart already match the latest AppCo revision tags. No new revision images to test."
+    export APPCO_REVISION_IMAGES_CURRENT=true
+  else
+    export APPCO_REVISION_IMAGES_CURRENT=false
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  TARGET_LONGHORN_VERSION="${1:-1.11.2}"
+  fetch_appco_revision_tags "$TARGET_LONGHORN_VERSION"
+fi

--- a/pipelines/appco/scripts/longhorn_helm_chart.sh
+++ b/pipelines/appco/scripts/longhorn_helm_chart.sh
@@ -4,6 +4,7 @@ set -x
 
 source pipelines/utilities/longhorn_status.sh
 source pipelines/utilities/create_network_policies.sh
+source pipelines/appco/scripts/fetch-revision-tag.sh
 TAG_ARGS=()
 SECRET_ARGS=()
 LONGHORN_NAMESPACE="longhorn-system"
@@ -129,19 +130,51 @@ install_longhorn_custom(){
   set +x
   prepare_chart_source "${chart_uri}"
   set -x
-  set_longhorn_registry_args
-  set_longhorn_repository_args
-  set_longhorn_tag_args
-  set_secret_args "${chart_uri}" true
 
-  helm upgrade --install longhorn "${chart_uri}" \
-    --namespace "${LONGHORN_NAMESPACE}" \
-    --version "${LONGHORN_VERSION}" \
-    "${REGISTRY_ARGS[@]}" \
-    "${REPOSITORY_ARGS[@]}" \
-    "${TAG_ARGS[@]}" \
-    "${SECRET_ARGS[@]}"
-  setup_longhorn_manager_networkpolicy
+  # If USE_REVERSION_IMAGES is true, use the released SUSE Storage chart with latest revision tags
+  if [[ "${USE_REVERSION_IMAGES}" == "true" ]]; then
+    # Fetch latest revision tags from AppCo API
+    set +x
+    fetch_appco_revision_tags "${LONGHORN_VERSION}"
+    set -x
+
+    set_secret_args "${chart_uri}"
+
+    helm upgrade --install longhorn "${chart_uri}" \
+      --namespace "${LONGHORN_NAMESPACE}" \
+      --version "${LONGHORN_VERSION}" \
+      --set image.longhorn.engine.tag="${LONGHORN_ENGINE_TAG}" \
+      --set image.longhorn.manager.tag="${LONGHORN_MANAGER_TAG}" \
+      --set image.longhorn.ui.tag="${LONGHORN_UI_TAG}" \
+      --set image.longhorn.instanceManager.tag="${LONGHORN_INSTANCE_MANAGER_TAG}" \
+      --set image.longhorn.shareManager.tag="${LONGHORN_SHARE_MANAGER_TAG}" \
+      --set image.longhorn.backingImageManager.tag="${LONGHORN_BACKING_IMAGE_MANAGER_TAG}" \
+      --set image.longhorn.supportBundleKit.tag="${RANCHER_SUPPORT_BUNDLE_KIT_TAG}" \
+      --set image.csi.attacher.tag="${KUBERNETES_CSI_EXTERNAL_ATTACHER_TAG}" \
+      --set image.csi.provisioner.tag="${KUBERNETES_CSI_EXTERNAL_PROVISIONER_TAG}" \
+      --set image.csi.nodeDriverRegistrar.tag="${KUBERNETES_CSI_NODE_DRIVER_REGISTRAR_TAG}" \
+      --set image.csi.resizer.tag="${KUBERNETES_CSI_EXTERNAL_RESIZER_TAG}" \
+      --set image.csi.snapshotter.tag="${KUBERNETES_CSI_EXTERNAL_SNAPSHOTTER_TAG}" \
+      --set image.csi.livenessProbe.tag="${KUBERNETES_CSI_LIVENESSPROBE_TAG}" \
+      "${SECRET_ARGS[@]}"
+      setup_longhorn_manager_networkpolicy
+  else
+    if [[ -n "${APPCO_LONGHORN_COMPONENT_IMAGE_PATH}" ]]; then
+      set_longhorn_registry_args
+      set_longhorn_repository_args
+    fi
+    set_longhorn_tag_args
+    set_secret_args "${chart_uri}" true
+
+    helm upgrade --install longhorn "${chart_uri}" \
+      --namespace "${LONGHORN_NAMESPACE}" \
+      --version "${LONGHORN_VERSION}" \
+      "${REGISTRY_ARGS[@]}" \
+      "${REPOSITORY_ARGS[@]}" \
+      "${TAG_ARGS[@]}" \
+      "${SECRET_ARGS[@]}"
+      setup_longhorn_manager_networkpolicy
+  fi
   wait_longhorn_status_running
 }
 

--- a/pipelines/appco/scripts/longhorn_setup.sh
+++ b/pipelines/appco/scripts/longhorn_setup.sh
@@ -40,6 +40,7 @@ main(){
 
   if [[ "$LONGHORN_TEST_CLOUDPROVIDER" == "harvester" ]]; then
     apply_kubectl_retry
+    apply_helm_retry
   fi
 
   if [[ ${DISTRO} == "rhel" ]] || [[ ${DISTRO} == "rockylinux" ]] || [[ ${DISTRO} == "oracle" ]]; then
@@ -77,12 +78,30 @@ main(){
     LONGHORN_UPGRADE_TEST_POD_NAME="longhorn-test-upgrade"
     setup_longhorn_ui_nodeport
     export_longhorn_ui_url
+
+    if [[ "${USE_REVERSION_IMAGES}" == "true" ]]; then
+      set +x
+      fetch_appco_revision_tags "${LONGHORN_VERSION}"
+      set -x
+
+      if [[ "${APPCO_REVISION_IMAGES_CURRENT}" == "true" ]]; then
+        echo "INFO: Skipping test — chart already contains the latest AppCo revision images. Nothing new to validate."
+        return 0
+      fi
+    fi
+
     run_longhorn_upgrade_test
     run_longhorn_test
   else
     install_longhorn_custom
     setup_longhorn_ui_nodeport
     export_longhorn_ui_url
+
+    if [[ "${USE_REVERSION_IMAGES}" == "true" ]] && [[ "${APPCO_REVISION_IMAGES_CURRENT}" == "true" ]]; then
+      echo "INFO: Skipping test — chart already contains the latest AppCo revision images. Nothing new to validate."
+      return 0
+    fi
+
     if [[ "${TEST_TYPE}" == "robot" ]]; then
       if [[ "${OUT_OF_CLUSTER}" == true ]]; then
         run_longhorn_test_out_of_cluster

--- a/pipelines/utilities/create_appco_secret.sh
+++ b/pipelines/utilities/create_appco_secret.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
 create_appco_secret(){
-  # set debugging mode off to avoid leaking docker secrets to the logs.
-  # DON'T REMOVE!
-  set +x
   kubectl -n longhorn-system create secret docker-registry application-collection --docker-server=dp.apps.rancher.io --docker-username="${APPCO_USERNAME}" --docker-password="${APPCO_PASSWORD}"
-  set -x
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/pipelines/utilities/create_network_policies.sh
+++ b/pipelines/utilities/create_network_policies.sh
@@ -8,8 +8,32 @@ source "${SCRIPT_DIR}/longhorn_namespace.sh"
 
 
 longhorn_internal_networkpolicies_exist(){
-  kubectl get networkpolicy longhorn-manager -n "${LONGHORN_NAMESPACE}" >/dev/null 2>&1 &&
-    kubectl get networkpolicy instance-manager -n "${LONGHORN_NAMESPACE}" >/dev/null 2>&1
+  echo "Checking if Longhorn internal NetworkPolicies exist in namespace ${LONGHORN_NAMESPACE}..."
+
+  local found_manager=false
+  local found_instance=false
+
+  if kubectl get networkpolicy longhorn-manager -n "${LONGHORN_NAMESPACE}" --request-timeout=300s >/dev/null 2>&1; then
+    found_manager=true
+    echo "DEBUG: NetworkPolicy 'longhorn-manager' found in ${LONGHORN_NAMESPACE}"
+  else
+    echo "DEBUG: NetworkPolicy 'longhorn-manager' NOT found in ${LONGHORN_NAMESPACE} (or API server unreachable)"
+  fi
+
+  if kubectl get networkpolicy instance-manager -n "${LONGHORN_NAMESPACE}" --request-timeout=300s >/dev/null 2>&1; then
+    found_instance=true
+    echo "DEBUG: NetworkPolicy 'instance-manager' found in ${LONGHORN_NAMESPACE}"
+  else
+    echo "DEBUG: NetworkPolicy 'instance-manager' NOT found in ${LONGHORN_NAMESPACE} (or API server unreachable)"
+  fi
+
+  if [[ "${found_manager}" == true && "${found_instance}" == true ]]; then
+    echo "DEBUG: Both internal NetworkPolicies exist — will apply test NetworkPolicies"
+    return 0
+  else
+    echo "DEBUG: One or both internal NetworkPolicies missing — will skip test NetworkPolicies"
+    return 1
+  fi
 }
 
 apply_longhorn_test_networkpolicy(){

--- a/pipelines/utilities/kubectl_retry.sh
+++ b/pipelines/utilities/kubectl_retry.sh
@@ -50,3 +50,51 @@ EOF
 
   source ~/.bashrc
 }
+
+apply_helm_retry(){
+  cat << 'EOF' >> ~/.bashrc
+
+helm() {
+  { set +x; } 2>/dev/null
+  trap 'set -x' RETURN
+  local max_retries=60
+  local delay=5
+  local count=0
+
+  while true; do
+    output=$(/usr/local/bin/helm "$@" 2>&1)
+    exit_code=$?
+    echo "$output"
+    count=$((count + 1))
+
+    if grep -qiE "connection refused|apiserver not ready|unauthorized|error looking up secret|has prevented the request from succeeding|Kubernetes cluster unreachable" <<< "$output"; then
+      echo "Attempt $count failed with exit code $exit_code. Retrying in $delay seconds..." >&2
+    elif [[ $count -ge $max_retries ]]; then
+      break
+    else
+      break
+    fi
+
+    sleep $delay
+  done
+
+  return $exit_code
+}
+EOF
+
+  source ~/.bashrc
+}
+
+unset_helm_retry(){
+  cat << 'EOF' >> ~/.bashrc
+
+helm() {
+  { set +x; } 2>/dev/null
+  trap 'set -x' RETURN
+  /usr/local/bin/helm "$@"
+  return $?
+}
+EOF
+
+  source ~/.bashrc
+}

--- a/pipelines/utilities/run_longhorn_test.sh
+++ b/pipelines/utilities/run_longhorn_test.sh
@@ -134,6 +134,7 @@ run_longhorn_upgrade_test(){
 
   ## for appco test
   yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "APPCO_TEST", "value": "'${APPCO_TEST}'"}' "${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}"
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "USE_REVERSION_IMAGES", "value": "'${USE_REVERSION_IMAGES}'"}' "${LONGHORN_UPGRADE_TESTS_MANIFEST_FILE_PATH}"
 
   # environment variables for upgrade test
   # install method can be manifest, helm, rancher, flux, fleet and argocd


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Running suse-storage tests with revision images, if no revision images, test will be skipped

<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->


- Fetch reversion images tag as environment variable then deploy to test

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '12px'}}}%%
flowchart TD
    A["Read LONGHORN_VERSION<br/>Example: 1.11.3"] --> B["Core Longhorn components<br/>Use version 1.11.3"]
    A --> C["CSI and support-bundle-kit<br/>Read dep-versions/v1.11.x/versions.json<br/>Example: csi-attacher v4.12.0"]
    B --> D["Query AppCo API by component + version"]
    C --> D
    D --> E["Select latest revision<br/>Example: 4.12.0-14.2"]
    E --> F["Export image tags for installation"]
    F --> G["Compare tags and export<br/>APPCO_REVISION_IMAGES_CURRENT"]
```

- The output of fetch-revision-tag.sh
```
17:45:20  === AppCo Revision Tag Comparison ===
17:45:20  COMPONENT                                     DEP-VERSIONS TAG     CHART TAG            APPCO LATEST TAG     STATUS    
17:45:20  -------------------------------------------------------------------------------------------------------------------
17:45:20  kubernetes-csi-external-attacher              4.12.0               4.12.0-14.1          4.12.0-17.6          OUTDATED  
17:45:20  kubernetes-csi-external-provisioner           6.3.0                6.3.0-7.1            6.3.0-10.7           OUTDATED  
17:45:20  kubernetes-csi-external-resizer               2.2.1                2.2.1-7.2            2.2.1-10.8           OUTDATED  
17:45:20  kubernetes-csi-external-snapshotter           8.6.0                8.6.0-14.1           8.6.0-17.6           OUTDATED  
17:45:20  kubernetes-csi-livenessprobe                  2.19.0               2.19.0-14.1          2.19.0-17.6          OUTDATED  
17:45:20  kubernetes-csi-node-driver-registrar          2.17.0               2.17.0-14.1          2.17.0-17.6          OUTDATED  
17:45:20  rancher-support-bundle-kit                    0.0.88               0.0.88-10.5          0.0.88-10.8          OUTDATED  
17:45:20  longhorn-backing-image-manager                N/A                  1.11.3-4.10          1.11.3-6.30          OUTDATED  
17:45:20  longhorn-engine                               N/A                  1.11.3-4.10          1.11.3-6.33          OUTDATED  
17:45:20  longhorn-instance-manager                     N/A                  1.11.3-4.16          1.11.3-6.45          OUTDATED  
17:45:20  longhorn-manager                              N/A                  1.11.3-4.10          1.11.3-6.27          OUTDATED  
17:45:20  longhorn-share-manager                        N/A                  1.11.3-4.6           1.11.3-6.24          OUTDATED  
17:45:20  longhorn-ui                                   N/A                  1.11.3-4.4           1.11.3-6.10          OUTDATED  
17:45:20  ======================================
```

#### What this PR does / why we need it:

Install released suse-storage chart with revision images

#### Special notes for your reviewer:

#### Additional documentation or context

