### PR TITLE
test(pytest): fix flaky test_setting_concurrent_rebuild_limit on v2

### DIFF
--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -2595,8 +2595,11 @@ def crash_replica_processes(client, api, volname, replicas=None,
             exec_instance_manager(api, r.instanceManagerName, kill_command)
 
         if wait_to_fail is True:
+            wait_crashed = wait_for_replica_failed
+            if DATA_ENGINE == "v2":
+                wait_crashed = wait_for_replica_crashed
             thread = create_assert_error_check_thread(
-                wait_for_replica_failed,
+                wait_crashed,
                 client, volname, r['name'], RETRY_COUNTS, RETRY_INTERVAL_SHORT
             )
             threads.append(thread)
@@ -2658,6 +2661,38 @@ def wait_for_replica_failed(client, volname, replica_name,
         volname, replica_name, debug_replica_not_failed, debug_replica_in_im
     )
     assert failed, err_msg
+
+
+def wait_for_replica_crashed(client, volname, replica_name,
+                             retry_cnts=RETRY_COUNTS,
+                             retry_ivl=RETRY_INTERVAL):
+    # A crashed v2 replica keeps its instance registered in the instance
+    # manager and gets restarted instead of entering the failed state, so it
+    # never satisfies wait_for_replica_failed. Wait for the engine to register
+    # the crash instead. The engine only notices through the NVMe-oF
+    # fast_io_fail/ctrlr_loss timeouts, so this can take over ten seconds.
+    crashed = False
+    debug_replica = None
+
+    for i in range(retry_cnts):
+        volume = client.by_id_volume(volname)
+        debug_replica = None
+        for r in volume.replicas:
+            if r['name'] == replica_name:
+                debug_replica = r
+                break
+
+        if debug_replica is None or \
+                debug_replica['failedAt'] != "" or \
+                not debug_replica['running'] or \
+                debug_replica.mode == "ERR":
+            crashed = True
+            break
+        time.sleep(retry_ivl)
+
+    assert crashed, "Vol({}), Replica({}): {}".format(
+        volname, replica_name, debug_replica
+    )
 
 
 def wait_for_replica_running(client, volname, replica_name):

--- a/manager/integration/tests/test_settings.py
+++ b/manager/integration/tests/test_settings.py
@@ -901,45 +901,45 @@ def test_setting_concurrent_rebuild_limit(client, core_api, volume_name):  # NOQ
             replicas.append(r)
 
     assert len(replicas) > 0, replicas
-    if DATA_ENGINE == "v2":
-        # Crashing all v2 replicas causes them to restart, but not
-        # enter the failed state.
-        crash_replica_processes(client, core_api, volume1_name, replicas,
-                                wait_to_fail=False)
-    else:
-        crash_replica_processes(client, core_api, volume1_name, replicas)
+    crash_replica_processes(client, core_api, volume1_name, replicas)
     delete_replica_on_test_node(client, volume2_name)
 
     # While one volume is rebuilding, verify another volume is not
     # rebuilding and stuck in degrading state
+    def is_rebuilding(volume):
+        # The rebuild that was just crashed above keeps reporting the "error"
+        # state until its failed replica is replaced, so only an in_progress
+        # entry counts as an active rebuild.
+        return any(s.state == "in_progress" for s in volume.rebuildStatus)
+
     rebuild_started = False
     first_rebuild = None
     for i in range(RETRY_COUNTS):
         volume1 = client.by_id_volume(volume1_name)
         volume2 = client.by_id_volume(volume2_name)
 
-        if volume1.rebuildStatus == [] and \
-                volume2.rebuildStatus == [] and \
-                rebuild_started is False:
-            continue
-        elif volume1.rebuildStatus == [] and \
-                volume2.rebuildStatus == [] and \
-                rebuild_started is True:
+        volume1_rebuilding = is_rebuilding(volume1)
+        volume2_rebuilding = is_rebuilding(volume2)
+
+        # The concurrent limit is 1, so the volumes must never rebuild together
+        assert not (volume1_rebuilding and volume2_rebuilding), (
+            f"volume 1 rebuild status = {volume1.rebuildStatus}, "
+            f"volume 2 rebuild status = {volume2.rebuildStatus}"
+        )
+
+        if volume1_rebuilding or volume2_rebuilding:
+            rebuild_started = True
+            first_rebuild = \
+                volume1_name if volume1_rebuilding else volume2_name
+        elif rebuild_started:
             break
-        elif volume2.rebuildStatus == []:
-            assert volume1.rebuildStatus[0].state == "in_progress", (
-                f"volume 1 rebuild status = {volume1.rebuildStatus}"
-            )
-            rebuild_started = True
-            first_rebuild = volume1_name
-        elif volume1.rebuildStatus == []:
-            assert volume2.rebuildStatus[0].state == "in_progress", (
-                f"volume 2 rebuild status = {volume1.rebuildStatus}"
-            )
-            rebuild_started = True
-            first_rebuild = volume2_name
 
         time.sleep(RETRY_INTERVAL)
+
+    assert rebuild_started is True, (
+        f"volume 1 rebuild status = {volume1.rebuildStatus}, "
+        f"volume 2 rebuild status = {volume2.rebuildStatus}"
+    )
 
     # Wait for the second volume to start rebuilding.
     # At this point, one volume has already started rebuilding in


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13189


#### What this PR does / why we need it:

The test case crashes volume 1's in-flight rebuild and then asserts that the volumes rebuild one at a time. On v2 the crash and the assertions race.

crash_replica_processes() is not equivalent between the data engines:
- For v1 it kills the replica process, so the failure is instantaneous and wait_for_replica_failed() blocks until it is registered.
- For v2 it only runs `go-spdk-helper expose stop`, which removes the NVMf subsystem while the lvol and spdk_tgt keep running. Nothing dies, so the engine only notices through the NVMe-oF replicaFastIOFailTimeoutSec/ replicaCtrlrLossTimeoutSec timeouts. The replica also never satisfies wait_for_replica_failed(): its instance stays registered in the instance manager and it is replaced by a new replica rather than being marked failed, which is why the v2 path passed wait_to_fail=False and did not synchronise on the crash at all. The test therefore entered the verification loop while volume 1's rebuild was still reported as in_progress, and later observed the ~4s window where it reports "error" before volume 2 picks up the rebuild slot. The loop asserted rebuildStatus[0].state == "in_progress" whenever the other volume was idle, so it failed on that transient state.

Add wait_for_replica_crashed() as the v2 counterpart of wait_for_replica_failed(), waiting for the engine to register the crash (replica gone, failedAt set, not running, or mode ERR), and use it in crash_replica_processes() so wait_to_fail works for both data engines. The v1 path is unchanged. Drop the v2 special case in the test so the crash is synchronised the same way it is on v1.


#### Special notes for your reviewer:

#### Additional documentation or context
