### PR TITLE
fix(deploy): add NetworkPolicy for longhorn-manager to accept longhorn-test pod req

### DIFF
--- a/manager/integration/deploy/test.yaml
+++ b/manager/integration/deploy/test.yaml
@@ -17,6 +17,26 @@ subjects:
   name: longhorn-test-service-account
   namespace: default
 ---
+# The longhorn-manager policy only admits a few in-namespace components by default,
+# so this test pod - which lives in the default namespace - cannot reach the REST API on 9500.
+#
+# Allowing all ingress is deliberate rather than lazy. This relaxes a hardening measure,
+# which is acceptable only because it is scoped to a test manifest that already grants
+# the test account cluster-admin above.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: longhorn-test-allow-manager-ingress
+  namespace: longhorn-system
+spec:
+  podSelector:
+    matchLabels:
+      app: longhorn-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - {}
+---
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### What this PR does / why we need it:

This updated [longhorn-manager Network Policy](https://github.com/longhorn/longhorn/blob/026b8a2c6863b50e750b7393fd9befc0cd9a58ad/deploy/longhorn.yaml#L106-L139) will block the test pod process without this extra rule

#### Special notes for your reviewer:

#### Additional documentation or context
