### PR TITLE
test: remove deprecated v2 backing image test from test_upgrade

### DIFF
--- a/manager/integration/tests/test_upgrade.py
+++ b/manager/integration/tests/test_upgrade.py
@@ -401,13 +401,6 @@ def test_upgrade(client, core_api, volume_name, csi_pv, # NOQA
 
     # v2 data engine CRs
     if v2_data_engine_crs_before_upgrade:
-        v2_backing_image_name = BACKING_IMAGE_NAME + "-v2"
-        create_backing_image_with_matching_url(
-            client,
-            v2_backing_image_name,
-            BACKING_IMAGE_QCOW2_URL,
-            dataEngine="v2")
-
         vol_detached_v2_name = "vol-detached-v2"
         vol_detached_v2 = create_and_check_volume(client, vol_detached_v2_name,
                                                   data_engine="v2")


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

remove deprecated v2 backing image test from test_upgrade

#### Special notes for your reviewer:

#### Additional documentation or context
