### PR TITLE
test(robot): Add case V2 Replica Migration Should Not Cause IO Stall

### DIFF
--- a/e2e/keywords/io.resource
+++ b/e2e/keywords/io.resource
@@ -3,6 +3,7 @@ Library             ../libs/keywords/io_keywords.py
 Library             ../libs/keywords/instancemanager_keywords.py
 Library             ../libs/keywords/common_keywords.py
 Library             ../libs/keywords/node_keywords.py
+Library             ../libs/keywords/workload_keywords.py
 
 *** Keywords ***
 Create dm linear device from block device ${block_disk_path} as ${dm_device_name} on node ${node_id}
@@ -44,3 +45,12 @@ Wipe block device ${block_device_path} on node ${node_id}
     [Documentation]    Wipe filesystem and partition signatures from a block device.
     ${node_name} =    get_node_by_index    ${node_id}
     wipe_block_device_signatures    ${block_device_path}    ${node_name}
+
+Start fsync writer on ${workload_kind} ${workload_id}
+    [Documentation]    Start a background fsync writer that tracks max per-write latency in memory.
+    ${workload_name} =    generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${pod_name} =    get_workload_pod_name    ${workload_name}
+    start_fsync_writer    ${pod_name}
+
+Assert no IO stall greater than ${threshold_sec} seconds
+    assert_no_io_stall    ${threshold_sec}

--- a/e2e/libs/keywords/io_keywords.py
+++ b/e2e/libs/keywords/io_keywords.py
@@ -1,12 +1,70 @@
-from utility.utility import logging
+from utility.utility import logging, get_retry_count_and_interval
 from node_exec import NodeExec
 
+import subprocess
+import threading
 import time
 
 class io_keywords:
 
     def __init__(self):
-        pass
+        self._fsync_writer_process = None
+        self._fsync_writer_thread = None
+        self._max_elapsed = 0.0
+        self._max_elapsed_lock = threading.Lock()
+
+    def start_fsync_writer(self, pod_name, namespace="default"):
+        logging(f"Starting fsync writer on pod {pod_name}")
+
+        cmd = [
+            "kubectl", "exec", pod_name, "-n", namespace, "--",
+            "sh", "-c",
+            "mkdir -p /data && while true; do"
+            " dd if=/dev/zero of=/data/io_scratch bs=64k count=1 conv=fsync 2>&1"
+            r" | awk -F'copied, ' '/copied/ {print $2+0}';"
+            " done",
+        ]
+
+        self._max_elapsed = 0.0
+        self._fsync_writer_process = subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
+
+        def _reader():
+            for line in self._fsync_writer_process.stdout:
+                try:
+                    elapsed = float(line.strip().split()[0])
+                    logging(f"fsync latency: {elapsed}s")
+                    with self._max_elapsed_lock:
+                        if elapsed > self._max_elapsed:
+                            self._max_elapsed = elapsed
+                except (ValueError, IndexError):
+                    pass
+
+        self._fsync_writer_thread = threading.Thread(target=_reader, daemon=True)
+        self._fsync_writer_thread.start()
+        time.sleep(1)
+
+    def get_max_fsync_latency(self):
+        if self._fsync_writer_process is not None:
+            self._fsync_writer_process.terminate()
+            try:
+                self._fsync_writer_process.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                self._fsync_writer_process.kill()
+                self._fsync_writer_process.wait()
+            self._fsync_writer_thread.join(timeout=5.0)
+            self._fsync_writer_process = None
+        with self._max_elapsed_lock:
+            return self._max_elapsed
+
+    def assert_no_io_stall(self, threshold_sec=3.0):
+        max_latency = self.get_max_fsync_latency()
+        logging(f"Maximum fsync latency: {max_latency}s (threshold: {threshold_sec}s)")
+        if max_latency >= float(threshold_sec):
+            retry_count, retry_interval = get_retry_count_and_interval()
+            for i in range(retry_count):
+                logging(f"IO stall detected, keeping env for debugging ({i+1}/{retry_count}) ...")
+                time.sleep(int(retry_interval))
+            assert False, f"IO stall detected: max latency {max_latency}s >= {threshold_sec}s threshold"
 
     def setup_dm_linear_device_from_block_disk(self, block_disk_path, dm_device_name, node_name):
         """

--- a/e2e/tests/regression/test_v2.robot
+++ b/e2e/tests/regression/test_v2.robot
@@ -20,6 +20,7 @@ Resource    ../keywords/k8s.resource
 Resource    ../keywords/orphan.resource
 Resource    ../keywords/replica.resource
 Resource    ../keywords/engine_frontend.resource
+Resource    ../keywords/io.resource
 
 Test Setup    Set up v2 test environment
 Test Teardown    Cleanup test resources
@@ -396,3 +397,31 @@ Test V2 Instance Manager Pod Recreate Loop When Engine Frontend Recovery Blocks 
     And Wait for volume test-vol healthy
     And Write data to volume test-vol
     Then Check volume test-vol data is intact
+
+V2 Replica Migration Should Not Cause IO Stall
+    [Documentation]    issue: https://github.com/longhorn/longhorn/issues/13309
+    ...    Test steps:
+    ...    1. Create v2 SC with dataLocality: best-effort, numberOfReplicas: 2
+    ...    2. Create deployment using the volume, running an fsync writer logging per-write timing
+    ...    3. Cordon volume attached node
+    ...    4. Delete replica on volume attached node
+    ...    5. Wait for volume healthy
+    ...    6. Check no IO stall observed (max latency < 3 sec)
+    IF    '${DATA_ENGINE}' == 'v1'
+        Skip    Test only validate on v2 data engine
+    END
+
+    Given Create storageclass longhorn-test with
+    ...    dataEngine=v2
+    ...    dataLocality=best-effort
+    ...    numberOfReplicas=2
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-test
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Wait for volume of deployment 0 healthy
+
+    When Start fsync writer on deployment 0
+    And Cordon deployment 0 volume node
+    Then Delete replica of deployment 0 volume on volume node
+    And Wait for volume of deployment 0 attached and degraded
+    And Wait for volume of deployment 0 healthy
+    And Assert no IO stall greater than 3 seconds


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13311

#### What this PR does / why we need it:

Add case `V2 Replica Migration Should Not Cause IO Stall`

#### Special notes for your reviewer:

Test result

- master: [passed](https://ci.longhorn.io/job/private/job/longhorn-e2e-test/8338/)
- v1.12.0: [failed](https://ci.longhorn.io/job/private/job/longhorn-e2e-test/8339/), confirms this test case covered issue [13309](https://github.com/longhorn/longhorn/issues/13309) 

<img width="599" height="156" alt="image" src="https://github.com/user-attachments/assets/38c045b9-87c2-48b2-a1ff-6dba921a1c12" />

#### Additional documentation or context
