### PR TITLE
test: fix flaky test case test_support_bundle_should_not_timeout by extending timeout

### DIFF
--- a/manager/integration/tests/test_support_bundle.py
+++ b/manager/integration/tests/test_support_bundle.py
@@ -362,7 +362,7 @@ def test_support_bundle_should_not_timeout(client, core_api):  # NOQA
         rm -f {bundle} &&\
         stat -c \"%s\" /tmp/support-bundle-kit/$bundle",
     ]
-    with timeout(seconds=600, error_message='Timeout on executing command'):
+    with timeout(seconds=3000, error_message='Timeout on executing command'):
         zip_size = stream(core_api.connect_get_namespaced_pod_exec,
                           pod_name, LONGHORN_NAMESPACE,
                           command=cmd, stderr=True, stdin=False, stdout=True,


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix flaky test case test_support_bundle_should_not_timeout by extending timeout

https://ci.longhorn.io/job/private/job/longhorn-tests-regression/11354/testReport/junit/tests/test_support_bundle/test_support_bundle_should_not_timeout/

```
        with timeout(seconds=600, error_message='Timeout on executing command'):
>           zip_size = stream(core_api.connect_get_namespaced_pod_exec,
                              pod_name, LONGHORN_NAMESPACE,
                              command=cmd, stderr=True, stdin=False, stdout=True,
                              tty=False)

    def handle_timeout(self, signum, frame):
>       raise Exception(self.error_message)
E       Exception: Timeout on executing command
```

The total time required to generate the mock support bundle zip file can be very long:

```
# time dd if=/dev/urandom of=/tmp/mock-support-bundle bs=1G count=5
5+0 records in
5+0 records out
5368709120 bytes (5.4 GB, 5.0 GiB) copied, 79.5194 s, 67.5 MB/s

real	1m22.566s
user	0m0.000s
sys	1m8.124s
```

```
# time zip /tmp/support-bundle-kit/$bundle /tmp/mock-support-bundle
updating: tmp/mock-support-bundle (deflated 0%)

real	9m44.099s
user	8m45.758s
sys	0m16.415s
```

#### Special notes for your reviewer:

#### Additional documentation or context
