### PR TITLE
fix(pytest): test_engine_crash_for_dr_volume

### DIFF
--- a/manager/integration/tests/test_ha.py
+++ b/manager/integration/tests/test_ha.py
@@ -1966,7 +1966,10 @@ def test_engine_crash_for_dr_volume(set_random_backupstore, client, core_api, vo
     dr_pod['spec']['volumes'] = [create_pvc_spec(pvc_name)]
     create_and_wait_pod(core_api, dr_pod)
 
-    dr_volume = client.by_id_volume(dr_volume_name)
+    # The engine crash earlier in this test can fail a replica. Its rebuild
+    # may still be in progress after the volume is activated and reattached,
+    # so wait until the volume becomes healthy before checking robustness.
+    dr_volume = wait_for_volume_healthy(client, dr_volume_name)
     assert dr_volume[VOLUME_FIELD_ROBUSTNESS] == VOLUME_ROBUSTNESS_HEALTHY
 
     dr_md5sum1 = get_pod_data_md5sum(core_api, dr_pod_name, data_path)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13869

#### What this PR does / why we need it:

test_engine_crash_for_dr_volume asserts the DR volume is healthy immediately after the activated volume's pod starts. The engine crash earlier in the test can fail a replica, and its rebuild may still be in progress, so the volume can still be degraded at that moment.

#### Special notes for your reviewer:

The test previously passed because an engine-level restore error faulted the whole volume and auto-salvage reused all replicas in place, so no rebuild overlapped activation. With v2 volume per-replica restore failure introduced in longhorn/longhorn#13869, only the affected replica fails, and a real rebuild is required, exposing the missing wait.

#### Additional documentation or context

`None`
