### PR TITLE
test(robot): add volume endpoint check keywords and integrate into upgrade tests

### DIFF
--- a/e2e/keywords/host.resource
+++ b/e2e/keywords/host.resource
@@ -177,7 +177,7 @@ Check volume endpoint on node of ${resource_kind} ${resource_id}
     ...    ELSE
     ...        get_workload_volume_name    ${resource_name}
     ${node_name} =    get_volume_node    ${volume_name}
-    check_volume_endpoint_on_node    ${volume_name}    ${node_name}
+    execute_command_on_node_and_wait_for_output    ls -l /dev/longhorn/${volume_name}    ${node_name}    brw
 
 Check volume endpoint on node ${node_id}
     [Documentation]    Run "ls -l /dev/longhorn/" on node ${node_id} and log the output as a WARNING.

--- a/e2e/keywords/host.resource
+++ b/e2e/keywords/host.resource
@@ -166,3 +166,47 @@ Get host log list on path ${log_path} on node ${node_id}
     ${host_log_files} =    get_host_log_files    ${node_name}    ${log_path}
     log    ${host_log_files}
     Set Test Variable    ${host_log_files}
+
+Check volume endpoint on node of ${resource_kind} ${resource_id}
+    [Documentation]    Find which node ${resource_kind} ${resource_id}'s volume is attached to,
+    ...                then run "ls -l /dev/longhorn/${volume_name}" on that node and log the output.
+    ...                If the directory is empty or doesn't exist, log a WARNING.
+    ${resource_name} =    generate_name_with_suffix    ${resource_kind}    ${resource_id}
+    ${volume_name} =    Run Keyword If    '${resource_kind}' == 'volume'
+    ...        Set Variable    ${resource_name}
+    ...    ELSE
+    ...        get_workload_volume_name    ${resource_name}
+    ${node_name} =    get_volume_node    ${volume_name}
+    ${result} =    execute_command_on_node    ls -l /dev/longhorn/${volume_name}    ${node_name}
+
+    # Check if result is empty or contains error
+    ${result_stripped} =    Strip String    ${result}
+    ${is_empty} =    Run Keyword And Return Status    Should Be Empty    ${result_stripped}
+    ${has_error} =    Run Keyword And Return Status    Should Contain    ${result}    No such file or directory
+
+    IF    ${is_empty} or ${has_error}
+        ${warning_msg} =    Set Variable    /dev/longhorn/${volume_name} is empty or doesn't exist on node=${node_name}, ${resource_kind}=${resource_name}, volume=${volume_name}
+        Log    ${warning_msg}    level=WARN    console=True
+    ELSE
+        ${message} =    Set Variable    node=${node_name}, volume=${volume_name}\n/dev/longhorn/${volume_name}:\n${result}
+        Log    ${message}    console=True
+    END
+
+Check volume endpoint on node ${node_id}
+    [Documentation]    Run "ls -l /dev/longhorn/" on node ${node_id} and log the output.
+    ...                If the directory is empty or doesn't exist, log a WARNING.
+    ${node_name} =    get_node_by_index    ${node_id}
+    ${result} =    execute_command_on_node    ls -l /dev/longhorn/    ${node_name}
+
+    # Check if result is empty or contains error
+    ${result_stripped} =    Strip String    ${result}
+    ${is_empty} =    Run Keyword And Return Status    Should Be Empty    ${result_stripped}
+    ${has_error} =    Run Keyword And Return Status    Should Contain    ${result}    No such file or directory
+
+    IF    ${is_empty} or ${has_error}
+        ${warning_msg} =    Set Variable    /dev/longhorn/ is empty or doesn't exist on node=${node_name}
+        Log    ${warning_msg}    level=WARN    console=True
+    ELSE
+        ${message} =    Set Variable    node=${node_name}\n/dev/longhorn/:\n${result}
+        Log    ${message}    console=True
+    END

--- a/e2e/keywords/host.resource
+++ b/e2e/keywords/host.resource
@@ -170,43 +170,16 @@ Get host log list on path ${log_path} on node ${node_id}
 Check volume endpoint on node of ${resource_kind} ${resource_id}
     [Documentation]    Find which node ${resource_kind} ${resource_id}'s volume is attached to,
     ...                then run "ls -l /dev/longhorn/${volume_name}" on that node and log the output.
-    ...                If the directory is empty or doesn't exist, log a WARNING.
+    ...                Fails the test if the endpoint is empty or doesn't exist.
     ${resource_name} =    generate_name_with_suffix    ${resource_kind}    ${resource_id}
     ${volume_name} =    Run Keyword If    '${resource_kind}' == 'volume'
     ...        Set Variable    ${resource_name}
     ...    ELSE
     ...        get_workload_volume_name    ${resource_name}
     ${node_name} =    get_volume_node    ${volume_name}
-    ${result} =    execute_command_on_node    ls -l /dev/longhorn/${volume_name}    ${node_name}
-
-    # Check if result is empty or contains error
-    ${result_stripped} =    Strip String    ${result}
-    ${is_empty} =    Run Keyword And Return Status    Should Be Empty    ${result_stripped}
-    ${has_error} =    Run Keyword And Return Status    Should Contain    ${result}    No such file or directory
-
-    IF    ${is_empty} or ${has_error}
-        ${warning_msg} =    Set Variable    /dev/longhorn/${volume_name} is empty or doesn't exist on node=${node_name}, ${resource_kind}=${resource_name}, volume=${volume_name}
-        Log    ${warning_msg}    level=WARN    console=True
-    ELSE
-        ${message} =    Set Variable    node=${node_name}, volume=${volume_name}\n/dev/longhorn/${volume_name}:\n${result}
-        Log    ${message}    console=True
-    END
+    check_volume_endpoint_on_node    ${volume_name}    ${node_name}
 
 Check volume endpoint on node ${node_id}
-    [Documentation]    Run "ls -l /dev/longhorn/" on node ${node_id} and log the output.
-    ...                If the directory is empty or doesn't exist, log a WARNING.
-    ${node_name} =    get_node_by_index    ${node_id}
-    ${result} =    execute_command_on_node    ls -l /dev/longhorn/    ${node_name}
-
-    # Check if result is empty or contains error
-    ${result_stripped} =    Strip String    ${result}
-    ${is_empty} =    Run Keyword And Return Status    Should Be Empty    ${result_stripped}
-    ${has_error} =    Run Keyword And Return Status    Should Contain    ${result}    No such file or directory
-
-    IF    ${is_empty} or ${has_error}
-        ${warning_msg} =    Set Variable    /dev/longhorn/ is empty or doesn't exist on node=${node_name}
-        Log    ${warning_msg}    level=WARN    console=True
-    ELSE
-        ${message} =    Set Variable    node=${node_name}\n/dev/longhorn/:\n${result}
-        Log    ${message}    console=True
-    END
+    [Documentation]    Run "ls -l /dev/longhorn/" on node ${node_id} and log the output as a WARNING.
+    ${result} =    Run command on node ${node_id} and get output string    ls -l /dev/longhorn/
+    Log    /dev/longhorn/ on node ${node_id}:\n${result}    level=WARN    console=True

--- a/e2e/libs/keywords/host_keywords.py
+++ b/e2e/libs/keywords/host_keywords.py
@@ -147,9 +147,18 @@ class host_keywords:
         return ssh_exec(node_name, cmd)
 
     def check_volume_endpoint_on_node(self, volume_name, node_name):
-        cmd = f"ls -l /dev/longhorn/{volume_name}"
-        res = NodeExec(node_name).issue_cmd(cmd)
-        assert res.strip() and "No such file or directory" not in res, \
-            f"Volume endpoint /dev/longhorn/{volume_name} is empty or doesn't exist on node {node_name}"
-        logging(f"node={node_name}, volume={volume_name}\n/dev/longhorn/{volume_name}:\n{res}")
+        from utility.utility import get_retry_count_and_interval
+        import time
 
+        retry_count, retry_interval = get_retry_count_and_interval()
+        cmd = f"ls -l /dev/longhorn/{volume_name}"
+        for i in range(retry_count):
+            logging(f"Checking volume endpoint /dev/longhorn/{volume_name} on node {node_name} ... ({i})")
+            res = self.execute_command_on_node_and_get_output_string(cmd, node_name)
+            if res.strip() and "No such file or directory" not in res:
+                logging(f"node={node_name}, volume={volume_name}\n/dev/longhorn/{volume_name}:\n{res}")
+                return
+            time.sleep(retry_interval)
+
+        assert False, \
+            f"Volume endpoint /dev/longhorn/{volume_name} is empty or doesn't exist on node {node_name}"

--- a/e2e/libs/keywords/host_keywords.py
+++ b/e2e/libs/keywords/host_keywords.py
@@ -145,3 +145,11 @@ class host_keywords:
     def ssh_exec_on_node(self, node_name, cmd):
         logging(f"SSH into node {node_name} and run command: {cmd}")
         return ssh_exec(node_name, cmd)
+
+    def check_volume_endpoint_on_node(self, volume_name, node_name):
+        cmd = f"ls -l /dev/longhorn/{volume_name}"
+        res = NodeExec(node_name).issue_cmd(cmd)
+        assert res.strip() and "No such file or directory" not in res, \
+            f"Volume endpoint /dev/longhorn/{volume_name} is empty or doesn't exist on node {node_name}"
+        logging(f"node={node_name}, volume={volume_name}\n/dev/longhorn/{volume_name}:\n{res}")
+

--- a/e2e/libs/keywords/host_keywords.py
+++ b/e2e/libs/keywords/host_keywords.py
@@ -145,20 +145,3 @@ class host_keywords:
     def ssh_exec_on_node(self, node_name, cmd):
         logging(f"SSH into node {node_name} and run command: {cmd}")
         return ssh_exec(node_name, cmd)
-
-    def check_volume_endpoint_on_node(self, volume_name, node_name):
-        from utility.utility import get_retry_count_and_interval
-        import time
-
-        retry_count, retry_interval = get_retry_count_and_interval()
-        cmd = f"ls -l /dev/longhorn/{volume_name}"
-        for i in range(retry_count):
-            logging(f"Checking volume endpoint /dev/longhorn/{volume_name} on node {node_name} ... ({i})")
-            res = self.execute_command_on_node_and_get_output_string(cmd, node_name)
-            if res.strip() and "No such file or directory" not in res:
-                logging(f"node={node_name}, volume={volume_name}\n/dev/longhorn/{volume_name}:\n{res}")
-                return
-            time.sleep(retry_interval)
-
-        assert False, \
-            f"Volume endpoint /dev/longhorn/{volume_name} is empty or doesn't exist on node {node_name}"

--- a/e2e/tests/prerelease_checks.robot
+++ b/e2e/tests/prerelease_checks.robot
@@ -25,6 +25,7 @@ Resource    ../keywords/system_backup.resource
 Resource    ../keywords/engine_image.resource
 Resource    ../keywords/longhorn.resource
 Resource    ../keywords/setting.resource
+Resource    ../keywords/host.resource
 
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
@@ -227,33 +228,40 @@ Pre-release Checks
     IF    '${test_v2_only}' == 'false'
 
         # (1-1) check the data integrity of the volume with revision counter enabled
+        And Check volume endpoint on node of volume vol-revision-enabled
         And Check volume vol-revision-enabled data is intact
         And Check volume vol-revision-enabled works
 
         # (2-1) check the data integrity of the volume with revision counter disabled
+        And Check volume endpoint on node of volume vol-revision-disabled
         And Check volume vol-revision-disabled data is intact
         And Check volume vol-revision-disabled works
 
         # (3-1) check pod didn't restart and the data integrity of the volume used by a pod
+        And Check volume endpoint on node of volume vol-pod
         And Check pod vol-pod did not restart
         And Check pod vol-pod data in file data.txt is intact
         And Check pod vol-pod works
 
         # (4-1) check statefulset pod didn't restart and the data integrity of the volume used by a statefulset
+        And Check volume endpoint on node of statefulset ss-upgrade
         And Check statefulset ss-upgrade pods did not restart
         And Check statefulset ss-upgrade data in file data.txt is intact
         And Check statefulset ss-upgrade works
 
         # (5-1) check the data integrity of the strict-local volume
+        And Check volume endpoint on node of volume vol-strict-local
         And Check volume vol-strict-local data is intact
         And Check volume vol-strict-local works
 
         # (6-1) check deployment pod didn't restart and the data integrity of the volume of the rwx workload
+        And Check volume endpoint on node of deployment deploy-upgrade
         And Check deployment deploy-upgrade pods did not restart
         And Check deployment deploy-upgrade data in file data.txt is intact
         And Check deployment deploy-upgrade works
 
         # (7-1) check pod didn't restart and the data integrity of the volume with a backing image
+        And Check volume endpoint on node of volume vol-bi
         And Check pod vol-pod-bi did not restart
         And Check file guests/catparrot.gif exists in pod vol-pod-bi
         And Check pod vol-pod-bi data in file data.txt is intact
@@ -272,33 +280,40 @@ Pre-release Checks
     IF    '${test_v2_only}' == 'false'
 
         # (1-2) check the data integrity of the volume with revision counter enabled
-        Then Check volume vol-revision-enabled data is intact
+        Then Check volume endpoint on node of volume vol-revision-enabled
+        And Check volume vol-revision-enabled data is intact
         And Check volume vol-revision-enabled works
     
         # (2-2) check the data integrity of the volume with revision counter disabled
+        And Check volume endpoint on node of volume vol-revision-disabled
         And Check volume vol-revision-disabled data is intact
         And Check volume vol-revision-disabled works
 
         # (3-2) check pod didn't restart and the data integrity of the volume used by a pod
+        And Check volume endpoint on node of volume vol-pod
         And And Check pod vol-pod did not restart
         And Check pod vol-pod data in file data.txt is intact
         And Check pod vol-pod works
 
        # (4-2) check statefulset pod didn't restart and the data integrity of the volume used by a statefulset
+        And Check volume endpoint on node of statefulset ss-upgrade
         And Check statefulset ss-upgrade pods did not restart
         And Check statefulset ss-upgrade data in file data.txt is intact
         And Check statefulset ss-upgrade works
 
         # (5-2) check the data integrity of the strict-local volume
+        And Check volume endpoint on node of volume vol-strict-local
         And Check volume vol-strict-local data is intact
         And Check volume vol-strict-local works
 
         # (6-2) check deployment pod didn't restart and the data integrity of the volume of the rwx workload
+        And Check volume endpoint on node of deployment deploy-upgrade
         And Check deployment deploy-upgrade pods did not restart
         And Check deployment deploy-upgrade data in file data.txt is intact
         And Check deployment deploy-upgrade works
 
         # (7-2) check pod didn't restart and the data integrity of the volume with a backing image
+        And Check volume endpoint on node of volume vol-bi
         And Check pod vol-pod-bi did not restart
         And Check file guests/catparrot.gif exists in pod vol-pod-bi
         And Check pod vol-pod-bi data in file data.txt is intact

--- a/e2e/tests/regression/test_encrypted_volume.robot
+++ b/e2e/tests/regression/test_encrypted_volume.robot
@@ -570,6 +570,11 @@ Test Encrypted Volume Upgrade
 
     # ==================== Upgrade Longhorn (Keep Old Engine) ====================
     When Setting concurrent-automatic-engine-upgrade-per-node-limit is set to 0
+
+    FOR    ${i}    IN RANGE    7
+        Check volume endpoint on node of deployment ${i}
+    END
+
     When Upgrade Longhorn to custom version
     And Wait for volume of deployment 0 healthy
     And Wait for volume of deployment 1 healthy
@@ -578,6 +583,10 @@ Test Encrypted Volume Upgrade
     And Wait for volume of deployment 4 healthy
     And Wait for volume of deployment 5 healthy
     And Wait for volume of deployment 6 healthy
+
+    FOR    ${i}    IN RANGE    7
+        Check volume endpoint on node of deployment ${i}
+    END
 
     # ==================== Post-Upgrade: Initial State Verification ====================
     # Verify old engine semantics are preserved after Longhorn system upgrade


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/13256

#### What this PR does / why we need it:
Add two new keywords to keywords/host.resource for logging /dev/longhorn/ device endpoints on nodes, useful for diagnosing volume state before/after Longhorn upgrades:
- "Check volume endpoint on node of ${resource_kind} ${resource_id}"
- "Check volume endpoint on node ${node_id}" Both keywords log a WARNING instead of failing when the path doesn't exist.

Integrate the new keywords into:
- tests/prerelease_checks.robot: import host.resource and call "Check volume endpoint on node of ..." before each post-system-upgrade and post-engine-upgrade data integrity check for all volumes/workloads.
- tests/regression/test_encrypted_volume.robot: call "Check volume endpoint on node of deployment ${i}" for deployments 0-6 before and after Longhorn upgrade in Test Encrypted Volume Upgrade.

#### Special notes for your reviewer:

#### Additional documentation or context
https://github.com/longhorn/longhorn/issues/13194