### PR TITLE
fix(infra): support calico cni ip-in-ip mode

### DIFF
--- a/test_framework/terraform/aws/oracle/instances.tf
+++ b/test_framework/terraform/aws/oracle/instances.tf
@@ -12,6 +12,7 @@ resource "aws_instance" "lh_aws_instance_controlplane" {
   instance_type = var.lh_aws_instance_type_controlplane
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id
   ]
@@ -48,6 +49,7 @@ resource "aws_instance" "lh_aws_instance_worker" {
   instance_type = var.lh_aws_instance_type_worker
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   associate_public_ip_address = true
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id

--- a/test_framework/terraform/aws/oracle/main.tf
+++ b/test_framework/terraform/aws/oracle/main.tf
@@ -108,6 +108,17 @@ resource "aws_security_group" "lh_aws_secgrp" {
     protocol    = "udp"
     cidr_blocks = ["10.0.0.0/8"]
   }
+  dynamic "ingress" {
+    for_each = var.cni == "calico" ? [1] : []
+
+    content {
+      description = "Allow Calico IP-in-IP between cluster nodes"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "4"
+      cidr_blocks = [aws_vpc.lh_aws_vpc.cidr_block]
+    }
+  }
 
   egress {
     from_port   = 0

--- a/test_framework/terraform/aws/rhel/instances.tf
+++ b/test_framework/terraform/aws/rhel/instances.tf
@@ -12,6 +12,7 @@ resource "aws_instance" "lh_aws_instance_controlplane" {
   instance_type = var.lh_aws_instance_type_controlplane
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id
   ]
@@ -48,6 +49,7 @@ resource "aws_instance" "lh_aws_instance_worker" {
   instance_type = var.lh_aws_instance_type_worker
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   associate_public_ip_address = true
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id

--- a/test_framework/terraform/aws/rhel/main.tf
+++ b/test_framework/terraform/aws/rhel/main.tf
@@ -108,6 +108,17 @@ resource "aws_security_group" "lh_aws_secgrp" {
     protocol    = "udp"
     cidr_blocks = ["10.0.0.0/8"]
   }
+  dynamic "ingress" {
+    for_each = var.cni == "calico" ? [1] : []
+
+    content {
+      description = "Allow Calico IP-in-IP between cluster nodes"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "4"
+      cidr_blocks = [aws_vpc.lh_aws_vpc.cidr_block]
+    }
+  }
 
   egress {
     from_port   = 0

--- a/test_framework/terraform/aws/rockylinux/instances.tf
+++ b/test_framework/terraform/aws/rockylinux/instances.tf
@@ -12,6 +12,7 @@ resource "aws_instance" "lh_aws_instance_controlplane" {
   instance_type = var.lh_aws_instance_type_controlplane
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id
   ]
@@ -48,6 +49,7 @@ resource "aws_instance" "lh_aws_instance_worker" {
   instance_type = var.lh_aws_instance_type_worker
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   associate_public_ip_address = true
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id

--- a/test_framework/terraform/aws/rockylinux/main.tf
+++ b/test_framework/terraform/aws/rockylinux/main.tf
@@ -110,6 +110,18 @@ resource "aws_security_group" "lh_aws_secgrp" {
     cidr_blocks = ["10.0.0.0/8"]
   }
 
+  dynamic "ingress" {
+    for_each = var.cni == "calico" ? [1] : []
+
+    content {
+      description = "Allow Calico IP-in-IP between cluster nodes"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "4"
+      cidr_blocks = [aws_vpc.lh_aws_vpc.cidr_block]
+    }
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/test_framework/terraform/aws/sle-micro/instances.tf
+++ b/test_framework/terraform/aws/sle-micro/instances.tf
@@ -12,6 +12,7 @@ resource "aws_instance" "lh_aws_instance_controlplane" {
   instance_type = var.lh_aws_instance_type_controlplane
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp_public.id
   ]
@@ -47,6 +48,7 @@ resource "aws_instance" "lh_aws_instance_worker" {
   associate_public_ip_address = true
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp_public.id
   ]

--- a/test_framework/terraform/aws/sle-micro/main.tf
+++ b/test_framework/terraform/aws/sle-micro/main.tf
@@ -109,6 +109,18 @@ resource "aws_security_group" "lh_aws_secgrp_public" {
     cidr_blocks = ["10.0.0.0/8"]
   }
 
+  dynamic "ingress" {
+    for_each = var.cni == "calico" ? [1] : []
+
+    content {
+      description = "Allow Calico IP-in-IP between cluster nodes"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "4"
+      cidr_blocks = [aws_vpc.lh_aws_vpc.cidr_block]
+    }
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/test_framework/terraform/aws/sles/instances.tf
+++ b/test_framework/terraform/aws/sles/instances.tf
@@ -12,6 +12,7 @@ resource "aws_instance" "lh_aws_instance_controlplane" {
   instance_type = var.lh_aws_instance_type_controlplane
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id
   ]
@@ -49,6 +50,7 @@ resource "aws_instance" "lh_aws_instance_worker" {
   instance_type = var.lh_aws_instance_type_worker
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id
   ]

--- a/test_framework/terraform/aws/sles/main.tf
+++ b/test_framework/terraform/aws/sles/main.tf
@@ -216,6 +216,18 @@ resource "aws_security_group" "lh_aws_secgrp" {
     ipv6_cidr_blocks = [aws_vpc.lh_aws_vpc.ipv6_cidr_block]
   }
 
+  dynamic "ingress" {
+    for_each = var.cni == "calico" ? [1] : []
+
+    content {
+      description = "Allow Calico IP-in-IP between cluster nodes"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "4"
+      cidr_blocks = [aws_vpc.lh_aws_vpc.cidr_block]
+    }
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/test_framework/terraform/aws/ubuntu/instances.tf
+++ b/test_framework/terraform/aws/ubuntu/instances.tf
@@ -12,6 +12,7 @@ resource "aws_instance" "lh_aws_instance_controlplane" {
   instance_type = var.lh_aws_instance_type_controlplane
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id
   ]
@@ -48,6 +49,7 @@ resource "aws_instance" "lh_aws_instance_worker" {
   instance_type = var.lh_aws_instance_type_worker
 
   subnet_id = aws_subnet.lh_aws_public_subnet.id
+  source_dest_check = var.cni == "default"
   associate_public_ip_address = true
   vpc_security_group_ids = [
     aws_security_group.lh_aws_secgrp.id

--- a/test_framework/terraform/aws/ubuntu/main.tf
+++ b/test_framework/terraform/aws/ubuntu/main.tf
@@ -110,6 +110,18 @@ resource "aws_security_group" "lh_aws_secgrp" {
     cidr_blocks = ["10.0.0.0/8"]
   }
 
+  dynamic "ingress" {
+    for_each = var.cni == "calico" ? [1] : []
+
+    content {
+      description = "Allow Calico IP-in-IP between cluster nodes"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "4"
+      cidr_blocks = [aws_vpc.lh_aws_vpc.cidr_block]
+    }
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13438 https://github.com/longhorn/longhorn/issues/13521

#### What this PR does / why we need it:

The Calico CNI plugin works in IP-in-IP mode, i.e. the IP packet is packed into another IP packet and forward to other nodes. However, AWS EC2 checks the source & destination, and drops such packets due to security concern. This PR allows such traffic for such CNI setup.

#### Special notes for your reviewer:

#### Additional documentation or context
