### PR TITLE
Revert "fix(pytest): remove trailing slash from DEFAULT_DISK_PATH default"

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -58,7 +58,7 @@ spec:
     - name: RESOURCE_SUFFIX
       value: ""
     - name: DEFAULT_DATA_PATH
-      value: "/var/lib/longhorn"
+      value: "/var/lib/longhorn/"
     volumeMounts:
     - name: dev
       mountPath: /dev

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -147,7 +147,7 @@ WAIT_FOR_POD_STABLE_MAX_RETRY = 90
 DEFAULT_VOLUME_SIZE = 3  # In Gi
 EXPANDED_VOLUME_SIZE = 4  # In Gi
 
-DEFAULT_DISK_PATH = os.environ.get('DEFAULT_DATA_PATH', '/var/lib/longhorn')
+DEFAULT_DISK_PATH = os.environ.get('DEFAULT_DATA_PATH', '/var/lib/longhorn/')
 DIRECTORY_PATH = os.path.join(DEFAULT_DISK_PATH, 'longhorn-test')
 
 VOLUME_CONDITION_SCHEDULED = "Scheduled"

--- a/manager/integration/tests/test_node.py
+++ b/manager/integration/tests/test_node.py
@@ -17,6 +17,7 @@ from common import get_core_api_client, get_longhorn_api_client, \
     get_self_host_id, get_apps_api_client
 from common import SETTING_STORAGE_OVER_PROVISIONING_PERCENTAGE, \
     SETTING_STORAGE_MINIMAL_AVAILABLE_PERCENTAGE, \
+    SETTING_DEFAULT_DATA_PATH, \
     SETTING_CREATE_DEFAULT_DISK_LABELED_NODES, \
     DEFAULT_STORAGE_OVER_PROVISIONING_PERCENTAGE, \
     SETTING_DISABLE_SCHEDULING_ON_CORDONED_NODE, \
@@ -139,12 +140,16 @@ def reset_disk_settings():
     api = get_longhorn_api_client()
     setting = api.by_id_setting(SETTING_CREATE_DEFAULT_DISK_LABELED_NODES)
     api.update(setting, value="false")
+    setting = api.by_id_setting(SETTING_DEFAULT_DATA_PATH)
+    api.update(setting, value=DEFAULT_DISK_PATH)
 
     yield
 
     api = get_longhorn_api_client()
     setting = api.by_id_setting(SETTING_CREATE_DEFAULT_DISK_LABELED_NODES)
     api.update(setting, value="false")
+    setting = api.by_id_setting(SETTING_DEFAULT_DATA_PATH)
+    api.update(setting, value=DEFAULT_DISK_PATH)
 
 
 def get_default_disk_path():
@@ -1529,20 +1534,21 @@ def test_replica_datapath_cleanup(client):  # NOQA
 
 @pytest.mark.v2_volume_test   # NOQA
 @pytest.mark.node  # NOQA
-def test_node_default_disk_labeled(client, core_api, reset_default_disk_label,  reset_disk_settings):  # NOQA
+def test_node_default_disk_labeled(client, core_api, random_disk_path,  reset_default_disk_label,  reset_disk_settings):  # NOQA
     """
     Test node feature: create default Disk according to the node label
 
-    Makes sure the created Disk is at the Default Data Path.
+    Makes sure the created Disk matches the Default Data Path Setting.
 
     1. Add labels to node 0 and 1, don't add label to node 2.
     2. Remove all the disks on node 1 and 2.
         1. The initial default disk will not be recreated.
-    3. Set setting `create default disk labeled node` to true.
-    4. Check node 0. It should still use the previous default disk path.
+    3. Set setting `default disk path` to a random disk path.
+    4. Set setting `create default disk labeled node` to true.
+    5. Check node 0. It should still use the previous default disk path.
         1. Due to we didn't remove the disk from node 0.
-    5. Check node 1. A new disk should be created at the default disk path.
-    6. Check node 2. There is still no disks
+    6. Check node 1. A new disk should be created at the random disk path.
+    7. Check node 2. There is still no disks
     """
     # Set up cases.
     cases = {
@@ -1579,6 +1585,8 @@ def test_node_default_disk_labeled(client, core_api, reset_default_disk_label,  
     cleanup_node_disks(client, node.id)
 
     # Set disk creation and path Settings.
+    setting = client.by_id_setting(SETTING_DEFAULT_DATA_PATH)
+    client.update(setting, value=random_disk_path)
     setting = client.by_id_setting(SETTING_CREATE_DEFAULT_DISK_LABELED_NODES)
     client.update(setting, value="true")
     wait_for_disk_update(client, cases["labeled"], 1)
@@ -1598,7 +1606,7 @@ def test_node_default_disk_labeled(client, core_api, reset_default_disk_label,  
     node = client.by_id_node(cases["labeled"])
     assert len(node.disks) == 1
     assert node.disks[list(node.disks)[0]].path == \
-        DEFAULT_DISK_PATH
+        random_disk_path
 
     # Remove the Disk from the Node used for this test case so we can have the
     # fixtures clean up after.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
This revert PR https://github.com/longhorn/longhorn-tests/pull/3551

longhorn/longhorn#13910

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
https://github.com/longhorn/longhorn/issues/13910
https://github.com/longhorn/longhorn/issues/9083#issuecomment-5404695306
