### PR TITLE
testg(robot): print the selected test cases before the execution starts

### DIFF
--- a/e2e/libs/test_lister.py
+++ b/e2e/libs/test_lister.py
@@ -1,0 +1,34 @@
+from robot.api import SuiteVisitor
+from robot.api.logger import console
+
+
+class _TestCollector(SuiteVisitor):
+
+    def __init__(self):
+        self.tests = []
+
+    def visit_test(self, test):
+        self.tests.append((test.longname, sorted(test.tags)))
+
+
+class TestLister:
+    """Listener printing the selected test cases before the execution starts.
+
+    A listener is used instead of a pre-run modifier because pre-run modifiers run
+    before the --include/--exclude/--suite/--test filtering is applied, so they
+    cannot report what is actually going to be run.
+
+    Usage: robot --listener test_lister.TestLister ...
+    """
+
+    ROBOT_LISTENER_API_VERSION = 3
+
+    def start_suite(self, data, result):
+        if data.parent is not None:
+            return
+        collector = _TestCollector()
+        data.visit(collector)
+        console(f"\n{'=' * 78}\nSelected {len(collector.tests)} test case(s)\n{'=' * 78}")
+        for index, (name, tags) in enumerate(collector.tests, start=1):
+            console(f"{index:4d}. {name}    [{', '.join(tags) if tags else '-'}]")
+        console("=" * 78)

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -30,4 +30,4 @@ for ((i=0; i<count; i++)); do
   tests+=("./tests")
 done
 
-robot -x junit.xml -P ./libs -d /tmp/test-report "${args[@]}" "${tests[@]}"
+robot -x junit.xml -P ./libs --listener test_lister.TestLister -d /tmp/test-report "${args[@]}" "${tests[@]}"


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

Add a listener that prints the test cases selected by the --include/--exclude/ --suite/--test options, so it is clear from the console log what is going to be run before the first test case starts.

A listener is used instead of a pre-run modifier because pre-run modifiers run before the filtering is applied and would report the unfiltered test cases.


e.g.

```
pod/longhorn-test condition met
+ [[ manifest == \r\a\n\c\h\e\r ]]
++ kubectl get pod longhorn-test '-o=jsonpath={.status.containerStatuses[?(@.name=="longhorn-test")].state}'
++ grep -v terminated
+ [[ -n {"running":{"startedAt":"2026-08-30T07:39:43Z"}} ]]
+ kubectl logs longhorn-test -c longhorn-test --follow --since=10s
==============================================================================
Tests                                                                         
==============================================================================

==============================================================================
Selected 12 test case(s)
==============================================================================
   1. Tests.Negative.Test Dr Volume.DR Volume Node Reboot During Initial Restoration    [backup, dr-volume, manual, negative]
   2. Tests.Negative.Test Dr Volume.DR Volume Node Reboot During Incremental Restoration    [backup, dr-volume, manual, negative]
   3. Tests.Negative.Test Dr Volume.Sync Up With Backup Target During DR Volume Activation    [backup, dr-volume, manual, negative]
   4. Tests.Negative.Test Dr Volume.Test DR Volume Live Upgrade And Rebuild    [backup, dr-volume, expansion, manual, negative, upgrade]
   5. Tests.Negative.Test Dr Volume.Test DR Volume Incremental Restore After Source Volume Expansion    [backup, dr-volume, expansion, manual, negative]
   6. Tests.Negative.Test Dr Volume.Activate Degraded DR Volume With Failed Replica Node    [backup, dr-volume, manual, negative]
   7. Tests.Negative.Uninstallation Checks.Uninstallation Checks    [backup, dr-volume, negative, uninstall]
   8. Tests.Regression.Test Backup.Test Incremental Restore    [backup, dr-volume, regression]
   9. Tests.Regression.Test Backup.Test DR Volume Backup Block Size    [backup, dr-volume, regression]
  10. Tests.Regression.Test Encrypted Volume.Test Encrypted DR Volume Activation    [backup, dr-volume, encrypted, regression, restore, rwo]
  11. Tests.Regression.Test Encrypted Volume.Test Encrypted Volume Upgrade - DR Volume    [backup, dr-volume, encrypted, expansion, regression, replica-rebuild, restore, rwo, upgrade]
  12. Tests.Regression.Test System Backup.Test Create System Backup With DR Volume    [dr-volume, regression, system_backup]
==============================================================================
Tests.Negative                                                                
==============================================================================
Initialized in-cluster k8s api client
Tests.Negative.Test Dr Volume :: Test DR volume                               
==============================================================================
DR Volume Node Reboot During Initial Restoration :: Test DR volume... Setting default backuptarget to {'spec': {'backupTargetURL': 's3://backupbucket@us-east-1/backupstore', 'credentialSecret': 'minio-secret', 'pollInterval': '30s'}} ... (0)
```


#### Special notes for your reviewer:

#### Additional documentation or context
