### PR TITLE
test: wait for recreated share-manager pod and stable workload pod in rwx test

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -5420,6 +5420,39 @@ def wait_and_get_any_deployment_pod(core_api, deployment_name,
     assert False
 
 
+def wait_and_get_stable_pod(core_api, pod_name, namespace="default",
+                            is_phase="Running",
+                            timeout_cnt=RETRY_COUNTS,
+                            stable_retry=WAIT_FOR_POD_STABLE_MAX_RETRY):
+    """
+    Add mechanism to wait for a stable running pod when workload restarts its
+    pod, since Longhorn manager could create/delete the new workload pod
+    multiple times, it's possible that we get an unstable pod which will be
+    deleted immediately, so add a wait mechanism to get a stable running pod.
+    """
+    stable_pod = None
+    wait_for_stable_retry = 0
+
+    for _ in range(timeout_cnt):
+        try:
+            pod = core_api.read_namespaced_pod(name=pod_name,
+                                               namespace=namespace)
+            if pod.status.phase == is_phase:
+                if stable_pod is None or \
+                        stable_pod.metadata.uid != pod.metadata.uid:
+                    stable_pod = pod
+                    wait_for_stable_retry = 0
+                else:
+                    wait_for_stable_retry += 1
+                    if wait_for_stable_retry == stable_retry:
+                        return stable_pod
+        except Exception as e:
+            print(f"Waiting for pod {pod_name} {is_phase} failed: {e}")
+
+        time.sleep(RETRY_INTERVAL)
+    assert False
+
+
 def wait_delete_deployment(apps_api, deployment_name, namespace='default'):
     for i in range(DEFAULT_DEPLOYMENT_TIMEOUT):
         ret = apps_api.list_namespaced_deployment(namespace=namespace)

--- a/manager/integration/tests/test_rwx.py
+++ b/manager/integration/tests/test_rwx.py
@@ -15,6 +15,7 @@ from common import wait_for_volume_creation, DATA_SIZE_IN_MB_3
 from common import create_pv_for_volume, create_pvc_for_volume
 from common import DEFAULT_STATEFULSET_TIMEOUT, DEFAULT_STATEFULSET_INTERVAL
 from common import wait_for_pod_remount
+from common import wait_for_pod_phase, wait_and_get_stable_pod
 from common import get_core_api_client, write_pod_volume_random_data
 from common import create_pvc_spec, make_deployment_with_pvc  # NOQA
 from common import core_api, statefulset, pvc, pod, client  # NOQA
@@ -392,7 +393,12 @@ def test_rwx_delete_share_manager_pod(client, core_api, statefulset, storage_cla
     delete_and_wait_pod(core_api, share_manager_name,
                         namespace=LONGHORN_NAMESPACE)
 
+    # Wait for the recreated share-manager pod before checking remount.
+    wait_for_pod_phase(core_api, share_manager_name, "Running",
+                       namespace=LONGHORN_NAMESPACE)
     wait_for_pod_remount(core_api, pod_name)
+
+    wait_and_get_stable_pod(core_api, pod_name, stable_retry=3)
 
     test_data_2 = generate_random_data(VOLUME_RWTEST_SIZE)
     write_pod_volume_data(core_api, pod_name, test_data_2, filename='test2')


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

https://github.com/longhorn/longhorn/issues/13221

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
