### PR TITLE
test(negative): cover longhorn-global-manager component

### DIFF
--- a/e2e/keywords/longhorn.resource
+++ b/e2e/keywords/longhorn.resource
@@ -18,6 +18,7 @@ Library             ../libs/keywords/engine_keywords.py
 ...    csi-snapshotter
 ...    longhorn-driver-deployer
 ...    longhorn-csi-plugin
+...    longhorn-global-manager
 ...    longhorn-manager
 ...    longhorn-ui
 
@@ -138,6 +139,14 @@ Delete ${engine_type} instance manager of deployment ${deployment_id} volume
 Wait for Longhorn components all running
     ${longhorn_namespace} =    get_longhorn_namespace
     wait_for_namespace_pods_running    ${longhorn_namespace}
+
+Get Longhorn global manager lease holder
+    ${holder} =    get_global_manager_lease_holder
+    RETURN    ${holder}
+
+Wait for Longhorn global manager lease holder changed from ${old_holder}
+    ${holder} =    wait_for_global_manager_lease_holder_changed    ${old_holder}
+    RETURN    ${holder}
 
 Install Longhorn stable version
     [Arguments]    &{config}

--- a/e2e/libs/k8s/k8s.py
+++ b/e2e/libs/k8s/k8s.py
@@ -369,6 +369,21 @@ def get_pods_by_label_selector(label_selector, namespace=constant.LONGHORN_NAMES
     pods = list_namespaced_pod(namespace=namespace, label_selector=label_selector)
     return [pod.metadata.name for pod in pods]
 
+def get_lease_holder(lease_name, namespace=constant.LONGHORN_NAMESPACE):
+    api = client.CoordinationV1Api()
+    lease = api.read_namespaced_lease(lease_name, namespace)
+    return lease.spec.holder_identity
+
+def wait_for_lease_holder_changed(lease_name, old_holder, namespace=constant.LONGHORN_NAMESPACE):
+    retry_count, retry_interval = get_retry_count_and_interval()
+    for i in range(retry_count):
+        holder = get_lease_holder(lease_name, namespace)
+        logging(f"Waiting for lease {lease_name} holder changed from {old_holder}, current holder is {holder} ... ({i})")
+        if holder and holder != old_holder:
+            return holder
+        time.sleep(retry_interval)
+    assert False, f"Lease {lease_name} holder did not change from {old_holder}"
+
 def verify_pods_log_after_time_contains(label_selector, expect_log, test_start_time, namespace=constant.LONGHORN_NAMESPACE, container=None):
     pods = get_pods_by_label_selector(label_selector, namespace)
     if not pods:

--- a/e2e/libs/keywords/k8s_keywords.py
+++ b/e2e/libs/keywords/k8s_keywords.py
@@ -25,6 +25,8 @@ from k8s.k8s import remove_longhorn_component_resources_limit
 from k8s.k8s import verify_pod_log_after_time_not_contains
 from k8s.k8s import is_namespaced_pods_all_running
 from k8s.k8s import get_pods_by_label_selector
+from k8s.k8s import get_lease_holder
+from k8s.k8s import wait_for_lease_holder_changed
 from k8s.k8s import verify_pods_log_after_time_contains
 from k8s.k8s import verify_pods_log_after_time_not_contains
 from k8s.k8s import wait_for_node_ready
@@ -204,6 +206,15 @@ class k8s_keywords:
 
     def get_longhorn_ui_pods(self, namespace=constant.LONGHORN_NAMESPACE):
         return get_pods_by_label_selector(constant.LABEL_SELECTOR_LONGHORN_UI, namespace)
+
+    def get_longhorn_global_manager_pods(self, namespace=constant.LONGHORN_NAMESPACE):
+        return get_pods_by_label_selector(constant.LABEL_SELECTOR_GLOBAL_MANAGER, namespace)
+
+    def get_global_manager_lease_holder(self, namespace=constant.LONGHORN_NAMESPACE):
+        return get_lease_holder(constant.GLOBAL_MANAGER_LEASE_NAME, namespace)
+
+    def wait_for_global_manager_lease_holder_changed(self, old_holder, namespace=constant.LONGHORN_NAMESPACE):
+        return wait_for_lease_holder_changed(constant.GLOBAL_MANAGER_LEASE_NAME, old_holder, namespace)
 
     def get_pods_by_label_selector(self, label_selector, namespace=constant.LONGHORN_NAMESPACE):
         return get_pods_by_label_selector(label_selector, namespace)

--- a/e2e/libs/metrics/metrics.py
+++ b/e2e/libs/metrics/metrics.py
@@ -172,6 +172,8 @@ def get_longhorn_components_memory_cpu_usage():
             name = "longhorn-csi-plugin"
         elif name.startswith("longhorn-driver-deployer"):
             name = "longhorn-driver-deployer"
+        elif name.startswith("longhorn-global-manager"):
+            name = "longhorn-global-manager"
         elif name.startswith("longhorn-manager"):
             name = "longhorn-manager"
         elif name.startswith("longhorn-ui"):
@@ -303,6 +305,14 @@ def check_longhorn_components_memory_cpu_usage():
         high_usage = high_usage or is_high_resource_consumption("longhorn-driver-deployer", "memory",
             usage["longhorn-driver-deployer"]["memory"],
             old_usage["longhorn-driver-deployer"]["memory"])
+
+    if "longhorn-global-manager" in usage and "longhorn-global-manager" in old_usage:
+        high_usage = high_usage or is_high_resource_consumption("longhorn-global-manager", "cpu",
+            usage["longhorn-global-manager"]["cpu"],
+            old_usage["longhorn-global-manager"]["cpu"])
+        high_usage = high_usage or is_high_resource_consumption("longhorn-global-manager", "memory",
+            usage["longhorn-global-manager"]["memory"],
+            old_usage["longhorn-global-manager"]["memory"])
 
     if "longhorn-manager" in usage and "longhorn-manager" in old_usage:
         high_usage = high_usage or is_high_resource_consumption("longhorn-manager", "cpu",

--- a/e2e/libs/utility/constant.py
+++ b/e2e/libs/utility/constant.py
@@ -43,7 +43,10 @@ LABEL_SELECTOR_CSI_PROVISIONER = "app=csi-provisioner"
 LABEL_SELECTOR_CSI_RESIZER = "app=csi-resizer"
 LABEL_SELECTOR_CSI_SNAPSHOTTER = "app=csi-snapshotter"
 LABEL_SELECTOR_DRIVER_DEPLOYER = "app=longhorn-driver-deployer"
+LABEL_SELECTOR_GLOBAL_MANAGER = "app=longhorn-global-manager"
 LABEL_SELECTOR_LONGHORN_UI = "app=longhorn-ui"
+
+GLOBAL_MANAGER_LEASE_NAME = "longhorn-global-manager"
 
 DISK_UNSCHEDULABLE_KEEP_ROUNDS = 30
 

--- a/e2e/tests/negative/component_resilience.robot
+++ b/e2e/tests/negative/component_resilience.robot
@@ -80,6 +80,7 @@ Test Longhorn Components Recovery
     And Delete Longhorn component instance-manager pod on node 1
     And Delete Longhorn Deployment longhorn-ui pod
     And Delete Longhorn Deployment longhorn-driver-deployer pod
+    And Delete Longhorn Deployment longhorn-global-manager pod
 
     Then Wait for Longhorn components all running
     And Wait for volume 0 healthy
@@ -195,3 +196,37 @@ Test Longhorn Dynamic Provisioned RWO Volume Recovery
     When Delete replica of deployment 0 volume on replica node
     And Wait until volume of deployment 0 replica rebuilding started on replica node
     Then Delete ${DATA_ENGINE} instance manager of deployment 0 volume and wait for recover
+
+Test Longhorn Global Manager Leader Failover
+    [Tags]    sharemanager
+    [Documentation]    -- Manual test plan --
+    ...                Test data setup:
+    ...                    Deploy Longhorn on a 3 nodes cluster.
+    ...                    Create a RWO volume using the Longhorn storage class(deployment 0)
+    ...
+    ...                    Write some data in the volume created and record the data.
+    ...                    Have the volume in attached state.
+    ...
+    ...                Test steps:
+    ...                    Delete the longhorn-global-manager leader pod and verify one of the standby pods takes over the lease.
+    ...                    Create a RWX volume using the Longhorn storage class(deployment 1) and verify it becomes ready under the new leader.
+    ...                    Delete the IM of the RWO volume and verify the workload remounts and recovers under the new leader.
+    Given Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    volume_type=RWO    sc_name=longhorn-test
+    And Create deployment 0 with persistentvolumeclaim 0
+    And Write 100 MB data to file data.txt in deployment 0
+
+    ${leader_pod} =    Get Longhorn global manager lease holder
+    ${global_manager_pods} =    get_longhorn_global_manager_pods
+    ${longhorn_namespace} =    get_longhorn_namespace
+    When delete_pod    ${leader_pod}    ${longhorn_namespace}
+    ${new_leader_pod} =    Wait for Longhorn global manager lease holder changed from ${leader_pod}
+    Then List Should Contain Value    ${global_manager_pods}    ${new_leader_pod}
+
+    When Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-test
+    And Create deployment 1 with persistentvolumeclaim 1
+    And Write 100 MB data to file data.txt in deployment 1
+    Then Check deployment 1 data in file data.txt is intact
+
+    Then Delete ${DATA_ENGINE} instance manager of deployment 0 volume and wait for recover
+    And Wait for Longhorn components all running

--- a/e2e/tests/negative/component_resilience.robot
+++ b/e2e/tests/negative/component_resilience.robot
@@ -208,7 +208,7 @@ Test Longhorn Global Manager Leader Failover
     ...                    Have the volume in attached state.
     ...
     ...                Test steps:
-    ...                    Delete the longhorn-global-manager leader pod and verify one of the standby pods takes over the lease.
+    ...                    Delete the longhorn-global-manager leader pod and verify another replica takes over the lease.
     ...                    Create a RWX volume using the Longhorn storage class(deployment 1) and verify it becomes ready under the new leader.
     ...                    Delete the IM of the RWO volume and verify the workload remounts and recovers under the new leader.
     Given Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}
@@ -217,10 +217,11 @@ Test Longhorn Global Manager Leader Failover
     And Write 100 MB data to file data.txt in deployment 0
 
     ${leader_pod} =    Get Longhorn global manager lease holder
-    ${global_manager_pods} =    get_longhorn_global_manager_pods
     ${longhorn_namespace} =    get_longhorn_namespace
     When delete_pod    ${leader_pod}    ${longhorn_namespace}
     ${new_leader_pod} =    Wait for Longhorn global manager lease holder changed from ${leader_pod}
+    And Wait for Longhorn components all running
+    ${global_manager_pods} =    get_longhorn_global_manager_pods
     Then List Should Contain Value    ${global_manager_pods}    ${new_leader_pod}
 
     When Create persistentvolumeclaim 1    volume_type=RWX    sc_name=longhorn-test

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4360,6 +4360,7 @@ def check_longhorn(core_api):
     ready = False
     has_engine_image = False
     has_driver_deployer = False
+    has_global_manager = False
     has_manager = False
     has_ui = False
     has_instance_manager = False
@@ -4381,6 +4382,9 @@ def check_longhorn(core_api):
                 elif labels.get('app', '') == 'longhorn-driver-deployer' \
                         and item.status.phase == "Running":
                     has_driver_deployer = True
+                elif labels.get('app', '') == 'longhorn-global-manager' \
+                        and item.status.phase == "Running":
+                    has_global_manager = True
                 elif labels.get('app', '') == 'longhorn-manager' \
                         and item.status.phase == "Running":
                     has_manager = True
@@ -4392,7 +4396,8 @@ def check_longhorn(core_api):
                         and item.status.phase == "Running":
                     has_instance_manager = True
 
-            if has_engine_image and has_driver_deployer and has_manager and \
+            if has_engine_image and has_driver_deployer and \
+                    has_global_manager and has_manager and \
                     has_ui and has_instance_manager and pod_running:
                 ready = True
                 break

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -4357,10 +4357,22 @@ def find_replica_for_backup(client, volume_name, backup_id):
 
 
 def check_longhorn(core_api):
+    # Longhorn before v1.13 has no longhorn-global-manager Deployment, and
+    # the upgrade test runs this check against such a version before
+    # upgrading. Require the component only when its Deployment exists.
+    try:
+        get_apps_api_client().read_namespaced_deployment(
+            'longhorn-global-manager', 'longhorn-system')
+        need_global_manager = True
+    except ApiException as e:
+        if e.status != 404:
+            raise
+        need_global_manager = False
+
     ready = False
     has_engine_image = False
     has_driver_deployer = False
-    has_global_manager = False
+    has_global_manager = not need_global_manager
     has_manager = False
     has_ui = False
     has_instance_manager = False


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13059

#### What this PR does / why we need it:

Registers the `longhorn-global-manager` Deployment introduced by longhorn/longhorn#13100 in the component inventories (`longhorn_workloads`, resource-usage metrics, pytest `check_longhorn`) and includes it in the `Test Longhorn Components Recovery` deletion list.

Adds a `Test Longhorn Global Manager Leader Failover` case: delete the lease-holding pod, verify a standby takes over the `longhorn-global-manager` lease, then verify the controllers hosted by the new leader — the Kubernetes PV controller by a RWX volume created after the failover becoming ready, and the Kubernetes pod controller by workload remount recovery after instance-manager deletion.

#### Special notes for your reviewer:

The added cases need the `longhorn-global-manager` Deployment introduced by longhorn/longhorn#13100, so please merge this after that chart PR. Until then they fail on a master-manifest installation.

#### Additional documentation or context

Verified on a 4-node k3s v1.35 cluster with the PR builds: the leader-failover case, `Test Longhorn Components Recovery` (including the added deletion), and resource-usage recording all pass.