### PR TITLE
ci: skip devel_basis installation in sles setup

### DIFF
--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -11,7 +11,6 @@ if ! SUSEConnect --status 2>/dev/null | grep -q "Registered"; then
   sudo registercloudguest --force-new || true
 fi
 sudo zypper --gpg-auto-import-keys ref
-sudo zypper install -y -t pattern devel_basis
 sudo zypper install -y open-iscsi nfs-client cryptsetup device-mapper samba
 
 sudo mkdir -p /etc/certs

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_server.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_k3s_server.sh.tpl
@@ -11,7 +11,6 @@ if ! SUSEConnect --status 2>/dev/null | grep -q "Registered"; then
   sudo registercloudguest --force-new || true
 fi
 sudo zypper --gpg-auto-import-keys ref
-sudo zypper install -y -t pattern devel_basis
 sudo zypper install -y open-iscsi nfs-client jq
 
 sudo mkdir -p /etc/certs

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_agent.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_agent.sh.tpl
@@ -11,7 +11,6 @@ if ! SUSEConnect --status 2>/dev/null | grep -q "Registered"; then
   sudo registercloudguest --force-new || true
 fi
 sudo zypper --gpg-auto-import-keys ref
-sudo zypper install -y -t pattern devel_basis
 sudo zypper install -y open-iscsi nfs-client cryptsetup device-mapper samba iptables
 
 sudo mkdir -p /etc/certs

--- a/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_server.sh.tpl
+++ b/test_framework/terraform/aws/sles/user-data-scripts/provision_rke2_server.sh.tpl
@@ -11,7 +11,6 @@ if ! SUSEConnect --status 2>/dev/null | grep -q "Registered"; then
   sudo registercloudguest --force-new || true
 fi
 sudo zypper --gpg-auto-import-keys ref
-sudo zypper install -y -t pattern devel_basis 
 sudo zypper install -y open-iscsi nfs-client jq iptables
 
 sudo mkdir -p /etc/certs


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

skip devel_basis installation in sles setup

```
Problem: 1: the to be installed pattern:devel_basis-20170319-160000.2.2.x86_64 requires 'patterns-devel-base-devel_basis', 
but this requirement cannot be provided
not installable providers: patterns-devel-base-devel_basis-20170319-160000.2.2.x86_64[SUSE_Linux_Enterprise_Server_x86_64:SLE-Product-SLES-16.0]
```

#### Special notes for your reviewer:

#### Additional documentation or context
