### PR TITLE
ci: prevent unexpected NetworkPolicy apply on HAL

### DIFF
--- a/pipelines/utilities/kubectl_retry.sh
+++ b/pipelines/utilities/kubectl_retry.sh
@@ -29,6 +29,8 @@ kubectl() {
     fi
     sleep $delay
   done
+
+  return $exit_code
 }
 EOF
 


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13443

#### What this PR does / why we need it:

Add a return code to `apply_kubectl_retry` so that `longhorn_internal_networkpolicies_exist` can work correctly in the HAL environment.

#### Special notes for your reviewer:

#### Additional documentation or context
