### PR TITLE
test(robot): sync RecurringJob group labels from PVC without source

### DIFF
--- a/e2e/keywords/persistentvolumeclaim.resource
+++ b/e2e/keywords/persistentvolumeclaim.resource
@@ -128,3 +128,11 @@ Wait for persistentvolumeclaim ${claim_id} status to be ${phase}
     wait_for_pvc_status_phase    ${claim_name}    ${phase}
 
 
+
+Label persistentvolumeclaim ${claim_id} with ${label_key} ${label_value}
+    ${claim_name} =     generate_name_with_suffix    claim    ${claim_id}
+    set_persistentvolumeclaim_label    ${claim_name}    ${label_key}    ${label_value}
+
+Check persistentvolumeclaim ${claim_id} has label ${label_key} ${label_value}
+    ${claim_name} =     generate_name_with_suffix    claim    ${claim_id}
+    check_persistentvolumeclaim_has_label    ${claim_name}    ${label_key}    ${label_value}

--- a/e2e/libs/keywords/persistentvolumeclaim_keywords.py
+++ b/e2e/libs/keywords/persistentvolumeclaim_keywords.py
@@ -1,3 +1,6 @@
+import ast
+import time
+
 from persistentvolumeclaim import PersistentVolumeClaim
 from volume import Volume
 
@@ -26,9 +29,28 @@ class persistentvolumeclaim_keywords:
             if volume_name is not None:
                 self.volume.wait_for_volume_deleted(volume_name)
 
-    def create_persistentvolumeclaim(self, name, volume_type="RWO", sc_name="longhorn", storage_size="3GiB", dataSourceName=None, dataSourceKind=None, volumeMode="Filesystem", wait_for_bound=True):
+    def create_persistentvolumeclaim(self, name, volume_type="RWO", sc_name="longhorn", storage_size="3GiB", dataSourceName=None, dataSourceKind=None, volumeMode="Filesystem", wait_for_bound=True, labels=None):
+        if isinstance(labels, str):
+            labels = ast.literal_eval(labels)
         logging(f'Creating {volume_type} persistentvolumeclaim {name} with {sc_name} storageclass')
-        return self.claim.create(name, volume_type, sc_name, storage_size, dataSourceName, dataSourceKind, volumeMode, wait_for_bound)
+        return self.claim.create(name, volume_type, sc_name, storage_size, dataSourceName, dataSourceKind, volumeMode, wait_for_bound, labels=labels)
+
+    def set_persistentvolumeclaim_label(self, claim_name, label_key, label_value):
+        logging(f'Setting persistentvolumeclaim {claim_name} label {label_key}={label_value}')
+        self.claim.set_label(claim_name, label_key, label_value)
+
+    def check_persistentvolumeclaim_has_label(self, claim_name, label_key, label_value):
+        logging(f'Checking persistentvolumeclaim {claim_name} has label {label_key}={label_value}')
+        for i in range(self.claim.retry_count):
+            claim = self.claim.get(claim_name)
+            labels = claim.metadata.labels or {}
+            if labels.get(label_key) == label_value:
+                return
+            logging(f'Waiting for pvc {claim_name} label {label_key}={label_value}, current={labels} ... ({i})')
+            time.sleep(self.claim.retry_interval)
+        claim = self.claim.get(claim_name)
+        labels = claim.metadata.labels or {}
+        assert False, f"Failed to find label {label_key}={label_value} on PVC {claim_name}, current={labels}"
 
     def delete_persistentvolumeclaim(self, name):
         logging(f'Deleting persistentvolumeclaim {name}')

--- a/e2e/libs/keywords/persistentvolumeclaim_keywords.py
+++ b/e2e/libs/keywords/persistentvolumeclaim_keywords.py
@@ -30,8 +30,13 @@ class persistentvolumeclaim_keywords:
                 self.volume.wait_for_volume_deleted(volume_name)
 
     def create_persistentvolumeclaim(self, name, volume_type="RWO", sc_name="longhorn", storage_size="3GiB", dataSourceName=None, dataSourceKind=None, volumeMode="Filesystem", wait_for_bound=True, labels=None):
-        if isinstance(labels, str):
-            labels = ast.literal_eval(labels)
+        if labels is not None:
+            if isinstance(labels, str):
+                try:
+                    labels = ast.literal_eval(labels)
+                except (SyntaxError, ValueError) as e:
+                    raise AssertionError(f"labels must be a dict literal, got {labels!r}: {e}") from e
+            assert isinstance(labels, dict), f"labels must be a dict, got {type(labels).__name__}: {labels!r}"
         logging(f'Creating {volume_type} persistentvolumeclaim {name} with {sc_name} storageclass')
         return self.claim.create(name, volume_type, sc_name, storage_size, dataSourceName, dataSourceKind, volumeMode, wait_for_bound, labels=labels)
 

--- a/e2e/libs/persistentvolumeclaim/persistentvolumeclaim.py
+++ b/e2e/libs/persistentvolumeclaim/persistentvolumeclaim.py
@@ -32,6 +32,7 @@ class PersistentVolumeClaim():
             # add label
             manifest_dict['metadata']['labels'][LABEL_TEST] = LABEL_TEST_VALUE
             if labels:
+                assert isinstance(labels, dict), f"labels must be a dict, got {type(labels).__name__}: {labels!r}"
                 manifest_dict['metadata']['labels'].update(labels)
 
             # correct storageclass name

--- a/e2e/libs/persistentvolumeclaim/persistentvolumeclaim.py
+++ b/e2e/libs/persistentvolumeclaim/persistentvolumeclaim.py
@@ -18,7 +18,7 @@ class PersistentVolumeClaim():
         self.core_v1_api = client.CoreV1Api()
         self.retry_count, self.retry_interval = get_retry_count_and_interval()
 
-    def create(self, name, volume_type, sc_name, storage_size="3GiB", dataSourceName=None, dataSourceKind=None, volumeMode="Filesystem", wait_for_bound=True, volume_name=None):
+    def create(self, name, volume_type, sc_name, storage_size="3GiB", dataSourceName=None, dataSourceKind=None, volumeMode="Filesystem", wait_for_bound=True, volume_name=None, labels=None):
         storage_size_bytes = convert_size_to_bytes(storage_size)
 
         filepath = "./templates/workload/pvc.yaml"
@@ -31,6 +31,8 @@ class PersistentVolumeClaim():
 
             # add label
             manifest_dict['metadata']['labels'][LABEL_TEST] = LABEL_TEST_VALUE
+            if labels:
+                manifest_dict['metadata']['labels'].update(labels)
 
             # correct storageclass name
             manifest_dict['spec']['storageClassName'] = sc_name

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -978,13 +978,14 @@ class CRD(Base):
 
     def check_volume_has_recurringjob(self, volume_name, job_name):
         logging(f"Checking volume {volume_name} has recurring job {job_name}")
+        jobs = []
         for i in range(self.retry_count):
             jobs = self.get_volume_recurringjobs(volume_name)
             if job_name in jobs:
                 return
-            logging(f"Failed to find recurring job {job_name} for volume {volume_name} ... ({i})")
+            logging(f"Waiting for volume {volume_name} recurring job {job_name}, current={jobs} ... ({i})")
             time.sleep(self.retry_interval)
-        assert False, f"Failed to find recurring job {job_name} for volume {volume_name}"
+        assert False, f"Timed out waiting for recurring job {job_name} on volume {volume_name}, current={jobs}"
 
     def get_volume_recurringjob_groups(self, volume_name):
         cmd = f"kubectl get volumes -n {constant.LONGHORN_NAMESPACE} {volume_name} -o yaml"
@@ -995,13 +996,14 @@ class CRD(Base):
 
     def check_volume_has_recurringjob_group(self, volume_name, job_group_name):
         logging(f"Checking volume {volume_name} has recurring job group {job_group_name}")
+        job_groups = []
         for i in range(self.retry_count):
             job_groups = self.get_volume_recurringjob_groups(volume_name)
             if job_group_name in job_groups:
                 return
-            logging(f"Failed to find recurring job group {job_group_name} for volume {volume_name} ... ({i})")
+            logging(f"Waiting for volume {volume_name} recurring job group {job_group_name}, current={job_groups} ... ({i})")
             time.sleep(self.retry_interval)
-        assert False, f"Failed to find recurring job group {job_group_name} for volume {volume_name}"
+        assert False, f"Timed out waiting for recurring job group {job_group_name} on volume {volume_name}, current={job_groups}"
 
     def get_state(self, volume_name):
         """

--- a/e2e/libs/volume/crd.py
+++ b/e2e/libs/volume/crd.py
@@ -978,11 +978,13 @@ class CRD(Base):
 
     def check_volume_has_recurringjob(self, volume_name, job_name):
         logging(f"Checking volume {volume_name} has recurring job {job_name}")
-        jobs = self.get_volume_recurringjobs(volume_name)
-        if job_name not in jobs:
-            logging(f"Failed to find recurring job {job_name} for volume {volume_name}")
+        for i in range(self.retry_count):
+            jobs = self.get_volume_recurringjobs(volume_name)
+            if job_name in jobs:
+                return
+            logging(f"Failed to find recurring job {job_name} for volume {volume_name} ... ({i})")
             time.sleep(self.retry_interval)
-            assert False, f"Failed to find recurring job {job_name} for volume {volume_name}"
+        assert False, f"Failed to find recurring job {job_name} for volume {volume_name}"
 
     def get_volume_recurringjob_groups(self, volume_name):
         cmd = f"kubectl get volumes -n {constant.LONGHORN_NAMESPACE} {volume_name} -o yaml"
@@ -993,11 +995,13 @@ class CRD(Base):
 
     def check_volume_has_recurringjob_group(self, volume_name, job_group_name):
         logging(f"Checking volume {volume_name} has recurring job group {job_group_name}")
-        job_groups = self.get_volume_recurringjob_groups(volume_name)
-        if job_group_name not in job_groups:
-            logging(f"Failed to find recurring job group {job_group_name} for volume {volume_name}")
+        for i in range(self.retry_count):
+            job_groups = self.get_volume_recurringjob_groups(volume_name)
+            if job_group_name in job_groups:
+                return
+            logging(f"Failed to find recurring job group {job_group_name} for volume {volume_name} ... ({i})")
             time.sleep(self.retry_interval)
-            assert False, f"Failed to find recurring job group {job_group_name} for volume {volume_name}"
+        assert False, f"Failed to find recurring job group {job_group_name} for volume {volume_name}"
 
     def get_state(self, volume_name):
         """

--- a/e2e/tests/regression/test_recurringjob.robot
+++ b/e2e/tests/regression/test_recurringjob.robot
@@ -37,6 +37,42 @@ Test Recurring Job Assignment Using StorageClass
     And Check snapshot recurringjob snapshot-job work for volume of deployment 0
     And Check backup recurringjob backup-job work for volume of deployment 0
 
+Test Recurring Job Group Labels Sync From PVC Without Source Label
+    [Documentation]    Issue: https://github.com/longhorn/longhorn/issues/13928
+    ...    1. Create a StorageClass and a PVC labeled with RecurringJob groups
+    ...       (default and rebuildable) but without recurring-job.longhorn.io/source=enabled.
+    ...    2. Create a deployment that consumes the PVC.
+    ...    3. Verify the Volume CR has both group labels.
+    ...    4. Verify Longhorn infers recurring-job.longhorn.io/source=enabled on the PVC.
+    ...    5. Add another group label on the bound PVC and verify it syncs to the Volume CR.
+    Given Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    sc_name=longhorn-test    labels={"recurring-job-group.longhorn.io/default":"enabled","recurring-job-group.longhorn.io/rebuildable":"enabled"}
+    And Create deployment 0 with persistentvolumeclaim 0
+
+    Then Check volume of deployment 0 has recurringjob group default
+    And Check volume of deployment 0 has recurringjob group rebuildable
+    And Check persistentvolumeclaim 0 has label recurring-job.longhorn.io/source enabled
+
+    When Label persistentvolumeclaim 0 with recurring-job-group.longhorn.io/extra enabled
+    Then Check volume of deployment 0 has recurringjob group extra
+    And Check volume of deployment 0 has recurringjob group default
+    And Check volume of deployment 0 has recurringjob group rebuildable
+
+Test Recurring Job Group Labels Sync After PVC Is Bound
+    [Documentation]    Issue: https://github.com/longhorn/longhorn/issues/13928
+    ...    1. Create a StorageClass and a PVC with no RecurringJob labels.
+    ...    2. Create a deployment that consumes the PVC.
+    ...    3. Label the already-bound PVC with recurring-job-group.longhorn.io/default=enabled
+    ...       without setting recurring-job.longhorn.io/source=enabled.
+    ...    4. Verify the Volume CR joins the default group and the source label is inferred.
+    Given Create storageclass longhorn-test with    dataEngine=${DATA_ENGINE}
+    And Create persistentvolumeclaim 0    sc_name=longhorn-test
+    And Create deployment 0 with persistentvolumeclaim 0
+
+    When Label persistentvolumeclaim 0 with recurring-job-group.longhorn.io/default enabled
+    Then Check volume of deployment 0 has recurringjob group default
+    And Check persistentvolumeclaim 0 has label recurring-job.longhorn.io/source enabled
+
 Test Volume Deletion During Recurring Job Execution
     [Tags]    snapshot-purge
     [Documentation]    Issue: https://github.com/longhorn/longhorn/issues/11925


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue longhorn/longhorn#13928

#### What this PR does / why we need it:
Add e2e coverage for RecurringJob group labels on the Volume CR when the PVC already has job groups, including when `recurring-job.longhorn.io/source=enabled` is omitted.

- PVC created with `default` + `rebuildable` group labels (no source) syncs both groups to the Volume CR and infers the source label on the PVC.
- Adding another group on a bound PVC continues to sync.
- PVC labeled with a group after bind (no source) also infers source and joins the group.

These cases require the manager change in https://github.com/longhorn/longhorn-manager/pull/5165.

#### Special notes for your reviewer:
@mantissahz this is the e2e asked for on longhorn/longhorn#13928. I cannot self-assign that issue (no ReplaceActorsForAssignable); please assign it to me if you still want that.

Volume RecurringJob label checks now retry until `RETRY_COUNT` instead of failing after a single interval, because PVC-to-Volume sync is asynchronous.

#### Additional documentation or context
Manager unit tests for the same behavior live in longhorn-manager#5165 (`controller/recurring_job_label_sync_test.go`).
