### PR TITLE
test(negative): reproduce stuck attach from stale stopped v1 engine record

### DIFF
--- a/e2e/keywords/engine.resource
+++ b/e2e/keywords/engine.resource
@@ -3,6 +3,7 @@ Documentation       Longhorn engine related keywords
 
 Library             ../libs/keywords/common_keywords.py
 Library             ../libs/keywords/engine_keywords.py
+Library             ../libs/keywords/instancemanager_keywords.py
 
 *** Keywords ***
 Engine state should eventually be ${expected_engine_state}
@@ -19,3 +20,16 @@ Engine state should be ${expected_engine_state}
 Volume ${volume_id} engine ${setting_name} should be ${setting_value}
     ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
     validate_engine_setting    ${volume_name}    ${setting_name}    ${setting_value}
+
+Inject stale stopped v1 engine process for volume ${volume_id} on node ${node_id}
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${node_name} =    get_node_by_index    ${node_id}
+    ${engine_name} =    get_engine_name    ${volume_name}
+    create_stale_stopped_engine_process    ${node_name}    ${engine_name}
+
+Volume ${volume_id} engine process should exist on node ${node_id}
+    ${volume_name} =    generate_name_with_suffix    volume    ${volume_id}
+    ${node_name} =    get_node_by_index    ${node_id}
+    ${engine_name} =    get_engine_name    ${volume_name}
+    ${present} =    is_engine_process_present    ${node_name}    ${engine_name}
+    Should Be True    ${present}    Engine process ${engine_name} should exist on node ${node_name}

--- a/e2e/libs/instancemanager/v1_instancemanager.py
+++ b/e2e/libs/instancemanager/v1_instancemanager.py
@@ -6,12 +6,51 @@ from instancemanager.base import Base
 
 from utility.utility import logging
 from utility.utility import subprocess_exec_cmd
+from utility.utility import pod_exec
 import utility.constant as constant
 
 class V1_InstanceManager(Base):
 
     def __init__(self):
         super().__init__()
+
+    def create_stale_stopped_engine_process(self, node_name, engine_name):
+        # Reproduces the leaked `stopped` v1 engine process record from
+        # longhorn/longhorn#13687. A binary that exits 0 immediately makes the v1
+        # process manager keep a `stopped` process record (findProcess/ProcessGet
+        # still answer for it), which is exactly the stale record that wedges attach.
+        # port-count 1 is required so the process manager takes the health-check path
+        # and does not force the record into `running` when there is no listening port.
+        im_pod_name = self.get_instance_manager_pod_on_node(node_name, "v1")
+        logging(f"Injecting stale stopped engine process {engine_name} into v1 instance manager {im_pod_name} on node {node_name}")
+        create_cmd = ("longhorn-instance-manager process create "
+                      f"--name {engine_name} --binary /usr/bin/true --port-count 1")
+        pod_exec(im_pod_name, constant.LONGHORN_NAMESPACE, create_cmd)
+        self.wait_for_engine_process_stopped(node_name, engine_name)
+
+    def wait_for_engine_process_stopped(self, node_name, engine_name):
+        im_pod_name = self.get_instance_manager_pod_on_node(node_name, "v1")
+        get_cmd = f"longhorn-instance-manager process get --name {engine_name}"
+        for i in range(self.retry_count):
+            try:
+                output = pod_exec(im_pod_name, constant.LONGHORN_NAMESPACE, get_cmd)
+                if "stopped" in output.lower():
+                    logging(f"Engine process {engine_name} is in stopped state on node {node_name}")
+                    return
+            except Exception as e:
+                logging(f"Waiting for engine process {engine_name} stopped record on node {node_name}: {e}")
+            time.sleep(self.retry_interval)
+        assert False, f"Engine process {engine_name} did not reach stopped state on node {node_name}"
+
+    def is_engine_process_present(self, node_name, engine_name):
+        im_pod_name = self.get_instance_manager_pod_on_node(node_name, "v1")
+        get_cmd = f"longhorn-instance-manager process get --name {engine_name}"
+        try:
+            output = pod_exec(im_pod_name, constant.LONGHORN_NAMESPACE, get_cmd)
+        except Exception as e:
+            logging(f"Failed to get engine process {engine_name} on node {node_name}: {e}")
+            return False
+        return "cannot find" not in output.lower() and "notfound" not in output.lower()
 
     def get_replicas(self, node_name):
         im_pod_name = self.get_instance_manager_pod_on_node(node_name, "v1")

--- a/e2e/libs/keywords/instancemanager_keywords.py
+++ b/e2e/libs/keywords/instancemanager_keywords.py
@@ -42,6 +42,12 @@ class instancemanager_keywords:
     def get_instance_manager_pod_on_node(self, node_name, engine_type):
         return self.instancemanager.get_instance_manager_pod_on_node(node_name, engine_type)
 
+    def create_stale_stopped_engine_process(self, node_name, engine_name):
+        self.instancemanager.create_stale_stopped_engine_process(node_name, engine_name)
+
+    def is_engine_process_present(self, node_name, engine_name):
+        return self.instancemanager.is_engine_process_present(node_name, engine_name)
+
     def create_orphaned_replica(self, node_name, volume_name, engine_type):
         if engine_type == "v1":
             return self.instancemanager.create_orphaned_replica(node_name, volume_name)

--- a/e2e/tests/negative/stale_stopped_engine_record.robot
+++ b/e2e/tests/negative/stale_stopped_engine_record.robot
@@ -1,0 +1,45 @@
+*** Settings ***
+Documentation    Negative Test Cases
+...
+...              Reference: https://github.com/longhorn/longhorn/issues/13687
+
+Test Tags    negative    volume    v1
+
+Resource    ../keywords/variables.resource
+Resource    ../keywords/common.resource
+Resource    ../keywords/volume.resource
+Resource    ../keywords/engine.resource
+
+Test Setup    Set up test environment
+Test Teardown    Cleanup test resources
+
+*** Test Cases ***
+Attach V1 Volume With Stale Stopped Engine Process Record On Target Node
+    [Documentation]    Reproduce longhorn/longhorn#13687: a stale `stopped` v1 engine
+    ...    process record left in an instance manager registry must not turn
+    ...    createInstance into a silent no-op. Before the fix (v1.12.0/v1.12.1) the
+    ...    volume stays stuck in `attaching` forever; after the fix the stale record is
+    ...    reaped and the attach proceeds.
+    ...
+    ...    1. Given a healthy v1 RWO volume attached to node 0
+    ...    2. And data written to the volume
+    ...    3. When the volume is detached
+    ...    4. And a stale stopped engine process record is injected into node 1 instance manager
+    ...    5. And the volume is attached to node 1
+    ...    6. Then the volume should become healthy (fails on v1.12.0/v1.12.1, passes with the fix)
+    ...    7. And the volume data should be intact
+    Given Create volume 0 with    dataEngine=v1    numberOfReplicas=2    accessMode=RWO
+    And Attach volume 0 to node 0
+    And Wait for volume 0 healthy
+    And Write data 0 to volume 0
+
+    When Detach volume 0
+    And Wait for volume 0 detached
+
+    And Inject stale stopped v1 engine process for volume 0 on node 1
+    And Volume 0 engine process should exist on node 1
+
+    And Attach volume 0 to node 1
+    Then Wait for volume 0 healthy
+    And Volume 0 should be attached to node 1
+    And Check volume 0 data is data 0


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13687 https://github.com/longhorn/longhorn/issues/13688

#### What this PR does / why we need it:


Add an e2e case for longhorn/longhorn#13687. It injects a leaked `stopped` v1 engine process record into the target node's instance manager (via `longhorn-instance-manager process create` with a binary that exits 0, using `--port-count 1` so the record settles in `stopped` rather than `running`), then attaches the volume to that node and asserts it becomes healthy.

On v1.12.0/v1.12.1 the volume stays wedged in `attaching` and the case fails; with the longhorn-manager fix that reaps the stale record, the attach proceeds and the case passes.

Adds injection/query helpers to the v1 instance manager lib, exposes them through instancemanager_keywords, and wires up the engine.resource keywords.

#### Special notes for your reviewer:

#### Additional documentation or context
