### PR TITLE
test: fix flaky test case test_engine_live_upgrade_while_replica_concurrent_rebuild by extending timeout

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -177,8 +177,6 @@ NODE_CONDITION_SCHEDULABLE = "Schedulable"
 DISK_CONDITION_SCHEDULABLE = "Schedulable"
 DISK_CONDITION_READY = "Ready"
 
-STREAM_EXEC_TIMEOUT = 60
-
 EXCEPTION_ERROR_REASON_NOT_FOUND = "Not Found"
 
 SETTING_AUTO_SALVAGE = "auto-salvage"
@@ -365,7 +363,6 @@ if disktype == "hdd":
     DEFAULT_POD_TIMEOUT *= 32
     DEFAULT_DEPLOYMENT_TIMEOUT *= 32
     DEFAULT_STATEFULSET_TIMEOUT *= 32
-    STREAM_EXEC_TIMEOUT *= 32
 
 
 def load_k8s_config():
@@ -826,7 +823,7 @@ def read_volume_data(api, pod_name, filename='test'):
         '-c',
         'cat /data/' + filename
     ]
-    with timeout(seconds=STREAM_EXEC_TIMEOUT,
+    with timeout(seconds=RETRY_COUNTS_LONG,
                  error_message='Timeout on executing stream read'):
         return stream(
             api.connect_get_namespaced_pod_exec, pod_name, 'default',
@@ -848,7 +845,7 @@ def write_pod_volume_data(api, pod_name, test_data, filename='test'):
         '-c',
         'echo -ne ' + test_data + ' > /data/' + filename
     ]
-    with timeout(seconds=STREAM_EXEC_TIMEOUT,
+    with timeout(seconds=RETRY_COUNTS_LONG,
                  error_message='Timeout on executing stream write'):
         return stream(
             api.connect_get_namespaced_pod_exec, pod_name, 'default',
@@ -869,7 +866,7 @@ def write_pod_block_volume_data(api, pod_name, test_data, offset, device_path):
         'dd if=' + tmp_file + ' of=' + device_path +
         ' bs=' + str(len(test_data)) + ' count=1 seek=' + str(offset)
     ]
-    with timeout(seconds=STREAM_EXEC_TIMEOUT,
+    with timeout(seconds=RETRY_COUNTS_LONG,
                  error_message='Timeout on executing stream write'):
         stream(api.connect_get_namespaced_pod_exec, pod_name, 'default',
                command=pre_write_cmd, stderr=True, stdin=False, stdout=True,
@@ -887,7 +884,7 @@ def read_pod_block_volume_data(api, pod_name, data_size, offset, device_path):
         'dd if=' + device_path +
         ' status=none bs=' + str(data_size) + ' count=1 skip=' + str(offset)
     ]
-    with timeout(seconds=STREAM_EXEC_TIMEOUT,
+    with timeout(seconds=RETRY_COUNTS_LONG,
                  error_message='Timeout on executing stream read'):
         return stream(
             api.connect_get_namespaced_pod_exec, pod_name, 'default',
@@ -911,7 +908,7 @@ def exec_command_in_pod(api, command, pod_name, namespace, container=None):
         '-c',
         command
     ]
-    with timeout(seconds=STREAM_EXEC_TIMEOUT,
+    with timeout(seconds=RETRY_COUNTS_LONG,
                  error_message='Timeout on executing stream read/write'):
         return stream(
             api.connect_get_namespaced_pod_exec, pod_name, namespace,
@@ -923,7 +920,7 @@ def get_pod_data_md5sum(api, pod_name, path):
     md5sum_command = [
         '/bin/sh', '-c', 'md5sum ' + path + " | awk '{print $1}'"
     ]
-    with timeout(seconds=STREAM_EXEC_TIMEOUT * 3,
+    with timeout(seconds=RETRY_COUNTS_LONG,
                  error_message='Timeout on executing stream md5sum'):
         return stream(
             api.connect_get_namespaced_pod_exec, pod_name, 'default',
@@ -959,27 +956,27 @@ def copy_pod_volume_data(api, pod_name, src_path, dest_path):
 
 def copy_file_to_volume_dev_mb_data(src_path, dest_path,
                                     src_offset, dest_offset, size_in_mb,
-                                    timeout_cnt=5):
+                                    stream_exec_timeout=RETRY_COUNTS_LONG):
     cmd = [
         '/bin/sh',
         '-c',
         'dd if=%s of=%s bs=1M count=%d skip=%d seek=%d' %
         (src_path, dest_path, size_in_mb, src_offset, dest_offset)
     ]
-    with timeout(seconds=STREAM_EXEC_TIMEOUT * timeout_cnt,
+    with timeout(seconds=stream_exec_timeout,
                  error_message='Timeout on copying file to dev'):
         subprocess.check_call(cmd)
 
 
 def write_volume_dev_random_mb_data(path, offset_in_mb, length_in_mb,
-                                    timeout_cnt=3):
+                                    stream_exec_timeout=RETRY_COUNTS_LONG):
     write_cmd = [
         '/bin/sh',
         '-c',
         'dd if=/dev/urandom of=%s bs=1M seek=%d count=%d' %
         (path, offset_in_mb, length_in_mb)
     ]
-    with timeout(seconds=STREAM_EXEC_TIMEOUT * timeout_cnt,
+    with timeout(seconds=stream_exec_timeout,
                  error_message='Timeout on writing dev'):
         subprocess.check_call(write_cmd)
 
@@ -991,7 +988,7 @@ def get_volume_dev_mb_data_md5sum(path, offset_in_mb, length_in_mb):
         (path, offset_in_mb, length_in_mb)
     ]
 
-    with timeout(seconds=STREAM_EXEC_TIMEOUT * 5,
+    with timeout(seconds=RETRY_COUNTS_LONG,
                  error_message='Timeout on computing dev md5sum'):
         output = subprocess.check_output(
             md5sum_command).strip().decode('utf-8')
@@ -2609,7 +2606,7 @@ def crash_replica_processes(client, api, volname, replicas=None,
 def exec_instance_manager(api, im_name, cmd):
     exec_cmd = ['/bin/sh', '-c', cmd]
 
-    with timeout(seconds=STREAM_EXEC_TIMEOUT,
+    with timeout(seconds=RETRY_COUNTS_LONG,
                  error_message='Timeout on executing stream read'):
         output = stream(api.connect_get_namespaced_pod_exec,
                         im_name,
@@ -5693,7 +5690,7 @@ def crash_engine_process_with_sigkill(client, core_api, volume_name):
                 '/bin/sh', '-c',
                 "kill `pgrep -f \"controller " + volume_name + "\"`"]
 
-        with timeout(seconds=STREAM_EXEC_TIMEOUT,
+        with timeout(seconds=RETRY_COUNTS_LONG,
                      error_message='Timeout on executing stream read'):
             stream(core_api.connect_get_namespaced_pod_exec,
                    ins_mgr_name,
@@ -5714,7 +5711,7 @@ def remount_volume_read_only(client, core_api, volume_name):
             f"mount -o remount,ro /host/var/lib/kubelet/plugins/kubernetes.io/csi/driver.longhorn.io/{volume_name_hash}/globalmount"    # NOQA
     ]
 
-    with timeout(seconds=STREAM_EXEC_TIMEOUT,
+    with timeout(seconds=RETRY_COUNTS_LONG,
                  error_message='Timeout on executing stream read'):
         stream(core_api.connect_get_namespaced_pod_exec,
                instance_manager_name, LONGHORN_NAMESPACE, command=command,

--- a/manager/integration/tests/test_basic.py
+++ b/manager/integration/tests/test_basic.py
@@ -5400,7 +5400,7 @@ def test_space_usage_for_rebuilding_only_volume(client, volume_name, request):  
     snap_offset = 1
     volume_endpoint = get_volume_endpoint(volume)
     write_volume_dev_random_mb_data(volume_endpoint,
-                                    snap_offset, 3000, 10)
+                                    snap_offset, 3000)
 
     snap2 = create_snapshot(client, volume_name)
     volume.snapshotCRDelete(name=snap2.name)
@@ -5412,7 +5412,7 @@ def test_space_usage_for_rebuilding_only_volume(client, volume_name, request):  
         wait_for_snapshot_purge(client, volume_name, snap2.name)
 
     write_volume_dev_random_mb_data(volume_endpoint,
-                                    snap_offset, 3000, 10)
+                                    snap_offset, 3000)
 
     for r in volume.replicas:
         if r.hostId != lht_hostId:
@@ -5468,7 +5468,7 @@ def test_space_usage_for_rebuilding_only_volume_worst_scenario(client, volume_na
     snap_offset = 1
     volume_endpoint = get_volume_endpoint(volume)
     write_volume_dev_random_mb_data(volume_endpoint,
-                                    snap_offset, 2000, 10)
+                                    snap_offset, 2000)
     snap1 = create_snapshot(client, volume_name)
     volume.snapshotCRDelete(name=snap1.name)
     volume.snapshotPurge()
@@ -5479,7 +5479,7 @@ def test_space_usage_for_rebuilding_only_volume_worst_scenario(client, volume_na
         wait_for_snapshot_purge(client, volume_name, snap1.name)
 
     write_volume_dev_random_mb_data(volume_endpoint,
-                                    snap_offset, 2000, 10)
+                                    snap_offset, 2000)
 
     for r in volume.replicas:
         if r.hostId != lht_hostId:
@@ -5489,7 +5489,7 @@ def test_space_usage_for_rebuilding_only_volume_worst_scenario(client, volume_na
     wait_for_volume_degraded(client, volume_name)
     wait_for_rebuild_start(client, volume_name)
     write_volume_dev_random_mb_data(volume_endpoint,
-                                    snap_offset, 2000, 10)
+                                    snap_offset, 2000)
 
     wait_for_rebuild_complete(client, volume_name)
     volume = client.by_id_volume(volume_name)

--- a/manager/integration/tests/test_settings.py
+++ b/manager/integration/tests/test_settings.py
@@ -820,9 +820,9 @@ def test_setting_concurrent_rebuild_limit(client, core_api, volume_name):  # NOQ
     volume1_endpoint = get_volume_endpoint(volume1)
     volume2_endpoint = get_volume_endpoint(volume2)
     write_volume_dev_random_mb_data(volume1_endpoint,
-                                    1, 3500, 5)
+                                    1, 3500)
     write_volume_dev_random_mb_data(volume2_endpoint,
-                                    1, 3500, 5)
+                                    1, 3500)
 
     # Step 1-4, 1-5
     delete_replica_on_test_node(client, volume1_name)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix flaky test case test_engine_live_upgrade_while_replica_concurrent_rebuild by extending timeout

https://ci.longhorn.io/job/private/job/longhorn-tests-regression/11354/testReport/junit/tests/test_engine_upgrade/test_engine_live_upgrade_while_replica_concurrent_rebuild/

```
>       write_volume_dev_random_mb_data(volume1_endpoint,
                                        1, 3500)

test_engine_upgrade.py:1099: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
common.py:981: in write_volume_dev_random_mb_data
    subprocess.check_call(write_cmd)
/usr/lib64/python3.13/subprocess.py:414: in check_call
    retcode = call(*popenargs, **kwargs)
/usr/lib64/python3.13/subprocess.py:397: in call
    return p.wait(timeout=timeout)
/usr/lib64/python3.13/subprocess.py:1280: in wait
    return self._wait(timeout=timeout)
/usr/lib64/python3.13/subprocess.py:2085: in _wait
    (pid, sts) = self._try_wait(0)
/usr/lib64/python3.13/subprocess.py:2043: in _try_wait
    (pid, sts) = os.waitpid(self.pid, wait_flags)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <common.timeout object at 0x7f951925e630>, signum = 14
frame = <frame at 0x7f95198966c0, file '/usr/lib64/python3.13/subprocess.py', line 2044, code _try_wait>

    def handle_timeout(self, signum, frame):
>       raise Exception(self.error_message)
E       Exception: Timeout on writing dev
```

#### Special notes for your reviewer:

#### Additional documentation or context
