### PR TITLE
feat: create network policy for testing

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -40,6 +40,7 @@ ADD e2e /e2e
 WORKDIR /e2e
 
 ADD pipelines ./pipelines
+ADD manager/integration/deploy/network-policies ./manager/integration/deploy/network-policies
 
 RUN pip install -r requirements.txt
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -36,6 +36,12 @@ kubectl port-forward services/longhorn-frontend 8080:http -n longhorn-system
 export KUBECONFIG=/path/to/your/kubeconfig.yaml
 ```
 
+1. Apply the test NetworkPolicy so Robot test pods in the `default` namespace can access the `longhorn-manager` API before testing. The NetworkPolicy helper requires `yq`:
+```
+# from the longhorn-tests repository root
+./pipelines/utilities/create_network_policies.sh install_longhorn_manager_networkpolicy
+```
+
 1. Export environment variable `LONGHORN_CLIENT_URL`:
 ```
 # for example, if it's exposed by nodeport:

--- a/e2e/libs/longhorn_deploy/longhorn_deploy.py
+++ b/e2e/libs/longhorn_deploy/longhorn_deploy.py
@@ -8,6 +8,7 @@ from longhorn_deploy.longhorn_argocd import LonghornArgocd
 from utility.utility import logging
 import utility.utility
 import os
+import subprocess
 import time
 
 class LonghornDeploy(Base):
@@ -42,6 +43,17 @@ class LonghornDeploy(Base):
     def check_longhorn_crd_removed(self):
         return self.longhorn.check_longhorn_crd_removed()
 
+    def apply_longhorn_manager_networkpolicy(self):
+        logging(f"Applying Longhorn manager test NetworkPolicy")
+        command = "./pipelines/utilities/create_network_policies.sh"
+        process = subprocess.Popen([command, "install_longhorn_manager_networkpolicy"],
+                                   shell=False)
+        process.wait()
+        if process.returncode != 0:
+            logging(f"Applying Longhorn manager test NetworkPolicy failed")
+            time.sleep(self.retry_count)
+            assert False, "Applying Longhorn manager test NetworkPolicy failed"
+
     def install(self, custom_cmd, install_stable_version, longhorn_namespace):
         logging(f"Installing Longhorn {'stable' if install_stable_version else 'the latest'} version")
         utility.utility.set_longhorn_namespace(longhorn_namespace)
@@ -57,6 +69,7 @@ class LonghornDeploy(Base):
             logging(f"Installing Longhorn failed")
             time.sleep(self.retry_count)
             assert False, "Installing Longhorn failed"
+        self.apply_longhorn_manager_networkpolicy()
         self.longhorn.setup_longhorn_ui_nodeport()
         logging(f"Installed Longhorn")
 
@@ -74,6 +87,7 @@ class LonghornDeploy(Base):
                 time.sleep(self.retry_count)
             return False
         else:
+            self.apply_longhorn_manager_networkpolicy()
             # add some delay between 2 upgrades
             time.sleep(60)
         logging(f"Upgraded Longhorn")

--- a/manager/integration/README.md
+++ b/manager/integration/README.md
@@ -24,8 +24,9 @@ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn-tests/mast
                -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/cifs-backupstore.yaml \
                -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/azurite-backupstore.yaml
 ```
-2. Deploy the test script to the Kubernetes cluster.
+2. From the `manager` directory, apply the test NetworkPolicy, then deploy the test script to the Kubernetes cluster. The NetworkPolicy helper requires `yq`.
 ```
+../pipelines/utilities/create_network_policies.sh install_longhorn_manager_networkpolicy
 kubectl create -f integration/deploy/test.yaml
 ```
 

--- a/manager/integration/deploy/network-policies/longhorn-manager-networkpolicy.yaml
+++ b/manager/integration/deploy/network-policies/longhorn-manager-networkpolicy.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-longhorn-test-to-manager
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+      podSelector:
+        matchLabels:
+          longhorn-test: test-job
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-longhorn-test-to-instance-manager
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      longhorn.io/component: instance-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+      podSelector:
+        matchLabels:
+          longhorn-test: test-job

--- a/manager/integration/deploy/stress.yml
+++ b/manager/integration/deploy/stress.yml
@@ -41,6 +41,9 @@ spec:
   completions: 10
   backoffLimit: 0
   template:
+    metadata:
+      labels:
+        longhorn-test: test-job
     spec:
       containers:
       - name: longhorn-test-pod

--- a/pipelines/appco/scripts/longhorn_helm_chart.sh
+++ b/pipelines/appco/scripts/longhorn_helm_chart.sh
@@ -3,6 +3,7 @@
 set -x
 
 source pipelines/utilities/longhorn_status.sh
+source pipelines/utilities/create_network_policies.sh
 TAG_ARGS=()
 SECRET_ARGS=()
 LONGHORN_NAMESPACE="longhorn-system"
@@ -141,6 +142,7 @@ install_longhorn_custom(){
     "${TAG_ARGS[@]}" \
     "${SECRET_ARGS[@]}"
   wait_longhorn_status_running
+  install_longhorn_manager_networkpolicy
 }
 
 install_longhorn_version() {
@@ -157,6 +159,7 @@ install_longhorn_version() {
     "${SECRET_ARGS[@]}"
 
   wait_longhorn_status_running
+  install_longhorn_manager_networkpolicy
 }
 
 install_longhorn_stable(){

--- a/pipelines/utilities/argocd.sh
+++ b/pipelines/utilities/argocd.sh
@@ -3,6 +3,7 @@
 set -x
 
 source pipelines/utilities/longhorn_status.sh
+source pipelines/utilities/create_network_policies.sh
 
 install_argocd(){
   kubectl create namespace argocd
@@ -101,6 +102,7 @@ update_argocd_app_target_revision(){
 sync_argocd_app(){
   argocd app sync longhorn
   wait_longhorn_status_running
+  install_longhorn_manager_networkpolicy
   kubectl config set-context --current --namespace=default
   kubectl config get-contexts
   kubectl config view

--- a/pipelines/utilities/create_network_policies.sh
+++ b/pipelines/utilities/create_network_policies.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -x
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+source "${SCRIPT_DIR}/longhorn_namespace.sh"
+
+install_longhorn_manager_networkpolicy(){
+  get_longhorn_namespace
+
+  if ! command -v yq > /dev/null 2>&1; then
+    echo "yq is required to install Longhorn test NetworkPolicies"
+    exit 1
+  fi
+
+  local policy_path="${SCRIPT_DIR}/../../manager/integration/deploy/network-policies/longhorn-manager-networkpolicy.yaml"
+  if [[ ! -f "${policy_path}" ]]; then
+    policy_path="${SCRIPT_DIR}/../../../manager/integration/deploy/network-policies/longhorn-manager-networkpolicy.yaml"
+  fi
+
+  if [[ ! -f "${policy_path}" ]]; then
+    echo "Longhorn manager test NetworkPolicy manifest not found"
+    exit 1
+  fi
+
+  LONGHORN_NAMESPACE="${LONGHORN_NAMESPACE}" yq e '.metadata.namespace = strenv(LONGHORN_NAMESPACE)' "${policy_path}" | kubectl apply -f -
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if declare -f "$1" > /dev/null; then
+    "$@"
+  else
+    echo "Function '$1' not found"
+    exit 1
+  fi
+fi

--- a/pipelines/utilities/fleet.sh
+++ b/pipelines/utilities/fleet.sh
@@ -3,6 +3,7 @@
 set -x
 
 source pipelines/utilities/longhorn_status.sh
+source pipelines/utilities/create_network_policies.sh
 
 install_fleet(){
   helm repo add fleet https://rancher.github.io/fleet-helm-charts/
@@ -31,6 +32,7 @@ EOF
   wait_for_bundle_deployment_applied
   wait_for_bundle_deployment_ready
   wait_longhorn_status_running
+  install_longhorn_manager_networkpolicy
 }
 
 wait_for_bundle_deployment_applied(){

--- a/pipelines/utilities/flux.sh
+++ b/pipelines/utilities/flux.sh
@@ -3,6 +3,7 @@
 set -x
 
 source pipelines/utilities/longhorn_status.sh
+source pipelines/utilities/create_network_policies.sh
 
 init_flux(){
   flux install
@@ -23,6 +24,7 @@ privateRegistry:
 EOF
   flux create helmrelease longhorn --chart longhorn --source HelmRepository/longhorn --chart-version "${HELM_CHART_VERSION}" --namespace "${LONGHORN_NAMESPACE}" --values "/tmp/values.yaml"
   wait_longhorn_status_running
+  install_longhorn_manager_networkpolicy
 }
 
 install_longhorn_stable(){

--- a/pipelines/utilities/longhorn_helm_chart.sh
+++ b/pipelines/utilities/longhorn_helm_chart.sh
@@ -4,6 +4,7 @@ set -x
 
 source pipelines/utilities/longhorn_status.sh
 source pipelines/utilities/longhorn_namespace.sh
+source pipelines/utilities/create_network_policies.sh
 
 get_longhorn_chart(){
   CHART_VERSION="${1:-$LONGHORN_REPO_BRANCH}"
@@ -80,6 +81,7 @@ install_longhorn(){
   get_longhorn_namespace
   helm upgrade --install longhorn "${LONGHORN_REPO_DIR}/chart/" --namespace "${LONGHORN_NAMESPACE}"
   wait_longhorn_status_running
+  install_longhorn_manager_networkpolicy
 }
 
 install_longhorn_stable(){

--- a/pipelines/utilities/longhorn_manifest.sh
+++ b/pipelines/utilities/longhorn_manifest.sh
@@ -4,6 +4,7 @@ set -x
 
 source pipelines/utilities/longhorn_status.sh
 source pipelines/utilities/longhorn_namespace.sh
+source pipelines/utilities/create_network_policies.sh
 
 get_longhorn_repo(){
   CHART_VERSION="${1:-$LONGHORN_REPO_BRANCH}"
@@ -102,6 +103,7 @@ install_longhorn(){
   sed -i "s/longhorn-system/${LONGHORN_NAMESPACE}/g" "${LONGHORN_MANIFEST_PATH}"
   kubectl apply -f "${LONGHORN_MANIFEST_PATH}"
   wait_longhorn_status_running
+  install_longhorn_manager_networkpolicy
 }
 
 install_longhorn_stable(){

--- a/pipelines/utilities/longhorn_rancher_chart.sh
+++ b/pipelines/utilities/longhorn_rancher_chart.sh
@@ -3,6 +3,7 @@
 set -x
 
 source pipelines/utilities/longhorn_status.sh
+source pipelines/utilities/create_network_policies.sh
 
 install_rancher() {
 
@@ -62,6 +63,7 @@ install_longhorn() {
             -var="registry_secret=docker-registry-secret" \
             -auto-approve -no-color
   wait_longhorn_status_running
+  install_longhorn_manager_networkpolicy
 }
 
 install_longhorn_stable() {
@@ -91,6 +93,7 @@ upgrade_longhorn() {
             -var="registry_secret=docker-registry-secret" \
             -auto-approve -no-color
   wait_longhorn_status_running
+  install_longhorn_manager_networkpolicy
 }
 
 upgrade_longhorn_transient() {


### PR DESCRIPTION
longhorn-13325

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13325 https://github.com/longhorn/longhorn/issues/13521

#### What this PR does / why we need it:

When Longhorn setup the NetworkPolicy, the test cases need a way to control the cluster. This PR creates a NetworkPolicy for testing purpose. This NetworkPolicy allows testing pod in default namespace to access the Longhorn backend API.

#### Special notes for your reviewer:

#### Additional documentation or context
