### PR TITLE
test(robot): skip 30s sleep unless a block disk is deleted

### DIFF
--- a/e2e/libs/node/node.py
+++ b/e2e/libs/node/node.py
@@ -150,6 +150,7 @@ class Node:
                 logging(f"Enabling scheduling disk {disk_name} on node {node_name}")
         self.update_disks(node_name, node.disks)
 
+        block_disk_deleted = False
         disks = {}
         for disk_name, disk in iter(node.disks.items()):
             # do not delete block-disk if v2 data engine enabled
@@ -158,6 +159,8 @@ class Node:
                 disk.allowScheduling = True
                 logging(f"Keeping disk {disk_name} on node {node_name}")
             else:
+                if disk.diskType == "block":
+                    block_disk_deleted = True
                 logging(f"Removing disk {disk_name} from node {node_name}")
         self.update_disks(node_name, disks)
 
@@ -165,7 +168,8 @@ class Node:
         # disk deletion takes some time, wait the device show up on the host
         # normally less than 30 seconds
         # ref: https://github.com/longhorn/longhorn/issues/11860
-        time.sleep(30)
+        if block_disk_deleted:
+            time.sleep(30)
 
     def set_node_disks_tags(self, node_name, tags):
         node = get_longhorn_client().by_id_node(node_name)

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3836,7 +3836,6 @@ def reset_disks_for_all_nodes(client, add_block_disks=False):  # NOQA
             }
             default_disks["v1"]["default"] = False
 
-    block_disk_deleted = False
     nodes = client.list_node()
     for n in nodes:
         node = n  # Captures the correct value of n in the closure.
@@ -3865,10 +3864,6 @@ def reset_disks_for_all_nodes(client, add_block_disks=False):  # NOQA
                     break
 
         if cleanup_required:
-            for _, disk in iter(node.disks.items()):
-                if disk.diskType == "block":
-                    block_disk_deleted = True
-                    break
             update_disks = get_update_disks(node.disks)
             for disk_name, disk in iter(update_disks.items()):
                 disk.allowScheduling = False
@@ -3925,13 +3920,6 @@ def reset_disks_for_all_nodes(client, add_block_disks=False):  # NOQA
             wait_for_disk_status(client, node.name, name,
                                  "storageReserved",
                                  expected_reserved_storage)
-
-    # for block type disks added by bdf (nvme disk driver)
-    # disk deletion takes some time, wait the device show up on the host
-    # normally less than 30 seconds
-    # ref: https://github.com/longhorn/longhorn/issues/11860
-    if block_disk_deleted:
-        time.sleep(30)
 
 
 def reset_settings(client):

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3836,6 +3836,7 @@ def reset_disks_for_all_nodes(client, add_block_disks=False):  # NOQA
             }
             default_disks["v1"]["default"] = False
 
+    block_disk_deleted = False
     nodes = client.list_node()
     for n in nodes:
         node = n  # Captures the correct value of n in the closure.
@@ -3864,6 +3865,10 @@ def reset_disks_for_all_nodes(client, add_block_disks=False):  # NOQA
                     break
 
         if cleanup_required:
+            for _, disk in iter(node.disks.items()):
+                if disk.diskType == "block":
+                    block_disk_deleted = True
+                    break
             update_disks = get_update_disks(node.disks)
             for disk_name, disk in iter(update_disks.items()):
                 disk.allowScheduling = False
@@ -3925,7 +3930,8 @@ def reset_disks_for_all_nodes(client, add_block_disks=False):  # NOQA
     # disk deletion takes some time, wait the device show up on the host
     # normally less than 30 seconds
     # ref: https://github.com/longhorn/longhorn/issues/11860
-    time.sleep(30)
+    if block_disk_deleted and BLOCK_DEV_PATH.startswith("/dev/nvme"):
+        time.sleep(30)
 
 
 def reset_settings(client):

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3930,7 +3930,7 @@ def reset_disks_for_all_nodes(client, add_block_disks=False):  # NOQA
     # disk deletion takes some time, wait the device show up on the host
     # normally less than 30 seconds
     # ref: https://github.com/longhorn/longhorn/issues/11860
-    if block_disk_deleted and BLOCK_DEV_PATH.startswith("/dev/nvme"):
+    if block_disk_deleted:
         time.sleep(30)
 
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
longhorn/longhorn#12999

#### What this PR does / why we need it:

The 30s sleep in `reset_disks_for_all_nodes` was added to handle delays
in block device detection after removing disks (longhorn/longhorn#11860).

Previously, the sleep ran unconditionally on every call, even when no
block disks were removed, causing unnecessary slowdowns in test execution.

This PR optimizes the behavior so that the sleep only triggers when a
block disk was actually deleted.

Changes:
- manager/integration/tests/common.py:  remove sleep 30s  due to https://github.com/longhorn/longhorn/issues/12999#issuecomment-4860550740

- e2e/libs/node/node.py: track block disk deletion and sleep only when a block disk is deleted

longhorn/longhorn#12999


#### Special notes for your reviewer:

#### Additional documentation or context
