### PR TITLE
ci: fix SLE Micro K3s deployment on AWS

### DIFF
--- a/test_framework/terraform/aws/sle-micro/instances.tf
+++ b/test_framework/terraform/aws/sle-micro/instances.tf
@@ -130,7 +130,7 @@ resource "null_resource" "registration_controlplane" {
     connection {
       type     = "ssh"
       user     = "ec2-user"
-      host     = aws_eip.lh_aws_eip_controlplane[0].public_ip
+      host     = aws_eip.lh_aws_eip_controlplane[count.index].public_ip
       private_key = file(var.aws_ssh_private_key_file_path)
     }
   }

--- a/test_framework/terraform/aws/sle-micro/main.tf
+++ b/test_framework/terraform/aws/sle-micro/main.tf
@@ -189,7 +189,7 @@ resource "aws_key_pair" "lh_aws_pair_key" {
 
 resource "aws_eip" "lh_aws_eip_controlplane" {
   count    = var.lh_aws_instance_count_controlplane
-  vpc      = true
+  domain   = "vpc"
 
   tags = {
     Name = "lh_aws_eip_controlplane-${count.index}-${random_string.random_suffix.id}"

--- a/test_framework/terraform/aws/sle-micro/user-data-scripts/provision_k3s_agent.sh.tpl
+++ b/test_framework/terraform/aws/sle-micro/user-data-scripts/provision_k3s_agent.sh.tpl
@@ -21,33 +21,34 @@ sudo sh -c "echo "vm.nr_hugepages=1024" >> /etc/sysctl.conf"
 
 if [[ "${extra_block_device}" != true ]]; then
   if [[ -b "/dev/nvme1n1" ]]; then
-    mkfs.ext4 -E nodiscard /dev/nvme1n1
-    mkdir /mnt/sda1
-    mount /dev/nvme1n1 /mnt/sda1
+    sudo mkfs.ext4 -E nodiscard /dev/nvme1n1
+    sudo mkdir -p /mnt/sda1
+    sudo mount /dev/nvme1n1 /mnt/sda1
 
-    mkdir /mnt/sda1/local
-    mkdir /opt/local-path-provisioner
-    mount --bind /mnt/sda1/local /opt/local-path-provisioner
+    sudo mkdir -p /mnt/sda1/local
+    sudo mkdir -p /opt/local-path-provisioner
+    sudo mount --bind /mnt/sda1/local /opt/local-path-provisioner
 
-    mkdir /mnt/sda1/longhorn
-    mkdir /var/lib/longhorn
-    mount --bind /mnt/sda1/longhorn /var/lib/longhorn
+    sudo mkdir -p /mnt/sda1/longhorn
+    sudo mkdir -p /var/lib/longhorn
+    sudo mount --bind /mnt/sda1/longhorn /var/lib/longhorn
   elif [ -b "/dev/xvdh" ]; then
-    mkfs.ext4 -E nodiscard /dev/xvdh
-    mkdir /var/lib/longhorn
-    mount /dev/xvdh /var/lib/longhorn
+    sudo mkfs.ext4 -E nodiscard /dev/xvdh
+    sudo mkdir -p /var/lib/longhorn
+    sudo mount /dev/xvdh /var/lib/longhorn
   fi
 fi
 
-mkdir -p /etc/rancher/k3s
+sudo mkdir -p /etc/rancher/k3s
 
-cat <<EOF >> /etc/rancher/k3s/config.yaml
+sudo sh -c "cat > /etc/rancher/k3s/config.yaml <<EOF
 server: ${k3s_server_url}
 token: ${k3s_cluster_secret}
 kubelet-arg:
   - cpu-manager-policy=none
   - reserved-cpus=0
 EOF
+"
 
 curl -sfL https://get.k3s.io | sudo INSTALL_K3S_EXEC="agent" INSTALL_K3S_VERSION="${k3s_version}" sh -
 sudo systemctl start k3s-agent


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
- Fix controlplane SSH connection to use `count.index`
- Update EIP to use 'domain' instead of deprecated 'vpc' parameter
- Add sudo permissions for k3s agent provisioning operations

#### Special notes for your reviewer:

#### Additional documentation or context
