### PR TITLE
test(robot): fix flaky test case Test Engine Image Liveness Probe DaemonSet Auto Update

### DIFF
--- a/e2e/keywords/engine_image.resource
+++ b/e2e/keywords/engine_image.resource
@@ -2,8 +2,9 @@
 Documentation       Longhorn engine image related keywords
 
 Library             String
+Library             ../libs/keywords/common_keywords.py
 Library             ../libs/keywords/engine_image_keywords.py
-Resource            workload.resource
+Library             ../libs/keywords/workload_keywords.py
 
 *** Keywords ***
 Create compatible engine image
@@ -13,10 +14,14 @@ Create compatible engine image
 Wait to engine image ${custom_engine_image} to be deployed
     wait_for_engine_image_deployed    ${custom_engine_image}
 
-Wait for engine image daemonset pods recreated
+Wait for engine image daemonset pods recreated and running
+    ${longhorn_namespace} =    get_longhorn_namespace
     ${output}=    Run Command
     ...    kubectl -n longhorn-system get ds -l longhorn.io/component=engine-image --no-headers -o custom-columns=NAME:.metadata.name
     @{ds_names}=    Split To Lines    ${output}
     FOR    ${ds_name}    IN    @{ds_names}
-        Wait for daemonset ${ds_name} pods recreated    namespace=longhorn-system
+        wait_for_workload_pods_recreated    ${ds_name}    daemonset    ${longhorn_namespace}
+        Run command and wait for output
+        ...    kubectl -n ${longhorn_namespace} get pods | grep ${ds_name} | grep -c Running
+        ...    3
     END

--- a/e2e/tests/regression/test_settings.robot
+++ b/e2e/tests/regression/test_settings.robot
@@ -366,7 +366,7 @@ Test Engine Image Liveness Probe DaemonSet Auto Update
     When Setting engine-image-pod-liveness-probe-timeout is set to 15
     And Setting engine-image-pod-liveness-probe-period is set to 30
     And Setting engine-image-pod-liveness-probe-failure-threshold is set to 10
-    And Wait for engine image daemonset pods recreated
+    And Wait for engine image daemonset pods recreated and running
     Then All engine image daemonset should have liveness probe settings
     ...    timeout=15
     ...    period=30


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue N/A

#### What this PR does / why we need it:

fix flaky test case Test Engine Image Liveness Probe DaemonSet Auto Update

https://ci.longhorn.io/job/public/job/v1.12.x/job/v1.12.x-longhorn-e2e-tests-sles-amd64/398/

```
KEYWORD backup_keywords . Cleanup Backups
ApiError: (ApiError(...), "500 : failed to get the parameters: failed to get target node ID: failed to find a node that is 
ready and has the default engine image longhornio/longhorn-engine:master-head deployed\n{'code': 500, 'detail': '', 
'message': 'failed to get the parameters: failed to get target node ID: failed to find a node that is ready and has the 
default engine image longhornio/longhorn-engine:master-head deployed', 'status': 500}")
```

#### Special notes for your reviewer:

#### Additional documentation or context
