### PR TITLE
test(robot): add test case Test NVMe TCP IO Queue Count

### DIFF
--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -110,6 +110,35 @@ Update volume ${volume_id} ${key} to ${value}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     update_volume_spec   ${volume_name}    ${key}    ${value}
 
+Get NVMe queue count of ${workload_kind} ${workload_id} volume
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    ${queue_count} =    get_nvme_queue_count_of_volume    ${volume_name}
+    RETURN    ${queue_count}
+
+Wait for NVMe queue count of ${workload_kind} ${workload_id} volume to be ${expected_count}
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    wait_for_nvme_queue_count    ${volume_name}    ${expected_count}
+
+Enable frontend of ${workload_kind} ${workload_id} volume
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    enable_volume_frontend    ${volume_name}
+
+Attach ${workload_kind} ${workload_id} volume in maintenance mode
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    attach_volume_in_maintenance_mode    ${volume_name}
+
+Detach ${workload_kind} ${workload_id} volume
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    detach_volume    ${volume_name}
+
+Validate volume spec ${key} of ${workload_kind} ${workload_id} is ${value}
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    validate_volume_setting    ${volume_name}    ${key}    ${value}
+
+Update volume spec ${key} of ${workload_kind} ${workload_id} to ${value}
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    update_volume_spec    ${volume_name}    ${key}    ${value}
+
 Attach volume ${volume_id} to node ${node_id}
     [Arguments]    &{config}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}

--- a/e2e/keywords/volume.resource
+++ b/e2e/keywords/volume.resource
@@ -167,6 +167,34 @@ Update volume of ${workload_kind} ${workload_id} ${key} to ${value} should fail
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${volume_name} =    get_workload_volume_name    ${workload_name}
     Run Keyword And Expect Error    *    update_volume_spec    ${volume_name}    ${key}    ${value}
+Get NVMe queue count of ${workload_kind} ${workload_id} volume
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    ${queue_count} =    get_nvme_queue_count_of_volume    ${volume_name}
+    RETURN    ${queue_count}
+
+Wait for NVMe queue count of ${workload_kind} ${workload_id} volume to be ${expected_count}
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    wait_for_nvme_queue_count    ${volume_name}    ${expected_count}
+
+Enable frontend of ${workload_kind} ${workload_id} volume
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    enable_volume_frontend    ${volume_name}
+
+Attach ${workload_kind} ${workload_id} volume in maintenance mode
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    attach_volume_in_maintenance_mode    ${volume_name}
+
+Detach ${workload_kind} ${workload_id} volume
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    detach_volume    ${volume_name}
+
+Validate volume spec ${key} of ${workload_kind} ${workload_id} is ${value}
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    validate_volume_setting    ${volume_name}    ${key}    ${value}
+
+Update volume spec ${key} of ${workload_kind} ${workload_id} to ${value}
+    ${volume_name} =    Get volume name of ${workload_kind} ${workload_id}
+    update_volume_spec    ${volume_name}    ${key}    ${value}
 
 Attach volume ${volume_id} to node ${node_id}
     [Arguments]    &{config}

--- a/e2e/keywords/workload.resource
+++ b/e2e/keywords/workload.resource
@@ -145,6 +145,16 @@ Reboot volume node of ${workload_kind} ${workload_id}
     reboot_node_by_name    ${node_name}
     Remove Values From List    ${powered_off_nodes}    ${node_name}
 
+Get volume name of ${workload_kind} ${workload_id}
+    ${workload_name} =    generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    RETURN    ${volume_name}
+
+Wait for volume of ${workload_kind} ${workload_id} degraded
+    ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
+    ${volume_name} =    get_workload_volume_name    ${workload_name}
+    wait_for_volume_degraded    ${volume_name}
+
 Wait for volume of ${workload_kind} ${workload_id} detached
     ${workload_name} =   generate_name_with_suffix    ${workload_kind}    ${workload_id}
     ${volume_name} =    get_workload_volume_name    ${workload_name}

--- a/e2e/libs/keywords/storageclass_keywords.py
+++ b/e2e/libs/keywords/storageclass_keywords.py
@@ -7,9 +7,9 @@ class storageclass_keywords:
     def __init__(self):
         self.storageclass = StorageClass()
 
-    def create_storageclass(self, name, numberOfReplicas=None, migratable=None, dataLocality=None, fromBackup=None, nfsOptions=None, dataEngine=None, encrypted=None, recurringJobSelector=None, volumeBindingMode=None, allowedTopologies=None, backingImage=None, backingImageDataSourceType=None, backingImageDataSourceParameters=None, nodeSelector=None):
+    def create_storageclass(self, name, numberOfReplicas=None, migratable=None, dataLocality=None, fromBackup=None, nfsOptions=None, dataEngine=None, encrypted=None, recurringJobSelector=None, volumeBindingMode=None, allowedTopologies=None, backingImage=None, backingImageDataSourceType=None, backingImageDataSourceParameters=None, nodeSelector=None, nvmeTcpNrIoQueues=None):
         logging(f'Creating storageclass with {locals()}')
-        self.storageclass.create(name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, recurringJobSelector, volumeBindingMode, allowedTopologies, backingImage, backingImageDataSourceType, backingImageDataSourceParameters, nodeSelector)
+        self.storageclass.create(name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, recurringJobSelector, volumeBindingMode, allowedTopologies, backingImage, backingImageDataSourceType, backingImageDataSourceParameters, nodeSelector, nvmeTcpNrIoQueues)
 
     def cleanup_storageclasses(self):
         self.storageclass.cleanup()

--- a/e2e/libs/keywords/storageclass_keywords.py
+++ b/e2e/libs/keywords/storageclass_keywords.py
@@ -7,9 +7,9 @@ class storageclass_keywords:
     def __init__(self):
         self.storageclass = StorageClass()
 
-    def create_storageclass(self, name, numberOfReplicas=None, migratable=None, dataLocality=None, fromBackup=None, nfsOptions=None, dataEngine=None, encrypted=None, recurringJobSelector=None, volumeBindingMode=None, allowedTopologies=None, backingImage=None, backingImageDataSourceType=None, backingImageDataSourceParameters=None, nodeSelector=None, volumeTopology=None, replicaZoneSoftAntiAffinity=None, dataLayout=None, fsType=None, replicaSoftAntiAffinity=None):
+    def create_storageclass(self, name, numberOfReplicas=None, migratable=None, dataLocality=None, fromBackup=None, nfsOptions=None, dataEngine=None, encrypted=None, recurringJobSelector=None, volumeBindingMode=None, allowedTopologies=None, backingImage=None, backingImageDataSourceType=None, backingImageDataSourceParameters=None, nodeSelector=None, volumeTopology=None, replicaZoneSoftAntiAffinity=None, dataLayout=None, fsType=None, replicaSoftAntiAffinity=None, nvmeTcpNrIoQueues=None):
         logging(f'Creating storageclass with {locals()}')
-        self.storageclass.create(name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, recurringJobSelector, volumeBindingMode, allowedTopologies, backingImage, backingImageDataSourceType, backingImageDataSourceParameters, nodeSelector, volumeTopology, replicaZoneSoftAntiAffinity, dataLayout, fsType, replicaSoftAntiAffinity)
+        self.storageclass.create(name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, recurringJobSelector, volumeBindingMode, allowedTopologies, backingImage, backingImageDataSourceType, backingImageDataSourceParameters, nodeSelector, volumeTopology, replicaZoneSoftAntiAffinity, dataLayout, fsType, replicaSoftAntiAffinity, nvmeTcpNrIoQueues)
 
     def cleanup_storageclasses(self):
         self.storageclass.cleanup()

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -15,6 +15,7 @@ import utility.constant as constant
 from utility.utility import logging
 from utility.utility import get_retry_count_and_interval
 from utility.utility import convert_size_to_bytes
+from utility.utility import pod_exec
 
 from volume import Volume
 from volume.rest import Rest as VolumeRest
@@ -545,3 +546,30 @@ class volume_keywords:
 
     def wait_for_volume_status(self, volume_name, status_name, status_value):
         self.volume.wait_for_volume_status(volume_name, status_name, status_value)
+
+    def get_nvme_queue_count_of_volume(self, volume_name):
+        im_pod = self.get_volume_instance_manager(volume_name)
+        cmd = (f"for ctrl in /sys/class/nvme/nvme*/; do "
+               f"grep -q '{volume_name}' \"$ctrl/subsysnqn\" 2>/dev/null && "
+               f"cat \"$ctrl/queue_count\" && break; done")
+        result = pod_exec(im_pod, constant.LONGHORN_NAMESPACE, cmd)
+        result = result.strip()
+        assert result, f"Failed to find NVMe queue_count for volume {volume_name} in pod {im_pod}"
+        return int(result)
+
+    def wait_for_nvme_queue_count(self, volume_name, expected_count):
+        expected_count = int(expected_count)
+        for i in range(self.retry_count):
+            logging(f"Waiting for NVMe queue count of volume {volume_name} to be {expected_count} ... ({i})")
+            time.sleep(self.retry_interval)
+            try:
+                count = self.get_nvme_queue_count_of_volume(volume_name)
+                if count == expected_count:
+                    return
+                logging(f"Current NVMe queue count: {count}, expected: {expected_count}")
+            except Exception as e:
+                logging(f"Error getting NVMe queue count: {e}")
+        assert False, f"NVMe queue count of volume {volume_name} did not reach {expected_count}"
+
+    def enable_volume_frontend(self, volume_name):
+        self.volume.enable_volume_frontend(volume_name)

--- a/e2e/libs/keywords/volume_keywords.py
+++ b/e2e/libs/keywords/volume_keywords.py
@@ -15,6 +15,7 @@ import utility.constant as constant
 from utility.utility import logging
 from utility.utility import get_retry_count_and_interval
 from utility.utility import convert_size_to_bytes
+from utility.utility import pod_exec
 
 from volume import Volume
 from volume.rest import Rest as VolumeRest
@@ -595,3 +596,30 @@ class volume_keywords:
 
     def wait_for_volume_status(self, volume_name, status_name, status_value):
         self.volume.wait_for_volume_status(volume_name, status_name, status_value)
+
+    def get_nvme_queue_count_of_volume(self, volume_name):
+        im_pod = self.get_volume_instance_manager(volume_name)
+        cmd = (f"for ctrl in /sys/class/nvme/nvme*/; do "
+               f"grep -q '{volume_name}' \"$ctrl/subsysnqn\" 2>/dev/null && "
+               f"cat \"$ctrl/queue_count\" && break; done")
+        result = pod_exec(im_pod, constant.LONGHORN_NAMESPACE, cmd)
+        result = result.strip()
+        assert result, f"Failed to find NVMe queue_count for volume {volume_name} in pod {im_pod}"
+        return int(result)
+
+    def wait_for_nvme_queue_count(self, volume_name, expected_count):
+        expected_count = int(expected_count)
+        for i in range(self.retry_count):
+            logging(f"Waiting for NVMe queue count of volume {volume_name} to be {expected_count} ... ({i})")
+            time.sleep(self.retry_interval)
+            try:
+                count = self.get_nvme_queue_count_of_volume(volume_name)
+                if count == expected_count:
+                    return
+                logging(f"Current NVMe queue count: {count}, expected: {expected_count}")
+            except Exception as e:
+                logging(f"Error getting NVMe queue count: {e}")
+        assert False, f"NVMe queue count of volume {volume_name} did not reach {expected_count}"
+
+    def enable_volume_frontend(self, volume_name):
+        self.volume.enable_volume_frontend(volume_name)

--- a/e2e/libs/storageclass/storageclass.py
+++ b/e2e/libs/storageclass/storageclass.py
@@ -12,7 +12,7 @@ class StorageClass():
     def __init__(self):
         self.api = client.StorageV1Api()
 
-    def create(self, name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, recurringJobSelector, volumeBindingMode, allowedTopologies, backingImage, backingImageDataSourceType, backingImageDataSourceParameters, nodeSelector):
+    def create(self, name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, recurringJobSelector, volumeBindingMode, allowedTopologies, backingImage, backingImageDataSourceType, backingImageDataSourceParameters, nodeSelector, nvmeTcpNrIoQueues=None):
 
         filepath = "./templates/workload/storageclass.yaml"
 
@@ -70,6 +70,9 @@ class StorageClass():
 
             if backingImageDataSourceParameters:
                 manifest_dict['parameters']['backingImageDataSourceParameters'] = backingImageDataSourceParameters
+
+            if nvmeTcpNrIoQueues:
+                manifest_dict['parameters']['nvmeTcpNrIoQueues'] = nvmeTcpNrIoQueues
 
             self.api.create_storage_class(body=manifest_dict)
 

--- a/e2e/libs/storageclass/storageclass.py
+++ b/e2e/libs/storageclass/storageclass.py
@@ -12,7 +12,7 @@ class StorageClass():
     def __init__(self):
         self.api = client.StorageV1Api()
 
-    def create(self, name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, recurringJobSelector, volumeBindingMode, allowedTopologies, backingImage, backingImageDataSourceType, backingImageDataSourceParameters, nodeSelector, volumeTopology=None, replicaZoneSoftAntiAffinity=None, dataLayout=None, fsType=None, replicaSoftAntiAffinity=None):
+    def create(self, name, numberOfReplicas, migratable, dataLocality, fromBackup, nfsOptions, dataEngine, encrypted, recurringJobSelector, volumeBindingMode, allowedTopologies, backingImage, backingImageDataSourceType, backingImageDataSourceParameters, nodeSelector, volumeTopology=None, replicaZoneSoftAntiAffinity=None, dataLayout=None, fsType=None, replicaSoftAntiAffinity=None, nvmeTcpNrIoQueues=None):
 
         filepath = "./templates/workload/storageclass.yaml"
 
@@ -86,6 +86,9 @@ class StorageClass():
 
             if fsType:
                 manifest_dict['parameters']['fsType'] = fsType
+
+            if nvmeTcpNrIoQueues:
+                manifest_dict['parameters']['nvmeTcpNrIoQueues'] = nvmeTcpNrIoQueues
 
             self.api.create_storage_class(body=manifest_dict)
 

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -841,7 +841,7 @@ class CRD(Base):
             try:
                 volume = self.get(volume_name)
                 spec = volume['spec']
-                if key in ["numberOfReplicas", "rebuildConcurrentSyncLimit", "staleReplicaTimeout"]:
+                if key in ["numberOfReplicas", "rebuildConcurrentSyncLimit", "staleReplicaTimeout", "nvmeTcpNrIoQueues"]:
                     spec[key] = int(value)
                 else:
                     spec[key] = value
@@ -860,6 +860,33 @@ class CRD(Base):
                 else:
                     raise e
             time.sleep(self.retry_interval)
+
+    def enable_volume_frontend(self, volume_name):
+        for i in range(self.retry_count):
+            logging(f"Enabling frontend of volume {volume_name} ... ({i})")
+            try:
+                body = get_cr(
+                    group="longhorn.io",
+                    version="v1beta2",
+                    namespace=constant.LONGHORN_NAMESPACE,
+                    plural="volumeattachments",
+                    name=volume_name
+                )
+                for ticket in body['spec']['attachmentTickets'].values():
+                    ticket['parameters']['disableFrontend'] = "false"
+                self.obj_api.patch_namespaced_custom_object(
+                    group="longhorn.io",
+                    version="v1beta2",
+                    namespace=constant.LONGHORN_NAMESPACE,
+                    plural="volumeattachments",
+                    name=volume_name,
+                    body=body
+                )
+                break
+            except Exception as e:
+                logging(f"Failed to enable frontend of volume {volume_name}: {e}")
+            time.sleep(self.retry_interval)
+        self.wait_for_volume_status(volume_name, "frontendDisabled", False)
 
     def activate(self, volume_name):
         return Rest().activate(volume_name)

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -949,7 +949,7 @@ class CRD(Base):
             try:
                 volume = self.get(volume_name)
                 spec = volume['spec']
-                if key in ["numberOfReplicas", "rebuildConcurrentSyncLimit", "staleReplicaTimeout"]:
+                if key in ["numberOfReplicas", "rebuildConcurrentSyncLimit", "staleReplicaTimeout", "nvmeTcpNrIoQueues"]:
                     spec[key] = int(value)
                 else:
                     spec[key] = value
@@ -968,6 +968,33 @@ class CRD(Base):
                 else:
                     raise e
             time.sleep(self.retry_interval)
+
+    def enable_volume_frontend(self, volume_name):
+        for i in range(self.retry_count):
+            logging(f"Enabling frontend of volume {volume_name} ... ({i})")
+            try:
+                body = get_cr(
+                    group="longhorn.io",
+                    version="v1beta2",
+                    namespace=constant.LONGHORN_NAMESPACE,
+                    plural="volumeattachments",
+                    name=volume_name
+                )
+                for ticket in body['spec']['attachmentTickets'].values():
+                    ticket['parameters']['disableFrontend'] = "false"
+                self.obj_api.patch_namespaced_custom_object(
+                    group="longhorn.io",
+                    version="v1beta2",
+                    namespace=constant.LONGHORN_NAMESPACE,
+                    plural="volumeattachments",
+                    name=volume_name,
+                    body=body
+                )
+                break
+            except Exception as e:
+                logging(f"Failed to enable frontend of volume {volume_name}: {e}")
+            time.sleep(self.retry_interval)
+        self.wait_for_volume_status(volume_name, "frontendDisabled", False)
 
     def activate(self, volume_name):
         return Rest().activate(volume_name)

--- a/e2e/libs/volume/volume.py
+++ b/e2e/libs/volume/volume.py
@@ -186,6 +186,9 @@ class Volume(Base):
     def update_volume_spec(self, volume_name, key, value):
         return self.volume.update_volume_spec(volume_name, key, value)
 
+    def enable_volume_frontend(self, volume_name):
+        return self.volume.enable_volume_frontend(volume_name)
+
     def activate(self, volume_name):
         return self.volume.activate(volume_name)
 

--- a/e2e/libs/volume/volume.py
+++ b/e2e/libs/volume/volume.py
@@ -201,6 +201,9 @@ class Volume(Base):
     def update_volume_spec(self, volume_name, key, value):
         return self.volume.update_volume_spec(volume_name, key, value)
 
+    def enable_volume_frontend(self, volume_name):
+        return self.volume.enable_volume_frontend(volume_name)
+
     def activate(self, volume_name):
         return self.volume.activate(volume_name)
 

--- a/e2e/tests/regression/test_v2.robot
+++ b/e2e/tests/regression/test_v2.robot
@@ -642,3 +642,122 @@ Test CPU Manager Policy And Data Engine Number Of CPU Cores
     And Run command in pod ${LONGHORN_NAMESPACE}/${im_pod} and wait for output
     ...    awk '/^Cpus_allowed_list:/ {print $2}' /proc/self/status
     ...    ^[0-9]+-[0-9]+$
+
+Test NVMe TCP IO Queue Count
+    [Documentation]    https://github.com/longhorn/longhorn/issues/13706
+    ...
+    ...                Test Setup:
+    ...                    Create a v2 StorageClass, PVC, and Deployment; wait for the volume to be healthy.
+    ...
+    ...                Step 1 - Record kernel-default queue count:
+    ...                    Read /sys/class/nvme/<ctrl>/queue_count from the volume's instance-manager pod.
+    ...
+    ...                Step 2 - Global setting:
+    ...                    Set default-nvme-tcp-nr-io-queues to {"v2":"2"}, detach and reattach the volume,
+    ...                    verify queue_count is 3 (2 I/O + 1 admin), and write data.
+    ...
+    ...                Step 3 - StorageClass per-volume override:
+    ...                    Create a StorageClass with nvmeTcpNrIoQueues=4, provision a new volume,
+    ...                    verify Volume.spec.nvmeTcpNrIoQueues is 4 and queue_count is 5, and write data.
+    ...
+    ...                Step 4 - Volume spec per-volume override:
+    ...                    Set Volume.spec.nvmeTcpNrIoQueues to 3, detach/reattach, verify queue_count is 4.
+    ...                    Reset to 0, detach/reattach, verify queue_count falls back to the global setting of 3.
+    ...
+    ...                Step 5 - Validation:
+    ...                    Verify that nvmeTcpNrIoQueues values 129 and -1 are rejected by the API.
+    ...
+    ...                Step 6 - Persistence across instance-manager restart:
+    ...                    Set nvmeTcpNrIoQueues=3, detach and reattach the volume, verify queue_count is 4,
+    ...                    delete the instance-manager pod, wait for recovery, and verify queue_count is still 4.
+    ...
+    ...                Step 7 - Maintenance attach:
+    ...                    Detach, attach in maintenance mode, enable the frontend,
+    ...                    and verify queue_count matches the configured value of 4.
+    ...
+    ...                Step 8 - Restore kernel default:
+    ...                    Reset default-nvme-tcp-nr-io-queues to {"v2":"0"}, detach and reattach deployment 0
+    ...                    (spec never changed from 0), and verify queue_count matches the default recorded in Step 1.
+    IF    '${DATA_ENGINE}' == 'v1'
+        Skip    Test only validates on v2 data engine
+    END
+
+    Given Create storageclass longhorn-test with    dataEngine=v2
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-test
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Wait for volume of deployment 0 healthy
+
+    # Step 1: Record the kernel-default NVMe-TCP queue count
+    ${default_queue_count} =    Get NVMe queue count of deployment 0 volume
+    Log    Default NVMe queue count: ${default_queue_count}
+
+    # Step 2: Verify the global NVMe-TCP I/O queue count setting
+    When Setting default-nvme-tcp-nr-io-queues is set to {"v2":"2"}
+    And Scale down deployment 0 to detach volume
+    And Wait for volume of deployment 0 detached
+    And Scale up deployment 0 to attach volume
+    And Wait for volume of deployment 0 healthy
+    # extra one queue for admin queue
+    And Wait for NVMe queue count of deployment 0 volume to be 3
+    And Write 100 MB data to file data.txt in deployment 0
+    And Check deployment 0 data in file data.txt is intact
+
+    # Step 3: Verify per-volume override through StorageClass
+    When Create storageclass longhorn-test-4q with    dataEngine=v2    nvmeTcpNrIoQueues=4
+    And Create persistentvolumeclaim 1    volume_type=RWO    sc_name=longhorn-test-4q
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 1 healthy
+    And Validate volume spec nvmeTcpNrIoQueues of deployment 1 is 4
+    And Wait for NVMe queue count of deployment 1 volume to be 5
+    And Write 100 MB data to file data.txt in deployment 1
+    And Check deployment 1 data in file data.txt is intact
+
+    # Step 4: Verify per-volume override on an existing volume
+    When Update volume spec nvmeTcpNrIoQueues of deployment 1 to 3
+    And Scale down deployment 1 to detach volume
+    And Wait for volume of deployment 1 detached
+    And Scale up deployment 1 to attach volume
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 4
+
+    When Update volume spec nvmeTcpNrIoQueues of deployment 1 to 0
+    And Scale down deployment 1 to detach volume
+    And Wait for volume of deployment 1 detached
+    And Scale up deployment 1 to attach volume
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 3
+
+    # Step 5: Verify NVMe-TCP I/O queue count validation
+    Run Keyword And Expect Error    *    Update volume spec nvmeTcpNrIoQueues of deployment 1 to 129
+    Run Keyword And Expect Error    *    Update volume spec nvmeTcpNrIoQueues of deployment 1 to -1
+
+    # Step 6: Verify queue count persists across instance-manager restart
+    When Update volume spec nvmeTcpNrIoQueues of deployment 1 to 3
+    And Scale down deployment 1 to detach volume
+    And Wait for volume of deployment 1 detached
+    And Scale up deployment 1 to attach volume
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 4
+    And Delete v2 instance manager of deployment 1 volume
+    And Wait for volume of deployment 1 degraded
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 4
+
+    # Step 7: Verify queue count for maintenance attach
+    When Scale down deployment 1 to detach volume
+    And Wait for volume of deployment 1 detached
+    And Attach deployment 1 volume in maintenance mode
+    And Wait for volume of deployment 1 healthy
+    And Enable frontend of deployment 1 volume
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 4
+    And Detach deployment 1 volume
+    And Wait for volume of deployment 1 detached
+
+    # Step 8: Verify kernel-default queue count is restored
+    When Setting default-nvme-tcp-nr-io-queues is set to {"v2":"0"}
+    And Scale down deployment 0 to detach volume
+    And Wait for volume of deployment 0 detached
+    And Scale up deployment 0 to attach volume
+    And Wait for volume of deployment 0 healthy
+    And Wait for NVMe queue count of deployment 0 volume to be ${default_queue_count}

--- a/e2e/tests/regression/test_v2.robot
+++ b/e2e/tests/regression/test_v2.robot
@@ -712,3 +712,121 @@ Test Create Default Disk On Labeled Nodes With V2 Data Engine
     And Check all Longhorn CRD removed
     And Install Longhorn
     And Wait for longhorn ready
+Test NVMe TCP IO Queue Count
+    [Documentation]    https://github.com/longhorn/longhorn/issues/13706
+    ...
+    ...                Test Setup:
+    ...                    Create a v2 StorageClass, PVC, and Deployment; wait for the volume to be healthy.
+    ...
+    ...                Step 1 - Record kernel-default queue count:
+    ...                    Read /sys/class/nvme/<ctrl>/queue_count from the volume's instance-manager pod.
+    ...
+    ...                Step 2 - Global setting:
+    ...                    Set default-nvme-tcp-nr-io-queues to {"v2":"2"}, detach and reattach the volume,
+    ...                    verify queue_count is 3 (2 I/O + 1 admin), and write data.
+    ...
+    ...                Step 3 - StorageClass per-volume override:
+    ...                    Create a StorageClass with nvmeTcpNrIoQueues=4, provision a new volume,
+    ...                    verify Volume.spec.nvmeTcpNrIoQueues is 4 and queue_count is 5, and write data.
+    ...
+    ...                Step 4 - Volume spec per-volume override:
+    ...                    Set Volume.spec.nvmeTcpNrIoQueues to 3, detach/reattach, verify queue_count is 4.
+    ...                    Reset to 0, detach/reattach, verify queue_count falls back to the global setting of 3.
+    ...
+    ...                Step 5 - Validation:
+    ...                    Verify that nvmeTcpNrIoQueues values 129 and -1 are rejected by the API.
+    ...
+    ...                Step 6 - Persistence across instance-manager restart:
+    ...                    Set nvmeTcpNrIoQueues=3, detach and reattach the volume, verify queue_count is 4,
+    ...                    delete the instance-manager pod, wait for recovery, and verify queue_count is still 4.
+    ...
+    ...                Step 7 - Maintenance attach:
+    ...                    Detach, attach in maintenance mode, enable the frontend,
+    ...                    and verify queue_count matches the configured value of 4.
+    ...
+    ...                Step 8 - Restore kernel default:
+    ...                    Reset default-nvme-tcp-nr-io-queues to {"v2":"0"}, detach and reattach deployment 0
+    ...                    (spec never changed from 0), and verify queue_count matches the default recorded in Step 1.
+    IF    '${DATA_ENGINE}' == 'v1'
+        Skip    Test only validates on v2 data engine
+    END
+
+    Given Create storageclass longhorn-test with    dataEngine=v2
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-test
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Wait for volume of deployment 0 healthy
+
+    # Step 1: Record the kernel-default NVMe-TCP queue count
+    ${default_queue_count} =    Get NVMe queue count of deployment 0 volume
+    Log    Default NVMe queue count: ${default_queue_count}
+
+    # Step 2: Verify the global NVMe-TCP I/O queue count setting
+    When Setting default-nvme-tcp-nr-io-queues is set to {"v2":"2"}
+    And Scale down deployment 0 to detach volume
+    And Wait for volume of deployment 0 detached
+    And Scale up deployment 0 to attach volume
+    And Wait for volume of deployment 0 healthy
+    # extra one queue for admin queue
+    And Wait for NVMe queue count of deployment 0 volume to be 3
+    And Write 100 MB data to file data.txt in deployment 0
+    And Check deployment 0 data in file data.txt is intact
+
+    # Step 3: Verify per-volume override through StorageClass
+    When Create storageclass longhorn-test-4q with    dataEngine=v2    nvmeTcpNrIoQueues=4
+    And Create persistentvolumeclaim 1    volume_type=RWO    sc_name=longhorn-test-4q
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Wait for volume of deployment 1 healthy
+    And Validate volume spec nvmeTcpNrIoQueues of deployment 1 is 4
+    And Wait for NVMe queue count of deployment 1 volume to be 5
+    And Write 100 MB data to file data.txt in deployment 1
+    And Check deployment 1 data in file data.txt is intact
+
+    # Step 4: Verify per-volume override on an existing volume
+    When Update volume spec nvmeTcpNrIoQueues of deployment 1 to 3
+    And Scale down deployment 1 to detach volume
+    And Wait for volume of deployment 1 detached
+    And Scale up deployment 1 to attach volume
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 4
+
+    When Update volume spec nvmeTcpNrIoQueues of deployment 1 to 0
+    And Scale down deployment 1 to detach volume
+    And Wait for volume of deployment 1 detached
+    And Scale up deployment 1 to attach volume
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 3
+
+    # Step 5: Verify NVMe-TCP I/O queue count validation
+    Run Keyword And Expect Error    *    Update volume spec nvmeTcpNrIoQueues of deployment 1 to 129
+    Run Keyword And Expect Error    *    Update volume spec nvmeTcpNrIoQueues of deployment 1 to -1
+
+    # Step 6: Verify queue count persists across instance-manager restart
+    When Update volume spec nvmeTcpNrIoQueues of deployment 1 to 3
+    And Scale down deployment 1 to detach volume
+    And Wait for volume of deployment 1 detached
+    And Scale up deployment 1 to attach volume
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 4
+    And Delete v2 instance manager of deployment 1 volume
+    And Wait for volume of deployment 1 degraded
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 4
+
+    # Step 7: Verify queue count for maintenance attach
+    When Scale down deployment 1 to detach volume
+    And Wait for volume of deployment 1 detached
+    And Attach deployment 1 volume in maintenance mode
+    And Wait for volume of deployment 1 healthy
+    And Enable frontend of deployment 1 volume
+    And Wait for volume of deployment 1 healthy
+    And Wait for NVMe queue count of deployment 1 volume to be 4
+    And Detach deployment 1 volume
+    And Wait for volume of deployment 1 detached
+
+    # Step 8: Verify kernel-default queue count is restored
+    When Setting default-nvme-tcp-nr-io-queues is set to {"v2":"0"}
+    And Scale down deployment 0 to detach volume
+    And Wait for volume of deployment 0 detached
+    And Scale up deployment 0 to attach volume
+    And Wait for volume of deployment 0 healthy
+    And Wait for NVMe queue count of deployment 0 volume to be ${default_queue_count}


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13783

#### What this PR does / why we need it:

#### Special notes for your reviewer:

This PR has some minor differences from the original [manual test plan](https://github.com/longhorn/longhorn/issues/13706#issuecomment-5300291168):

- Step 1 – Default behavior: Skip comparing the default nvme io queue count with the number of CPU cores. because the kernel default may vary by environment. Instead, record the initial default queue count and verify in end of test case.
- Step 8 – Resource effect: Skip the memory usage comparison because this step is optional and the result may vary depending on the test environment.

#### Additional documentation or context

N/A