### PR TITLE
ci: fix insufficient t2.xlarge capacity in the availability zone error in longhorn-storage-network-test pipeline

### DIFF
--- a/pipelines/storage_network/terraform/main.tf
+++ b/pipelines/storage_network/terraform/main.tf
@@ -72,7 +72,7 @@ resource "aws_route_table" "aws_public_rt" {
 
 resource "aws_subnet" "aws_subnet_1" {
   vpc_id                          = aws_vpc.aws_vpc.id
-  availability_zone               = "us-east-1c"
+  availability_zone               = "us-east-1b"
   cidr_block                      = "10.0.1.0/24"
   ipv6_cidr_block                 = cidrsubnet(aws_vpc.aws_vpc.ipv6_cidr_block, 8, 0)
   assign_ipv6_address_on_creation = true
@@ -85,7 +85,7 @@ resource "aws_subnet" "aws_subnet_1" {
 
 resource "aws_subnet" "aws_subnet_2" {
   vpc_id                          = aws_vpc.aws_vpc.id
-  availability_zone               = "us-east-1c"
+  availability_zone               = "us-east-1b"
   cidr_block                      = "10.0.2.0/24"
   ipv6_cidr_block                 = cidrsubnet(aws_vpc.aws_vpc.ipv6_cidr_block, 8, 1)
   assign_ipv6_address_on_creation = true
@@ -211,7 +211,7 @@ resource "aws_ebs_volume" "lh_aws_ssd_volume" {
 
   count = var.aws_instance_count
 
-  availability_zone = "us-east-1c"
+  availability_zone = "us-east-1b"
   size              = var.block_device_size_worker
   type              = "gp2"
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix insufficient t2.xlarge capacity in the availability zone error in longhorn-storage-network-test pipeline

the complete error is:

https://ci.longhorn.io/job/private/job/longhorn-storage-network-test/279/

```
Error: Error launching source instance: InsufficientInstanceCapacity: We currently do not have sufficient t2.xlarge capacity in the 
Availability Zone you requested (us-east-1c). Our system will be working on provisioning additional capacity. You can currently get 
t2.xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-1a, us-east-1b, us-east-1d, us-
east-1e, us-east-1f.
```

#### Special notes for your reviewer:

#### Additional documentation or context
