### PR TITLE
test(robot): add test case Test Backup On Cluster With Drained Nodes

### DIFF
--- a/e2e/tests/regression/test_backup.robot
+++ b/e2e/tests/regression/test_backup.robot
@@ -593,3 +593,26 @@ Test Restoring Volume From Backup With Missing Blocks
     And Attach volume 2
     And Wait for volume 2 healthy
     Then Check volume 2 data is backup 1 of volume 0
+
+Test Backup On Cluster With Drained Nodes
+    [Documentation]    Issue: https://github.com/longhorn/longhorn/issues/12562
+    ...    Verify that backups can be created successfully on a cluster where nodes
+    ...    are drained and have Longhorn scheduling disabled.
+    ...    1. Force drain node 0 and node 1
+    ...    2. Disable node 0 and node 1 Longhorn scheduling
+    ...    3. Create a volume with 1 replica and data engine ${DATA_ENGINE}
+    ...    4. Attach the volume to node 2
+    ...    5. Wait for the volume to become healthy
+    ...    6. For each of 10 iterations: write 100 MB data, create a backup, and wait for the backup to complete
+    Given Force drain node 0
+    And Force drain node 1
+    And Disable node 0 scheduling
+    And Disable node 1 scheduling
+    And Create volume 0 with    numberOfReplicas=1    dataEngine=${DATA_ENGINE}
+    And Attach volume 0 to node 2
+    And Wait for volume 0 healthy
+
+    FOR    ${i}    IN RANGE    10
+        And Write data ${i} 10 MB to volume 0
+        Then Create backup ${i} for volume 0
+    END


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13682

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context

Know issue for this test case https://github.com/longhorn/longhorn/issues/13775
