### PR TITLE
test: set data-engine-cpu-mask to 0x1 for v2 testing

### DIFF
--- a/e2e/keywords/common.resource
+++ b/e2e/keywords/common.resource
@@ -116,6 +116,7 @@ Enable v2 data engine and add block disks
     ${V2_DATA_ENGINE_ENABLED}=    get_setting    v2-data-engine
     # if it's already configured, no need to do it again
     Return From Keyword If    "${V2_DATA_ENGINE_ENABLED}" == "true"
+    update_setting    data-engine-cpu-mask    {"v2": "0x1"}
     update_setting    v2-data-engine    true
     ${worker_nodes}=    get_worker_nodes
     FOR    ${worker_node}    IN    @{worker_nodes}

--- a/e2e/libs/setting/setting.py
+++ b/e2e/libs/setting/setting.py
@@ -111,6 +111,15 @@ class Setting:
             if setting_name == "registry-secret":
                 continue
 
+            if data_engine == "v2" and setting_name == "data-engine-cpu-mask":
+                try:
+                    s = client.by_id_setting(setting_name)
+                    client.update(s, value='{"v2": "0x1"}')
+                    logging(f"Set {setting_name} to {{\"v2\": \"0x1\"}} because data_engine is v2")
+                except Exception as e:
+                    logging(f"Failed to set {setting_name} to {{\"v2\": \"0x1\"}}: {e}")
+                continue
+
             if data_engine == "v2" and setting_name == "v2-data-engine":
                 try:
                     s = client.by_id_setting(setting_name)

--- a/e2e/tests/regression/test_v2.robot
+++ b/e2e/tests/regression/test_v2.robot
@@ -657,8 +657,9 @@ Test Create Default Disk On Labeled Nodes With V2 Data Engine
     ...       node.longhorn.io/create-default-disk=config
     ...    2. Annotate each worker node with
     ...       node.longhorn.io/default-disks-config='[{"name":"block-disk","path":"<disk-path>","diskType":"block","allowScheduling":true}]'
-    ...    3. Install Longhorn with defaultSettings.createDefaultDiskLabeledNodes=true
-    ...       and defaultSettings.v2DataEngine=true
+    ...    3. Install Longhorn with defaultSettings.createDefaultDiskLabeledNodes=true,
+    ...       defaultSettings.v2DataEngine=true, and
+    ...       defaultSettings.dataEngineCPUMask={"v2":"0x1"}
     ...    4. Verify a default disk named block-disk with path "<disk-path> and
     ...       diskType block is created on each node
     ...    5. Create a v2 volume, write data and verify data integrity
@@ -678,10 +679,10 @@ Test Create Default Disk On Labeled Nodes With V2 Data Engine
     ${LONGHORN_INSTALL_METHOD} =    Get Environment Variable    LONGHORN_INSTALL_METHOD    default=manifest
     IF    '${LONGHORN_INSTALL_METHOD}' == 'helm'
         When Install Longhorn
-        ...    custom_cmd=yq -i '.defaultSettings.createDefaultDiskLabeledNodes = true | .defaultSettings.v2DataEngine = true' values.yaml
+        ...    custom_cmd=yq -i '.defaultSettings.createDefaultDiskLabeledNodes = true | .defaultSettings.v2DataEngine = true | .defaultSettings.dataEngineCPUMask = "{\\"v2\\": \\"0x1\\"}"' values.yaml
     ELSE
         When Install Longhorn
-        ...    custom_cmd=sed -i "/default-setting\\.yaml: |-/a\\${SPACE * 4}create-default-disk-labeled-nodes: true\\n${SPACE * 4}v2-data-engine: true" longhorn.yaml
+        ...    custom_cmd=sed -i "/default-setting\\.yaml: |-/a\\${SPACE * 4}create-default-disk-labeled-nodes: true\\n${SPACE * 4}v2-data-engine: true\\n${SPACE * 4}data-engine-cpu-mask: '{\\"v2\\":\\"0x1\\"}'" longhorn.yaml
     END
 
     Then Wait for longhorn ready

--- a/manager/integration/tests/common.py
+++ b/manager/integration/tests/common.py
@@ -240,6 +240,7 @@ SETTING_RESTORE_CONCURRENT_LIMIT = "restore-concurrent-limit"
 SETTING_V1_DATA_ENGINE = "v1-data-engine"
 SETTING_V2_DATA_ENGINE = "v2-data-engine"
 SETTING_DATA_ENGINE_INTERRUPT_MODE = "data-engine-interrupt-mode-enabled"
+SETTING_DATA_ENGINE_CPU_MASK = "data-engine-cpu-mask"
 SETTING_ALLOW_EMPTY_NODE_SELECTOR_VOLUME = \
     "allow-empty-node-selector-volume"
 SETTING_REPLICA_DISK_SOFT_ANTI_AFFINITY = "replica-disk-soft-anti-affinity"
@@ -4014,6 +4015,17 @@ def reset_settings(client):
 
         if setting_name == "registry-secret":
             continue
+
+        if setting_name == SETTING_DATA_ENGINE_CPU_MASK:
+            if os.environ.get('RUN_V2_TEST') == "true":
+                setting = client.by_id_setting(setting_name)
+                try:
+                    client.update(setting, value='{"v2": "0x1"}')
+                except Exception as e:
+                    print(f"\nException setting {setting_name} to "
+                          "{\"v2\": \"0x1\"}")
+                    print(e)
+                continue
 
         if setting_name == "v2-data-engine":
             if v2_data_engine_cr_supported(client):


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/13958

#### What this PR does / why we need it:

As suggested in https://github.com/longhorn/longhorn/issues/13939#issue-5342738886 and  https://github.com/longhorn/longhorn/issues/13585#issuecomment-5185984630, set `data-engine-cpu-mask` to `0x1` for v2 testing

#### Special notes for your reviewer:

#### Additional documentation or context
