### PR TITLE
ci: move user-volumes-patch to initial machine config for Talos `1.12.x` support

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -89,7 +89,10 @@ ISCSI_DEV_PATH = "/dev/disk/by-path"
 ISCSI_PROCESS = "iscsid"
 
 if os.environ.get("CLOUDPROVIDER") == "aws":
-    if os.uname().machine == "x86_64":
+    if os.environ.get("DISTRO") == "talos":
+        # Talos: nvme2n1 for Longhorn user volume, nvme1n1 for v2 block tests
+        BLOCK_DEV_PATH = "/dev/nvme1n1"
+    elif os.uname().machine == "x86_64":
         BLOCK_DEV_PATH = "/dev/xvdh"
     else:
         # can not use BDF path before https://github.com/longhorn/longhorn/issues/13243 # NOQA

--- a/pipelines/utilities/run_longhorn_test.sh
+++ b/pipelines/utilities/run_longhorn_test.sh
@@ -52,6 +52,9 @@ run_longhorn_test(){
   ## inject cloudprovider
   yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "CLOUDPROVIDER", "value": "'${LONGHORN_TEST_CLOUDPROVIDER}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
 
+  ## inject distro
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "DISTRO", "value": "'${DISTRO}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
+
   ## for v2 volume test
   yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "RUN_V2_TEST", "value": "'${RUN_V2_TEST}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
   yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "DISABLE_V1_DATA_ENGINE", "value": "'${DISABLE_V1_DATA_ENGINE}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"

--- a/test_framework/terraform/aws/talos/main.tf
+++ b/test_framework/terraform/aws/talos/main.tf
@@ -237,7 +237,8 @@ data "talos_machine_configuration" "worker" {
   examples           = false
   kubernetes_version = "${var.k8s_distro_version}"
   config_patches = [
-    file("${path.module}/talos-patch-worker.yaml")
+    file("${path.module}/talos-patch-worker.yaml"),
+    file("${path.module}/user-volumes-patch.yaml")
   ]
 }
 
@@ -259,12 +260,43 @@ resource "talos_machine_configuration_apply" "worker" {
   node                        = aws_instance.lh_aws_instance_worker[count.index].private_ip
 }
 
-resource "talos_machine_bootstrap" "this" {
-  depends_on = [talos_machine_configuration_apply.controlplane]
+resource "null_resource" "bootstrap" {
+  depends_on = [
+    talos_machine_configuration_apply.controlplane,
+    local_file.talosconfig,
+  ]
 
-  client_configuration = talos_machine_secrets.machine_secrets.client_configuration
-  endpoint             = aws_instance.lh_aws_instance_controlplane[0].public_ip
-  node                 = aws_instance.lh_aws_instance_controlplane[0].private_ip
+  triggers = {
+    controlplane_id = aws_instance.lh_aws_instance_controlplane[0].id
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      for i in $(seq 1 30); do
+        output=$(talosctl --talosconfig ${abspath(path.module)}/talos_k8s_config \
+          bootstrap \
+          -n ${aws_instance.lh_aws_instance_controlplane[0].private_ip} \
+          -e ${aws_instance.lh_aws_instance_controlplane[0].public_ip} 2>&1)
+        rc=$?
+        if [ $rc -eq 0 ]; then
+          exit 0
+        fi
+        if echo "$output" | grep -q "AlreadyExists"; then
+          echo "Bootstrap already completed, continuing..."
+          exit 0
+        fi
+        if echo "$output" | grep -q "FailedPrecondition\|Unavailable\|connection refused"; then
+          echo "Node not ready yet, retrying ($i/30)..."
+          sleep 20
+          continue
+        fi
+        echo "Bootstrap failed: $output"
+        exit $rc
+      done
+      echo "Bootstrap timed out after 10 minutes"
+      exit 1
+    EOT
+  }
 }
 
 data "talos_client_configuration" "this" {
@@ -279,7 +311,7 @@ resource "local_file" "talosconfig" {
 }
 
 resource "talos_cluster_kubeconfig" "this" {
-  depends_on = [talos_machine_bootstrap.this]
+  depends_on = [null_resource.bootstrap]
 
   client_configuration = talos_machine_secrets.machine_secrets.client_configuration
   endpoint             = aws_instance.lh_aws_instance_controlplane.0.public_ip
@@ -334,40 +366,15 @@ locals {
   talos_version = "v${var.os_distro_version}"
 }
 
-# Patch Talos cluster worker nodes to mount /var/mnt/longhorn
-resource "null_resource" "patch_worker_nodes" {
-  depends_on = [null_resource.upload_schematic]
-  count = var.lh_aws_instance_count_worker
-
-  provisioner "local-exec" {
-    command = <<EOT
-talosctl --talosconfig ${abspath(path.module)}/talos_k8s_config \
-  -n ${aws_instance.lh_aws_instance_worker[count.index].private_ip} get disks
-talosctl --talosconfig ${abspath(path.module)}/talos_k8s_config \
-  --endpoints ${aws_instance.lh_aws_instance_controlplane[0].public_ip} \
-  -n ${aws_instance.lh_aws_instance_worker[count.index].private_ip} \
-  patch mc --patch @${path.module}/user-volumes-patch.yaml
-while true; do
-  if talosctl --talosconfig ${abspath(path.module)}/talos_k8s_config -n ${aws_instance.lh_aws_instance_worker[count.index].private_ip} get volumestatus u-longhorn &>/dev/null; then
-    echo "Volume u-longhorn is now available on ${aws_instance.lh_aws_instance_worker[count.index].private_ip}"
-    break
-  fi
-  sleep 1
-done
-while true; do
-  if talosctl --talosconfig ${abspath(path.module)}/talos_k8s_config -n ${aws_instance.lh_aws_instance_worker[count.index].private_ip} get mountstatus u-longhorn &>/dev/null; then
-    echo "Mount u-longhorn is now available on ${aws_instance.lh_aws_instance_worker[count.index].private_ip}"
-    break
-  fi
-  sleep 1
-done
-EOT
-  }
-}
+# User volume is now configured at initial deployment via config_patches in worker machine configuration
+# No need to patch after deployment
 
 # Upgrade Talos cluster worker nodes using schematic ID
 resource "null_resource" "upgrade_worker_nodes" {
-  depends_on = [null_resource.patch_worker_nodes]
+  depends_on = [
+    null_resource.upload_schematic,
+    talos_machine_configuration_apply.worker
+  ]
   count = var.lh_aws_instance_count_worker
 
   provisioner "local-exec" {

--- a/test_framework/terraform/aws/talos/variables.tf
+++ b/test_framework/terraform/aws/talos/variables.tf
@@ -31,7 +31,7 @@ variable "arch" {
 
 variable "os_distro_version" {
   type        = string
-  default     = "1.11.5"
+  default     = "1.13.4"
 }
 
 variable "aws_ami_talos_account_number" {
@@ -61,14 +61,14 @@ variable "lh_aws_instance_name_worker" {
 
 variable "lh_aws_instance_type_controlplane" {
   type        = string
-  description = "Recommended instance types t2.xlarge for amd64 & a1.xlarge  for arm64"
-  default     = "t2.xlarge"
+  description = "Recommended instance types t3.xlarge for amd64 & a1.xlarge  for arm64"
+  default     = "t3.xlarge"
 }
 
 variable "lh_aws_instance_type_worker" {
   type        = string
-  description = "Recommended instance types t2.xlarge for amd64 & a1.xlarge  for arm64"
-  default     = "t2.xlarge"
+  description = "Recommended instance types t3.xlarge for amd64 & a1.xlarge  for arm64"
+  default     = "t3.xlarge"
 }
 
 variable "block_device_size_controlplane" {
@@ -83,7 +83,7 @@ variable "block_device_size_worker" {
 
 variable "k8s_distro_version" {
   type        = string
-  default     = "v1.34.2"
+  default     = "v1.36.1"
 }
 
 variable "use_hdd" {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#12965

#### What this PR does / why we need it:
Apply `user-volumes-patch.yaml` at initial deployment via `config_patches` instead of `post-deployment` patching.
Also update default instance type to `t3.xlarge`.

#### Special notes for your reviewer:

According to the official Talos `v1.13` documentation for AWS deployment,
there is a known issue that prevents Talos from running on t2 instance types.
Therefore, t3.xlarge is used instead of t2 for all control plane and worker nodes.


#### Additional documentation or context
Reference: https://docs.siderolabs.com/talos/v1.13/platform-specific-installations/cloud-platforms/aws#create-the-ec2-instances