### PR TITLE
test(robot): refactor instance manager disk size assertion to support  v1/v2 raw size check

### DIFF
--- a/e2e/keywords/longhorn.resource
+++ b/e2e/keywords/longhorn.resource
@@ -181,23 +181,34 @@ Check longhorn manager pods not restarted after test start
 Check longhorn backing image manager image is ${expected_image}
     check_backing_image_manager_images    ${expected_image}
 
-Assert disk size in instance manager pod for ${resource_kind} ${resource_id} is ${size}
-    ${expected_size_byte} =    convert_size_to_bytes    ${size}    to_str=True
+Assert disk size in instance manager for ${resource_kind} ${resource_id}
+    [Documentation]    Single keyword for volume disk size checks.
+    ...                Required: expected_disk_size in all engines.
+    ...                raw_size is optional; if set, RAW device size is checked.
+    ...                For v1, raw_size must not be set.
+    [Arguments]    ${expected_disk_size}    ${raw_size}=${EMPTY}
+    Run Keyword If    '${expected_disk_size}' == '${EMPTY}'
+    ...    Fail    expected_disk_size is required
+    Run Keyword If    '${DATA_ENGINE}' == 'v1' and '${raw_size}' != '${EMPTY}'
+    ...    Fail    raw_size must not be set when DATA_ENGINE is v1
+
+    ${expected_disk_size_byte} =    convert_size_to_bytes    ${expected_disk_size}    to_str=True
     ${resource_name}=    generate_name_with_suffix    ${resource_kind}    ${resource_id}
     ${volume_name}=    Run Keyword If    '${resource_kind}' == 'volume'
     ...        Set Variable    ${resource_name}
     ...    ELSE
     ...        get_workload_volume_name    ${resource_name}
     ${instance_manager_name} =    get_engine_instance_manager_name    ${volume_name}
-    Wait Until Keyword Succeeds    ${RETRY_COUNT}    ${RETRY_INTERVAL}
-    ...    Check disk size in instance manager pod    ${instance_manager_name}    ${volume_name}    ${expected_size_byte}
+    ${encrypted_device_name} =    Set Variable If    "${DATA_ENGINE}" == "v2"    ${volume_name}-encrypted    ${volume_name}
+    wait_for_disk_size_in_instance_manager_pod    ${instance_manager_name}    ${encrypted_device_name}    ${expected_disk_size_byte}
 
-Check disk size in instance manager pod
-    [Arguments]    ${instance_manager_name}    ${volume_name}    ${expected_size}
-    ${cmd} =    Set Variable    fdisk -l /dev/mapper/${volume_name}
-    ${longhorn_namespace} =    get_longhorn_namespace
-    ${result}=    pod_exec    ${instance_manager_name}    ${longhorn_namespace}    ${cmd}
-    Should Contain    ${result}    ${expected_size}
+    Run Keyword If    '${DATA_ENGINE}' == 'v2' and '${raw_size}' != '${EMPTY}'
+    ...    Assert v2 raw disk size in instance manager    ${instance_manager_name}    ${volume_name}    ${raw_size}
+
+Assert v2 raw disk size in instance manager
+    [Arguments]    ${instance_manager_name}    ${volume_name}    ${raw_size}
+    ${raw_size_byte} =    convert_size_to_bytes    ${raw_size}    to_str=True
+    wait_for_disk_size_in_instance_manager_pod    ${instance_manager_name}    ${volume_name}    ${raw_size_byte}
 
 Patch Longhorn Manager Resources With
     [Arguments]    ${cpu_request}    ${memory_request}    ${cpu_limit}    ${memory_limit}

--- a/e2e/libs/keywords/instancemanager_keywords.py
+++ b/e2e/libs/keywords/instancemanager_keywords.py
@@ -1,13 +1,19 @@
+import time
+
 from instancemanager import V1_InstanceManager
 from instancemanager import V2_InstanceManager
 
 from utility.utility import logging
+from utility.utility import get_retry_count_and_interval
+from utility.utility import pod_exec
+import utility.constant as constant
 
 class instancemanager_keywords:
 
     def __init__(self):
         self.instancemanager = V1_InstanceManager()
         self.v2_instancemanager = V2_InstanceManager()
+        self.retry_count, self.retry_interval = get_retry_count_and_interval()
 
     def wait_for_all_instance_manager_running(self):
         logging(f'Waiting for all instance manager running')
@@ -57,3 +63,19 @@ class instancemanager_keywords:
     def verify_replica_lvol_exists_in_spdk_lvol(self, node_name, replica_name):
         logging(f"Verifying replica {replica_name} exists in SPDK on node {node_name}")
         self.instancemanager.verify_replica_lvol_exists_in_spdk_lvol(node_name, replica_name)
+
+    def wait_for_disk_size_in_instance_manager_pod(self, instance_manager_name, device_name, expected_size):
+        for i in range(self.retry_count):
+            logging(f"Waiting for disk size in instance manager pod {instance_manager_name} to be {expected_size} ... ({i})")
+            time.sleep(self.retry_interval)
+            cmd = f"fdisk -l /dev/mapper/{device_name}"
+            try:
+                result = pod_exec(instance_manager_name, constant.LONGHORN_NAMESPACE, cmd)
+                logging(f"Current disk info in instance manager pod {instance_manager_name}: {result}")
+                if expected_size in result:
+                    return
+            except Exception as e:
+                logging(f"Error checking disk size in instance manager pod {instance_manager_name}: {e}")
+                continue
+
+        assert False, f"Disk size in instance manager pod {instance_manager_name} does not contain {expected_size}"

--- a/e2e/tests/regression/test_encrypted_volume.robot
+++ b/e2e/tests/regression/test_encrypted_volume.robot
@@ -50,7 +50,7 @@ Test Encrypted Volume Basic
         Assert replica file size of deployment 1 is 116Mi
     END
     # Verify sizes at different layers: backend replica → dm-crypt device → mounted filesystem
-    And Assert disk size in instance manager pod for deployment 0 is 100Mi
+    And Assert disk size in instance manager for deployment 0    expected_disk_size=100Mi
     And Assert encrypted disk size in sharemanager pod for deployment 1 is 100Mi
     And Write 10 MB data to file data.txt in deployment 0
     And Write 10 MB data to file data.txt in deployment 1
@@ -70,7 +70,7 @@ Test Encrypted Volume Basic
         Assert replica file size of deployment 1 is 116Mi
     END
     # Re-verify sizes after scale down/up cycle
-    And Assert disk size in instance manager pod for deployment 0 is 100Mi
+    And Assert disk size in instance manager for deployment 0    expected_disk_size=100Mi
     And Assert encrypted disk size in sharemanager pod for deployment 1 is 100Mi
     Then Check deployment 0 data in file data.txt is intact
     And Check deployment 1 data in file data.txt is intact
@@ -114,7 +114,7 @@ Test Encrypted Volume Cloning
         Assert replica file size of deployment cloned-rwo-deployment is 116Mi
         Assert replica file size of deployment cloned-rwx-deployment is 116Mi
     END
-    And Assert disk size in instance manager pod for deployment cloned-rwo-deployment is 100Mi
+    And Assert disk size in instance manager for deployment cloned-rwo-deployment    expected_disk_size=100Mi
     And Assert encrypted disk size in sharemanager pod for deployment cloned-rwx-deployment is 100Mi
     And Check deployment cloned-rwo-deployment file data.txt checksum matches checksum source-rwo-pvc
     And Check deployment cloned-rwx-deployment file data.txt checksum matches checksum source-rwx-pvc
@@ -151,7 +151,7 @@ Test Encrypted Volume Snapshot Clone
     And Record file data.txt checksum in deployment 0 as checksum 0
 
     # Verify source volume size
-    Assert disk size in instance manager pod for deployment 0 is 100Mi
+    And Assert disk size in instance manager for deployment 0    expected_disk_size=100Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 0 is 116Mi
     END
@@ -171,7 +171,7 @@ Test Encrypted Volume Snapshot Clone
 
     # Verify cloned volume size and data integrity
     Then Check deployment 1 file data.txt checksum matches checksum 0
-    And Assert disk size in instance manager pod for deployment 1 is 100Mi
+    And Assert disk size in instance manager for deployment 1    expected_disk_size=100Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 1 is 116Mi
     END
@@ -209,7 +209,7 @@ Test Encrypted Volume Expansion
     And Check deployment 0 pods did not restart
     And Check deployment 1 pods did not restart
     And Check no sharemanager pod of deployment 1 recreation
-    And Assert disk size in instance manager pod for deployment 0 is 200Mi
+    And Assert disk size in instance manager for deployment 0    expected_disk_size=200Mi
     And Assert encrypted disk size in sharemanager pod for deployment 1 is 200Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 0 is 216Mi
@@ -238,7 +238,7 @@ Test Encrypted RWO Block Volume Online Expansion
     # in the replica backend file (replica size = requested size + 16 Mi).
     # The dm-crypt device therefore presents the full requested size to the workload.
     # Therefore, after expansion to 200 Mi, the dm-crypt device shows 200 Mi.
-    And Assert disk size in instance manager pod for deployment 0 is 200Mi
+    And Assert disk size in instance manager for deployment 0    expected_disk_size=200Mi
     And Assert block device size in deployment pod for deployment 0 is 200Mi
     When Scale down deployment 0 to detach volume
     And Scale up deployment 0 to attach volume
@@ -280,7 +280,7 @@ Test Encrypted Volume Replica Rebuild
     When Delete replica of deployment 0 volume on replica node
     And Wait until volume of deployment 0 replica rebuilding completed on replica node
     Then Wait for volume of deployment 0 healthy
-    And Assert disk size in instance manager pod for deployment 0 is 100Mi
+    And Assert disk size in instance manager for deployment 0    expected_disk_size=100Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 0 is 116Mi
     END
@@ -343,8 +343,8 @@ Test Encrypted Volume Backup Restore To Encrypted Volume
 
     And Wait for volume of deployment 2 healthy
     And Wait for volume of deployment 3 healthy
-    Then Assert disk size in instance manager pod for deployment 2 is 100Mi
-    And Assert disk size in instance manager pod for deployment 3 is 100Mi
+    Then Assert disk size in instance manager for deployment 2    expected_disk_size=100Mi
+    And Assert disk size in instance manager for deployment 3    expected_disk_size=100Mi
     # v1 only: v2 replica backend uses a different format (no .img files)
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 2 is 116Mi
@@ -527,7 +527,7 @@ Test Encrypted Volume Upgrade
     # ==================== Pre-Upgrade: Initial State Verification ====================
     # All deployments should show old-engine semantics: device = requested_size - 16 Mi
     # Deployment 0 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
-    Then Assert disk size in instance manager pod for deployment 0 is 84Mi
+    Then Assert disk size in instance manager for deployment 0    expected_disk_size=84Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 0 is 100Mi
     END
@@ -545,7 +545,7 @@ Test Encrypted Volume Upgrade
     END
 
     # Deployment 3 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
-    And Assert disk size in instance manager pod for deployment 3 is 84Mi
+    And Assert disk size in instance manager for deployment 3    expected_disk_size=84Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 3 is 100Mi
     END
@@ -557,7 +557,7 @@ Test Encrypted Volume Upgrade
     END
 
     # Deployment 5 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
-    And Assert disk size in instance manager pod for deployment 5 is 84Mi
+    And Assert disk size in instance manager for deployment 5    expected_disk_size=84Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 5 is 100Mi
     END
@@ -591,7 +591,7 @@ Test Encrypted Volume Upgrade
     # ==================== Post-Upgrade: Initial State Verification ====================
     # Verify old engine semantics are preserved after Longhorn system upgrade
     # Deployment 0 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
-    Then Assert disk size in instance manager pod for deployment 0 is 84Mi
+    Then Assert disk size in instance manager for deployment 0    expected_disk_size=84Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 0 is 100Mi
     END
@@ -609,7 +609,7 @@ Test Encrypted Volume Upgrade
     END
 
     # Deployment 3 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
-    And Assert disk size in instance manager pod for deployment 3 is 84Mi
+    And Assert disk size in instance manager for deployment 3    expected_disk_size=84Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 3 is 100Mi
     END
@@ -621,7 +621,7 @@ Test Encrypted Volume Upgrade
     END
 
     # Deployment 5 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
-    And Assert disk size in instance manager pod for deployment 5 is 84Mi
+    And Assert disk size in instance manager for deployment 5    expected_disk_size=84Mi
     IF    '${DATA_ENGINE}' == 'v1'
         Assert replica file size of deployment 5 is 100Mi
     END
@@ -660,7 +660,7 @@ Test Encrypted Volume Upgrade
     And Check deployment 4 pods did not restart
 
     # After expansion: device = 184 Mi, replica = 20 Mi (old engine)
-    And Assert disk size in instance manager pod for deployment 3 is 184Mi
+    And Assert disk size in instance manager for deployment 3    expected_disk_size=184Mi
     And Check no sharemanager pod of deployment 4 recreation
     And Assert encrypted disk size in sharemanager pod for deployment 4 is 184Mi
     IF    '${DATA_ENGINE}' == 'v1'
@@ -695,9 +695,11 @@ Test Encrypted Volume Upgrade
     Then Wait for volume of deployment 5 healthy
     And Wait for workloads pods stable    deployment 5
     # Deployment 5 (RWO Filesystem): device = 84 Mi, replica = 100 Mi
-    And Assert disk size in instance manager pod for deployment 5 is 84Mi
     IF    '${DATA_ENGINE}' == 'v1'
+        And Assert disk size in instance manager for deployment 5    expected_disk_size=84Mi
         Assert replica file size of deployment 5 is 100Mi
+    ELSE
+        And Assert disk size in instance manager for deployment 5    expected_disk_size=84Mi    raw_size=100Mi
     END
     And Check deployment 5 data in file data.txt is intact
 
@@ -731,7 +733,7 @@ Test Encrypted Volume Upgrade
         When Delete replica of deployment 0 volume on replica node
         Then Wait until volume of deployment 0 replica rebuilding completed on replica node
         And Wait for volume of deployment 0 healthy
-        Then Assert disk size in instance manager pod for deployment 0 is 100Mi
+        Then Assert disk size in instance manager for deployment 0    expected_disk_size=100Mi
         And Assert replica file size of deployment 0 is 116Mi
         And Check deployment 0 data in file data.txt is intact
 
@@ -751,7 +753,7 @@ Test Encrypted Volume Upgrade
 
         # Deployment 3 (RWO Filesystem, 200 Mi after expansion):
         # device = 200 Mi, replica = 200 Mi + 16 Mi = 216 Mi
-        Then Assert disk size in instance manager pod for deployment 3 is 200Mi
+        Then Assert disk size in instance manager for deployment 3    expected_disk_size=200Mi
         And Assert replica file size of deployment 3 is 216Mi
         And Check deployment 3 data in file data.txt is intact
 
@@ -768,7 +770,7 @@ Test Encrypted Volume Upgrade
         And Wait for workloads pods stable    deployment 5
         # Deployment 5 (RWO Filesystem, 100 Mi):
         # device = 100 Mi, replica = 100 Mi + 16 Mi = 116 Mi
-        Then Assert disk size in instance manager pod for deployment 5 is 100Mi
+        Then Assert disk size in instance manager for deployment 5    expected_disk_size=100Mi
         And Assert replica file size of deployment 5 is 116Mi
         And Check deployment 5 data in file data.txt is intact
 
@@ -794,7 +796,7 @@ Test Encrypted Volume Upgrade
     And Create deployment 7 with volume 7    sc_name=longhorn-crypto-stable    node_stage_secret_name=longhorn-crypto    node_publish_secret_name=longhorn-crypto
 
     And Wait for volume of deployment 7 healthy
-    Then Assert disk size in instance manager pod for deployment 7 is 100Mi
+    Then Assert disk size in instance manager for deployment 7    expected_disk_size=100Mi
     And Assert replica file size of deployment 7 is 116Mi
     And Check deployment 7 file data.txt checksum matches checksum 0
 
@@ -804,7 +806,7 @@ Test Encrypted Volume Upgrade
     And Create deployment 8 with volume 8    sc_name=longhorn-crypto-stable    node_stage_secret_name=longhorn-crypto    node_publish_secret_name=longhorn-crypto
 
     And Wait for volume of deployment 8 healthy
-    Then Assert disk size in instance manager pod for deployment 8 is 100Mi
+    Then Assert disk size in instance manager for deployment 8    expected_disk_size=100Mi
     And Assert replica file size of deployment 8 is 116Mi
     And Check deployment 8 file data.txt checksum matches checksum 1
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/13163

#### What this PR does / why we need it:
- Add `wait_for_disk_size_in_instance_manager_pod` retry method in instancemanager_keywords.py
- Rework `Assert disk size in instance manager pod for ... is` keyword into `Assert disk size in instance manager for ${resource_kind} ${resource_id}` with named args `expected_disk_size` and optional `raw_size`
- Add `Assert v2 raw disk size in instance manager` keyword to verify v2 RAW device size independently of the encrypted device size
- Handle encrypted device naming difference for v2 (`${volume_name}-encrypted`)
- Update case in `test_encrypted_volume.robot` to use new keyword

#### Special notes for your reviewer:

#### Additional documentation or context
