### PR TITLE
test(robot): refine test case Test Volume Expansion After Iscsid Restart

### DIFF
--- a/e2e/libs/ssh/ssh.py
+++ b/e2e/libs/ssh/ssh.py
@@ -21,12 +21,9 @@ def ssh_exec(node_name, cmd):
 
     cmd = f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {username}@{ip} {cmd}"
 
-    retry_count, retry_interval = get_retry_count_and_interval()
-    for i in range(retry_count):
-        try:
-            res = subprocess_exec_cmd(cmd)
-            return res
-        except Exception as e:
-            logging(f"SSH command {cmd} on node {node_name} failed: {e} ... ({i})")
-            time.sleep(retry_interval)
-    assert False, f"Failed to SSH command {cmd} on node {node_name}"
+    try:
+        res = subprocess_exec_cmd(cmd)
+        return res
+    except Exception as e:
+        logging(f"SSH command {cmd} on node {node_name} failed: {e}")
+        raise Exception(f"{e}, {e.output}")

--- a/e2e/tests/negative/service_restart.robot
+++ b/e2e/tests/negative/service_restart.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation    Negative Test Cases
 
-Test Tags    kubelet-restart    negative
+Test Tags    service-restart    negative
 
 Resource    ../keywords/variables.resource
 Resource    ../keywords/common.resource
@@ -12,6 +12,10 @@ Resource    ../keywords/workload.resource
 Resource    ../keywords/k8s.resource
 Resource    ../keywords/setting.resource
 Resource    ../keywords/node.resource
+Resource    ../keywords/volume.resource
+Resource    ../keywords/sharemanager.resource
+Resource    ../keywords/deployment.resource
+Resource    ../keywords/host.resource
 
 Test Setup    Set up test environment
 Test Teardown    Cleanup test resources
@@ -197,3 +201,55 @@ Restart Volume Node Kubelet After Temporary Downtime On Single Node Cluster With
 Restart Volume Node Kubelet After Temporary Downtime On Single Node Cluster With RWX Fast Failover Disabled
     [Tags]    single-replica
     Restart Volume Node Kubelet After Temporary Downtime On Single Node Cluster    RWX_VOLUME_FAST_FAILOVER=false
+
+Test Volume Expansion After Iscsid Restart
+    [Tags]    expansion
+    [Documentation]    Verify that volumes can still be expanded correctly after iscsid
+    ...                is restarted on all worker nodes.
+    ...
+    ...                Issue: https://github.com/longhorn/longhorn/issues/10544
+    ...
+    ...                Steps:
+    ...                1. Create a RWO and a RWX deployment, each with a 1GiB volume.
+    ...                2. Write data to both deployments.
+    ...                3. Restart iscsid on every worker node.
+    ...                4. Expand the RWO deployment volume to 2GiB.
+    ...                5. Wait for the RWO volume size to be expanded.
+    ...                6. Assert the filesystem size in the RWO deployment is 2GiB.
+    ...                7. Check RWO data integrity.
+    ...                8. Expand the RWX deployment volume to 2GiB.
+    ...                9. Wait for the RWX volume size to be expanded.
+    ...                10. Assert the filesystem size in the RWX deployment is 2GiB.
+    ...                11. Assert the disk size in the sharemanager pod is 2GiB.
+    ...                12. Check RWX data integrity.
+    IF    '${DATA_ENGINE}' == 'v2'
+        Skip    v2 volume doesn't rely on iscsid
+    END
+
+    Given Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-test    storage_size=1GiB
+    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-test    storage_size=1GiB
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 0 healthy
+    And Wait for volume of deployment 1 healthy
+    And Write 512 MB data to file data.txt in deployment 0
+    And Write 512 MB data to file data.txt in deployment 1
+
+    # Restart iscsid on all worker nodes
+    When SSH into node 0 and run command    sudo systemctl restart iscsid
+    And SSH into node 1 and run command    sudo systemctl restart iscsid
+    And SSH into node 2 and run command    sudo systemctl restart iscsid
+
+    # Expand RWO deployment and verify
+    And Expand deployment 0 volume to 2GiB
+    Then Wait for deployment 0 volume size expanded
+    And Assert filesystem size in deployment 0 is 2GiB
+    And Check deployment 0 data in file data.txt is intact
+
+    # Expand RWX deployment and verify
+    When Expand deployment 1 volume to 2GiB
+    Then Wait for deployment 1 volume size expanded
+    And Assert filesystem size in deployment 1 is 2GiB
+    And Assert disk size in sharemanager pod for deployment 1 is 2GiB
+    And Check deployment 1 data in file data.txt is intact

--- a/e2e/tests/regression/test_expansion.robot
+++ b/e2e/tests/regression/test_expansion.robot
@@ -169,57 +169,6 @@ Test RWX Volume Automatic Online Expansion
     Then Check deployment 0 data in file data.txt is intact
     And Check deployment 0 data in file data2.txt is intact
 
-Test Volume Expansion After Iscsid Restart
-    [Documentation]    Verify that volumes can still be expanded correctly after iscsid
-    ...                is restarted on all worker nodes.
-    ...
-    ...                Issue: https://github.com/longhorn/longhorn/issues/10544
-    ...
-    ...                Steps:
-    ...                1. Create a RWO and a RWX deployment, each with a 1GiB volume.
-    ...                2. Write data to both deployments.
-    ...                3. Restart iscsid on every worker node.
-    ...                4. Expand the RWO deployment volume to 2GiB.
-    ...                5. Wait for the RWO volume size to be expanded.
-    ...                6. Assert the filesystem size in the RWO deployment is 2GiB.
-    ...                7. Check RWO data integrity.
-    ...                8. Expand the RWX deployment volume to 2GiB.
-    ...                9. Wait for the RWX volume size to be expanded.
-    ...                10. Assert the filesystem size in the RWX deployment is 2GiB.
-    ...                11. Assert the disk size in the sharemanager pod is 2GiB.
-    ...                12. Check RWX data integrity.
-    IF    '${DATA_ENGINE}' == 'v2'
-        Skip    v2 volume doesn't rely on iscsid
-    END
-
-    Given Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}
-    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-test    storage_size=1GiB
-    And Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-test    storage_size=1GiB
-    And Create deployment 0 with persistentvolumeclaim 0
-    And Create deployment 1 with persistentvolumeclaim 1
-    And Wait for volume of deployment 0 healthy
-    And Wait for volume of deployment 1 healthy
-    And Write 512 MB data to file data.txt in deployment 0
-    And Write 512 MB data to file data.txt in deployment 1
-
-    # Restart iscsid on all worker nodes
-    When SSH into node 0 and run command    sudo systemctl restart iscsid
-    And SSH into node 1 and run command    sudo systemctl restart iscsid
-    And SSH into node 2 and run command    sudo systemctl restart iscsid
-
-    # Expand RWO deployment and verify
-    And Expand deployment 0 volume to 2GiB
-    Then Wait for deployment 0 volume size expanded
-    And Assert filesystem size in deployment 0 is 2GiB
-    And Check deployment 0 data in file data.txt is intact
-
-    # Expand RWX deployment and verify
-    When Expand deployment 1 volume to 2GiB
-    Then Wait for deployment 1 volume size expanded
-    And Assert filesystem size in deployment 1 is 2GiB
-    And Assert disk size in sharemanager pod for deployment 1 is 2GiB
-    And Check deployment 1 data in file data.txt is intact
-
 Test Volume Offline Expansion With Unscheduled Replica
     [Documentation]    Issue: https://github.com/longhorn/longhorn/issues/13355
     ...    Test offline expansion of direct volume (non-dynamic provisioning) with unscheduled replica


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

refine test case Test Volume Expansion After Iscsid Restart

1. aws auto-assign public ips can change after an instance reboots, which currently breaks ssh access. further improvements are needed.
2. as a temporary workaround, separate the iscsid restart test case from other test cases that may reboot a node
3. since the ssh failure is caused by the ip change, retrying is ineffective. remove the retry mechanism accordingly

#### Special notes for your reviewer:

#### Additional documentation or context
