### PR TITLE
ci: fix registry.suse.de access in mirror_csi_images and secscan pipelines

### DIFF
--- a/mirror_csi_images/scripts/publish.sh
+++ b/mirror_csi_images/scripts/publish.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+apk add dnsmasq
+mkdir -p /etc/dnsmasq.d
+cat >/etc/dnsmasq.d/suse.conf <<EOF
+server=/suse.de/10.113.53.53
+server=8.8.8.8
+EOF
+cat >/etc/resolv.conf <<EOF
+nameserver 127.0.0.1
+EOF
+dnsmasq
+ps aux | grep dnsmasq
+nslookup google.com
+nslookup registry.suse.de
+
 INFILE="${PWD}/infile"
 touch "${INFILE}"
 

--- a/secscan/scripts/secscan.sh
+++ b/secscan/scripts/secscan.sh
@@ -2,6 +2,20 @@
 
 set -x
 
+apk add dnsmasq
+mkdir -p /etc/dnsmasq.d
+cat >/etc/dnsmasq.d/suse.conf <<EOF
+server=/suse.de/10.113.53.53
+server=8.8.8.8
+EOF
+cat >/etc/resolv.conf <<EOF
+nameserver 127.0.0.1
+EOF
+dnsmasq
+ps aux | grep dnsmasq
+nslookup google.com
+nslookup registry.suse.de
+
 mkdir -p /junit-reports /templates
 
 if [[ "${LONGHORN_VERSION}" =~ "oci://dp.apps.rancher.io/charts/suse-storage" ]]; then


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix registry.suse.de access in mirror_csi_images and secscan pipelines

#### Special notes for your reviewer:

#### Additional documentation or context
