### PR TITLE
test(robot): support v2 interrupt mode

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -113,6 +113,10 @@ Set disk path based on host provider and architecture
 
 Enable v2 data engine and add block disks
     set_disk_path_based_on_host_provider_and_architecture
+    ${RUN_V2_INTERRUPT_MODE}=    Get Environment Variable    RUN_V2_INTERRUPT_MODE    false
+    IF    "${RUN_V2_INTERRUPT_MODE}" == "true"
+        update_setting    data-engine-interrupt-mode-enabled    {"v2":"true"}
+    END
     ${V2_DATA_ENGINE_ENABLED}=    get_setting    v2-data-engine
     # if it's already configured, no need to do it again
     Return From Keyword If    "${V2_DATA_ENGINE_ENABLED}" == "true"

--- a/e2e/libs/setting/setting.py
+++ b/e2e/libs/setting/setting.py
@@ -120,6 +120,16 @@ class Setting:
                     logging(f"Failed to set {setting_name} to true: {e}")
                 continue
 
+            if data_engine == "v2" and setting_name == "data-engine-interrupt-mode-enabled":
+                if os.environ.get("RUN_V2_INTERRUPT_MODE", "false") == "true":
+                    try:
+                        s = client.by_id_setting(setting_name)
+                        client.update(s, value='{"v2":"true"}')
+                        logging(f"Set {setting_name} to {{\"v2\":\"true\"}} because RUN_V2_INTERRUPT_MODE is true")
+                    except Exception as e:
+                        logging(f"Failed to set {setting_name}: {e}")
+                    continue
+
             s = client.by_id_setting(setting_name)
             if s.value != setting_default_value and not setting_readonly:
                 for i in range(self.retry_count):

--- a/pipelines/e2e/Jenkinsfile
+++ b/pipelines/e2e/Jenkinsfile
@@ -29,6 +29,7 @@ def REGISTRY_URL = ""
 
 // parameter for v2 test
 def RUN_V2_TEST = params.RUN_V2_TEST ? params.RUN_V2_TEST : true
+def RUN_V2_INTERRUPT_MODE = params.RUN_V2_INTERRUPT_MODE ? params.RUN_V2_INTERRUPT_MODE : false
 
 // parameter for running test as a pod or a container
 def OUT_OF_CLUSTER = params.OUT_OF_CLUSTER ? params.OUT_OF_CLUSTER : false
@@ -114,6 +115,7 @@ node {
                                        --env TF_VAR_custom_ssh_public_key="${CUSTOM_SSH_PUBLIC_KEY}" \
                                        --env TF_VAR_resources_owner="${RESOURCE_OWNER}" \
                                        --env TF_VAR_extra_block_device=${RUN_V2_TEST} \
+                                       --env RUN_V2_INTERRUPT_MODE=${RUN_V2_INTERRUPT_MODE} \
                                        --env TF_VAR_lab_url=${LAB_URL} \
                                        --env TF_VAR_lab_access_key=${LAB_ACCESS_KEY} \
                                        --env TF_VAR_lab_secret_key=${LAB_SECRET_KEY} \

--- a/pipelines/utilities/run_longhorn_e2e_test.sh
+++ b/pipelines/utilities/run_longhorn_e2e_test.sh
@@ -72,6 +72,7 @@ run_longhorn_test(){
 
   # for v2 block device path
   yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "BLOCK_DEV_PATH", "value": "'${BLOCK_DEV_PATH}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
+  yq e -i 'select(.spec.containers[0].env != null).spec.containers[0].env += {"name": "RUN_V2_INTERRUPT_MODE", "value": "'${RUN_V2_INTERRUPT_MODE}'"}' "${LONGHORN_TESTS_MANIFEST_FILE_PATH}"
 
   # share instance mapping information between jenkins job agent and test pod for later use, e.g. power on/off nodes.
   if [[ -f /tmp/instance_mapping ]]; then
@@ -276,6 +277,7 @@ run_longhorn_test_out_of_cluster(){
              -e K8S_DISTRO="${TF_VAR_k8s_distro_name}"\
              -e OS_DISTRO="${DISTRO}"\
              -e BLOCK_DEV_PATH="${BLOCK_DEV_PATH}"\
+             -e RUN_V2_INTERRUPT_MODE="${RUN_V2_INTERRUPT_MODE}"\
              --mount source="vol-${IMAGE_NAME}",target=/tmp \
              --mount source="vol-${IMAGE_NAME}",target=/root/.ssh \
              "${LONGHORN_TESTS_CUSTOM_IMAGE}" "${ROBOT_COMMAND_ARGS[@]}"


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue  longhorn/longhorn#13946

#### What this PR does / why we need it:

e2e tests support v2 interrupt mode

#### Special notes for your reviewer:

test_basic.robot

- v2 interrupt mode not enalbed: https://10.115.5.5/job/private/job/longhorn-e2e-test-v2-interrupt/5/
- v2 interrupt mode enalbed: https://10.115.5.5/job/private/job/longhorn-e2e-test-v2-interrupt/6/

#### Additional documentation or context
