### PR TITLE
test: set default v2 data-engine-cpu-mask to 0x1

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -3978,6 +3978,15 @@ def reset_settings(client):
         if setting_name == "registry-secret":
             continue
 
+        if setting_name == "data-engine-cpu-mask":
+            setting = client.by_id_setting("data-engine-cpu-mask")
+            try:
+                client.update(setting, value="{\"v2\":\"0x1\"}")
+            except Exception as e:
+                print(f"\nException setting {setting_name} to {{\"v2\":\"0x1\"}}") # NOQA
+                print(e)
+            continue
+
         if setting_name == "v2-data-engine":
             if v2_data_engine_cr_supported(client):
                 setting = client.by_id_setting(SETTING_V2_DATA_ENGINE)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13585#issuecomment-5185984630

#### What this PR does / why we need it:

set default v2 data-engine-cpu-mask to 0x1

#### Special notes for your reviewer:

#### Additional documentation or context
