### PR TITLE
test(robot): add replica rebuild TCP keepalive test

### DIFF
--- a/e2e/keywords/network.resource
+++ b/e2e/keywords/network.resource
@@ -83,3 +83,31 @@ Disconnect network port ${port_number} of ${engine_type} instance manager networ
     ${node_name} =    get_node_by_index    ${node_id}
     ${pod_name} =    get_instance_manager_pod_on_node    ${node_name}    ${engine_type}
     disconnect_pod_network    ${pod_name}    ${duration}    ${port_number}
+
+Limit V1 volume ${volume_id} rebuild traffic from node ${source_node_id} to node ${target_node_id} to ${rate_in_mbit} Mbit
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${source_node_name} =    get_node_by_index    ${source_node_id}
+    ${target_node_name} =    get_node_by_index    ${target_node_id}
+    ${context} =    limit_v1_replica_rebuild_traffic
+    ...    ${volume_name}
+    ...    ${source_node_name}
+    ...    ${target_node_name}
+    ...    ${rate_in_mbit}
+    RETURN    ${context}
+
+Remove V1 replica rebuild traffic limit
+    [Arguments]    ${context}
+    cleanup_v1_replica_rebuild_traffic    ${context}
+
+Wait for FileSend connection
+    [Arguments]    ${context}
+    ${connection} =    find_file_send_connection    ${context}
+    RETURN    ${connection}
+
+Drop replies to FileSend connection for ${duration} seconds
+    [Arguments]    ${connection}
+    drop_file_send_connection_replies    ${connection}    ${duration}
+
+FileSend connection should remain established
+    [Arguments]    ${connection}
+    assert_file_send_connection_established    ${connection}

--- a/e2e/libs/keywords/network_keywords.py
+++ b/e2e/libs/keywords/network_keywords.py
@@ -4,13 +4,25 @@ from network.network import setup_control_plane_network_latency
 from network.network import cleanup_control_plane_network_latency
 from network.network import disconnect_node_network, disconnect_pod_network
 from network.network import drop_pod_egress_traffic
+from network.network import drop_tcp_connection_replies
+from network.network import get_pod_tcp_connections
+from network.network import limit_pod_traffic_to_ip
+from network.network import remove_pod_traffic_limit
 
+from replica import Replica
+
+from utility.utility import get_retry_count_and_interval
 from utility.utility import logging
 
 from workload.pod import wait_for_pod_status
 
 
 class network_keywords:
+
+    def __init__(self):
+        self.replica = Replica()
+        self.retry_count, self.retry_interval = \
+            get_retry_count_and_interval()
 
     def setup_control_plane_network_latency(self, latency_in_ms):
         logging(f"Setting up control plane network latency to {latency_in_ms} ms")
@@ -45,3 +57,91 @@ class network_keywords:
 
     def wait_for_block_network_pod_completed(self, pod_name, status, namespace='default'):
         wait_for_pod_status(pod_name, status, namespace)
+
+    def limit_v1_replica_rebuild_traffic(self, volume_name,
+                                         source_node_name,
+                                         target_node_name, rate_in_mbit):
+        source_replica = self._get_running_replica(
+            volume_name, source_node_name)
+        target_replica = self._get_running_replica(
+            volume_name, target_node_name)
+
+        context = {
+            "source_instance_manager":
+                source_replica["status"]["instanceManagerName"],
+            "source_ip": source_replica["status"]["ip"],
+            "source_sync_agent_port":
+                int(source_replica["status"]["port"]) + 2,
+            "target_ip": target_replica["status"]["ip"],
+        }
+        context["interface"] = limit_pod_traffic_to_ip(
+            context["source_instance_manager"],
+            context["target_ip"],
+            context["source_sync_agent_port"],
+            int(rate_in_mbit),
+        )
+        return context
+
+    def cleanup_v1_replica_rebuild_traffic(self, context):
+        remove_pod_traffic_limit(
+            context["source_instance_manager"], context["interface"])
+
+    def find_file_send_connection(self, context):
+        for i in range(self.retry_count):
+            connections = get_pod_tcp_connections(
+                context["source_instance_manager"])
+            for connection in connections:
+                if self._is_file_send_connection(connection, context):
+                    connection["pod_name"] = \
+                        context["source_instance_manager"]
+                    logging(f"Found FileSend TCP connection {connection}")
+                    return connection
+            logging(f"Waiting for FileSend TCP connection ... ({i})")
+            time.sleep(self.retry_interval)
+
+        assert False, (
+            "Failed to find FileSend TCP connection from target "
+            f"{context['target_ip']} to source "
+            f"{context['source_ip']}:"
+            f"{context['source_sync_agent_port']}"
+        )
+
+    def drop_file_send_connection_replies(self, connection,
+                                          drop_time_in_sec):
+        drop_tcp_connection_replies(
+            connection["pod_name"], connection, int(drop_time_in_sec))
+
+    def assert_file_send_connection_established(self, connection):
+        connections = get_pod_tcp_connections(connection["pod_name"])
+        assert self._connection_in_list(connection, connections), (
+            "FileSend TCP connection is no longer established: "
+            f"{connection}"
+        )
+
+    def _get_running_replica(self, volume_name, node_name):
+        replicas = [
+            replica for replica in self.replica.get(volume_name, node_name)
+            if replica.get("status", {}).get("currentState") == "running"
+        ]
+        assert len(replicas) == 1, (
+            f"Expected one running replica for volume {volume_name} on "
+            f"node {node_name}, got {len(replicas)}"
+        )
+        return replicas[0]
+
+    @staticmethod
+    def _is_file_send_connection(connection, context):
+        return (
+            connection["local_ip"] == context["source_ip"] and
+            connection["local_port"] ==
+            context["source_sync_agent_port"] and
+            connection["remote_ip"] == context["target_ip"]
+        )
+
+    @staticmethod
+    def _connection_in_list(expected, connections):
+        fields = ("local_ip", "local_port", "remote_ip", "remote_port")
+        return any(
+            all(connection[field] == expected[field] for field in fields)
+            for connection in connections
+        )

--- a/e2e/libs/network/network.py
+++ b/e2e/libs/network/network.py
@@ -107,3 +107,113 @@ def disconnect_pod_network(pod_name, disconnection_time_in_sec=10, port_number=N
     pod_exec(pod_name, constant.LONGHORN_NAMESPACE, cmd)
     if wait:
         time.sleep(disconnection_time_in_sec)
+
+
+def limit_pod_traffic_to_ip(pod_name, target_ip, excluded_source_port,
+                            rate_in_mbit):
+    wait_for_pod_status(
+        pod_name, "Running", namespace=constant.LONGHORN_NAMESPACE)
+
+    interface = pod_exec(
+        pod_name,
+        constant.LONGHORN_NAMESPACE,
+        f"ip route get {target_ip} | awk '{{for (i = 1; i <= NF; i++) "
+        f"if ($i == \"dev\") {{print $(i + 1); exit}}}}'",
+    ).strip()
+    assert interface, f"Failed to find route from {pod_name} to {target_ip}"
+
+    logging(
+        f"Limiting traffic from pod {pod_name} to {target_ip} to "
+        f"{rate_in_mbit} Mbit, excluding source port {excluded_source_port}"
+    )
+    # Classify the sync-agent server traffic first so only rebuild data is
+    # rate-limited. All unrelated traffic uses the unshaped default class.
+    cmd = (
+        "set -eu; "
+        "zypper install -y iptables > /dev/null; "
+        f"tc qdisc add dev {interface} root handle 1: htb default 20; "
+        f"tc class add dev {interface} parent 1: classid 1:1 "
+        "htb rate 10000mbit; "
+        f"tc class add dev {interface} parent 1:1 classid 1:10 "
+        f"htb rate {rate_in_mbit}mbit; "
+        f"tc class add dev {interface} parent 1:1 classid 1:20 "
+        "htb rate 10000mbit; "
+        f"tc filter add dev {interface} protocol ip parent 1: prio 1 u32 "
+        "match ip protocol 6 0xff "
+        f"match ip sport {excluded_source_port} 0xffff flowid 1:20; "
+        f"tc filter add dev {interface} protocol ip parent 1: prio 2 u32 "
+        f"match ip dst {target_ip}/32 flowid 1:10"
+    )
+
+    try:
+        pod_exec(pod_name, constant.LONGHORN_NAMESPACE, cmd)
+    except Exception:
+        remove_pod_traffic_limit(pod_name, interface)
+        raise
+
+    return interface
+
+
+def remove_pod_traffic_limit(pod_name, interface):
+    logging(
+        f"Removing traffic limit from pod {pod_name} interface {interface}")
+    pod_exec(
+        pod_name,
+        constant.LONGHORN_NAMESPACE,
+        f"tc qdisc del dev {interface} root handle 1: 2>/dev/null || true",
+    )
+
+
+def get_pod_tcp_connections(pod_name):
+    output = pod_exec(
+        pod_name,
+        constant.LONGHORN_NAMESPACE,
+        "ss -Htn state established",
+    )
+
+    connections = []
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) < 4:
+            continue
+        local_ip, local_port = _split_tcp_endpoint(fields[2])
+        remote_ip, remote_port = _split_tcp_endpoint(fields[3])
+        connections.append({
+            "local_ip": local_ip,
+            "local_port": local_port,
+            "remote_ip": remote_ip,
+            "remote_port": remote_port,
+        })
+    return connections
+
+
+def drop_tcp_connection_replies(pod_name, connection,
+                                drop_time_in_sec):
+    rule = (
+        f"-p tcp -s {connection['remote_ip']} "
+        f"--sport {connection['remote_port']} "
+        f"-d {connection['local_ip']} --dport {connection['local_port']} "
+        "-j DROP"
+    )
+    logging(
+        "Dropping replies to TCP connection "
+        f"{connection['remote_ip']}:{connection['remote_port']} -> "
+        f"{connection['local_ip']}:{connection['local_port']} for "
+        f"{drop_time_in_sec} seconds"
+    )
+    cmd = (
+        f"iptables -w -I INPUT 1 {rule}; "
+        f"{{ sleep {drop_time_in_sec}; "
+        f"iptables -w -D INPUT {rule} || true; }} > /dev/null 2>&1 &"
+    )
+    pod_exec(pod_name, constant.LONGHORN_NAMESPACE, cmd)
+
+
+def _split_tcp_endpoint(endpoint):
+    if endpoint.startswith("["):
+        ip, port = endpoint[1:].rsplit("]:", 1)
+    else:
+        ip, port = endpoint.rsplit(":", 1)
+    if ip.startswith("::ffff:"):
+        ip = ip[len("::ffff:"):]
+    return ip, int(port)

--- a/e2e/tests/negative/network_disconnect.robot
+++ b/e2e/tests/negative/network_disconnect.robot
@@ -279,3 +279,47 @@ Test Large Volume Replica Rebuilding Resilience
 
     And Wait for volume 0 healthy
     And Check volume 0 data is intact
+
+Test Replica Rebuild Survives Lost TCP Keepalive Response
+    [Tags]    replica-rebuilding    v1
+    [Documentation]    Test that losing replies on an idle FileSend connection does not cancel an active replica rebuild.
+    ...
+    ...                Issue: https://github.com/longhorn/longhorn/issues/13703
+    ...                The affected listener resets this connection after one unanswered TCP keepalive,
+    ...                canceling the independent ssync HTTP transfer.
+    ...
+    ...                Test Steps:
+    ...                1. Cordon node 2 and create a V1 volume with replicas on nodes 0 and 1.
+    ...                2. Attach the volume to node 0 and write 512 MiB of allocated data.
+    ...                3. Limit source-to-target rebuild traffic to 50 Mbit so the rebuild lasts over 40 seconds.
+    ...                   Traffic from the source sync-agent port is exempt from the limit.
+    ...                4. Delete the replica on node 1, making node 0 the source and node 1 the rebuild target.
+    ...                5. Find the established FileSend connection from the target to the source sync-agent.
+    ...                6. Drop replies on only that connection for 45 seconds. The ssync HTTP data connections remain active.
+    ...                7. After 40 seconds, verify that the original FileSend connection is still established.
+    ...                8. Verify that rebuilding completes and the data is intact.
+    IF    '${DATA_ENGINE}' != 'v1'
+        Skip    This test only applies to the V1 data engine
+    END
+
+    Given Cordon node 2
+    And Create volume 0    size=1Gi    numberOfReplicas=2    dataEngine=v1
+    And Attach volume 0 to node 0
+    And Wait for volume 0 healthy
+    And Prefill volume 0 with fio    size=512M
+
+    ${rebuild_network} =    Limit V1 volume 0 rebuild traffic from node 0 to node 1 to 50 Mbit
+    TRY
+        When Delete volume 0 replica on node 1
+        And Wait until volume 0 replica rebuilding started on node 1
+        ${file_send_connection} =    Wait for FileSend connection    ${rebuild_network}
+
+        When Drop replies to FileSend connection for 45 seconds    ${file_send_connection}
+        And Sleep    40
+        Then FileSend connection should remain established    ${file_send_connection}
+
+        And Wait for volume 0 healthy
+        And Check volume 0 data is intact
+    FINALLY
+        Remove V1 replica rebuild traffic limit    ${rebuild_network}
+    END


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13703 https://github.com/longhorn/longhorn/issues/13767

#### What this PR does / why we need it:

Reproduce a V1 replica rebuild interruption by rate-limiting the rebuild data transfer and withholding replies on the idle FileSend connection to ensure TCP keepalives get dropped. Verify that the original control connection remains established and that the rebuild completes with intact data.

#### Special notes for your reviewer:

I relied heavily on Codex to understand your testing framework, and while I was able to get the test running in a local Docker-based cluster that I think approximated your test environment, I'm not entirely confident it will run correctly in the real one.  Even so, the test appears to fail currently and passes with the fix at https://github.com/longhorn/longhorn-engine/pull/1970.

#### Additional documentation or context
