### PR TITLE
ci: workaround for terraform provisioning timeout on hal

### DIFF
--- a/pipelines/e2e/Jenkinsfile
+++ b/pipelines/e2e/Jenkinsfile
@@ -123,7 +123,7 @@ node {
                 """
             }
 
-            timeout(60) {
+            timeout(300) {
                 stage ('terraform') {
                     sh "docker exec ${JOB_BASE_NAME}-${BUILD_NUMBER} pipelines/utilities/terraform_setup.sh"
                 }

--- a/pipelines/utilities/cleanup.sh
+++ b/pipelines/utilities/cleanup.sh
@@ -12,8 +12,14 @@ fi
 sleep 30
 
 if [[ ${LONGHORN_TEST_CLOUDPROVIDER} == "harvester" ]]; then
-  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -target=rancher2_cluster_v2.e2e-cluster -auto-approve -no-color
-  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -auto-approve -no-color
+  while ! terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -target=rancher2_cluster_v2.e2e-cluster -auto-approve -no-color; do
+    echo "Terraform destroy failed, retrying in 10 seconds..."
+    sleep 10
+  done
+  while ! terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -auto-approve -no-color; do
+    echo "Terraform destroy failed, retrying in 10 seconds..."
+    sleep 10
+  done
 else
   terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} destroy -auto-approve -no-color
 fi

--- a/pipelines/utilities/kubectl_retry.sh
+++ b/pipelines/utilities/kubectl_retry.sh
@@ -18,9 +18,8 @@ kubectl() {
   while true; do
     output=$(/usr/local/bin/kubectl "$@" 2>&1)
     exit_code=$?
-    echo "$output"
     count=$((count + 1))
-    if grep -qiE "connection refused|apiserver not ready|unauthorized|error looking up secret|has prevented the request from succeeding" <<< "$output"; then
+    if grep -qiE "timeout|context cancellation|request canceled|connection lost|connection refused|apiserver not ready|unauthorized|error looking up secret|has prevented the request from succeeding" <<< "$output"; then
       echo "Attempt $count failed with exit code $exit_code. Retrying in $delay seconds..." >&2
     elif [[ $count -ge $max_retries ]]; then
       break

--- a/pipelines/utilities/terraform_setup.sh
+++ b/pipelines/utilities/terraform_setup.sh
@@ -2,15 +2,18 @@
 
 set -x
 
-if [[ ${TF_VAR_arch} == "amd64" ]]; then
+# terraform encountered a self-signed untrusted certificate when attempting to connect to the HAL API
+# underlying HTTP request became stuck during SSL/TLS certificate validation, eventually leading to a timeout.
+# we need to temporarily trust or ignore the HAL self-signed certificate
+if [[ ${LONGHORN_TEST_CLOUDPROVIDER} == "harvester" ]]; then
+  openssl s_client -showcerts -connect rancher.10.115.253.200.sslip.io:443 </dev/null 2>/dev/null | openssl x509 -outform PEM > /tmp/rancher.crt
+  cp /tmp/rancher.crt /usr/local/share/ca-certificates/rancher.crt
+  update-ca-certificates
   terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} init
-  terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} apply -auto-approve -no-color
-  if [[ ${TF_VAR_k8s_distro_name} == "rke" ]]; then
-    terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} apply -auto-approve -no-color -refresh-only
-    terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} output -raw rke_config > test_framework/rke.yml
-    sleep 30
-    rke up --config test_framework/rke.yml
-  fi
+  while ! terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} apply -auto-approve; do
+    echo "Terraform failed, retrying in 10 seconds..."
+    sleep 10
+  done
 else
   terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} init
   terraform -chdir=test_framework/terraform/${LONGHORN_TEST_CLOUDPROVIDER}/${DISTRO} apply -auto-approve -no-color

--- a/test_framework/terraform/harvester/oracle/main.tf
+++ b/test_framework/terraform/harvester/oracle/main.tf
@@ -12,6 +12,7 @@ provider "rancher2" {
   insecure  = true
   access_key = var.lab_access_key
   secret_key = var.lab_secret_key
+  timeout    = "600s"
 }
 
 resource "random_string" "random_suffix" {

--- a/test_framework/terraform/harvester/rockylinux/main.tf
+++ b/test_framework/terraform/harvester/rockylinux/main.tf
@@ -12,6 +12,7 @@ provider "rancher2" {
   insecure  = true
   access_key = var.lab_access_key
   secret_key = var.lab_secret_key
+  timeout    = "600s"
 }
 
 resource "random_string" "random_suffix" {

--- a/test_framework/terraform/harvester/sle-micro/main.tf
+++ b/test_framework/terraform/harvester/sle-micro/main.tf
@@ -12,6 +12,7 @@ provider "rancher2" {
   insecure  = true
   access_key = var.lab_access_key
   secret_key = var.lab_secret_key
+  timeout    = "600s"
 }
 
 resource "random_string" "random_suffix" {

--- a/test_framework/terraform/harvester/sles/main.tf
+++ b/test_framework/terraform/harvester/sles/main.tf
@@ -12,6 +12,7 @@ provider "rancher2" {
   insecure  = true
   access_key = var.lab_access_key
   secret_key = var.lab_secret_key
+  timeout    = "600s"
 }
 
 resource "random_string" "random_suffix" {

--- a/test_framework/terraform/harvester/ubuntu/main.tf
+++ b/test_framework/terraform/harvester/ubuntu/main.tf
@@ -12,6 +12,7 @@ provider "rancher2" {
   insecure  = true
   access_key = var.lab_access_key
   secret_key = var.lab_secret_key
+  timeout    = "600s"
 }
 
 resource "random_string" "random_suffix" {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

workaround for terraform provisioning timeout on hal

```
Error: Getting cluster V2 ID (fleet-default/e2e-cluster-krgj8iy0): Getting cluster V2: Get "****/v1/provisioning.cattle.io.clusters/fleet-default/e2e-cluster-krgj8iy0": context deadline exceeded (Client.Timeout exceeded while awaiting headers)

  with rancher2_cluster_v2.e2e-cluster,
  on main.tf line 165, in resource "rancher2_cluster_v2" "e2e-cluster":
 165: resource "rancher2_cluster_v2" "e2e-cluster" {
```

#### Special notes for your reviewer:

#### Additional documentation or context
